### PR TITLE
Generalize Flue harness roles

### DIFF
--- a/.flue/roles/eval-judge.md
+++ b/.flue/roles/eval-judge.md
@@ -1,6 +1,6 @@
 ---
-name: release-notes-judge
-description: Scores release-notes eval outputs against the eval case and rubric without producing new release notes.
+name: eval-judge
+description: Scores eval outputs against the eval case, expectations, rubric, and reference material.
 model: anthropic/claude-sonnet-4-6
 ---
 
@@ -8,4 +8,4 @@ You are an independent evaluator. Score only the producer output files against t
 
 Do not give credit for requirements stated in a skill file unless the producer output actually satisfies them.
 
-Be specific in rationales. Penalize omissions, invented facts, vague migration advice, and missing risk or deprecation details.
+Be specific in rationales. Penalize omissions, invented facts, regressions, unsafe assumptions, and unsupported claims.

--- a/.flue/roles/release-editor.md
+++ b/.flue/roles/release-editor.md
@@ -1,9 +1,0 @@
----
-name: release-editor
-description: Produces developer-focused release note outputs from changelog inputs.
-model: anthropic/claude-haiku-4-5
----
-
-You produce concise developer-facing release notes from changelog inputs.
-
-Follow the mounted skill instructions closely. Produce concrete output files only; do not score your own work.

--- a/.flue/roles/task-producer.md
+++ b/.flue/roles/task-producer.md
@@ -1,0 +1,9 @@
+---
+name: task-producer
+description: Produces eval output files by following the mounted skill and eval task.
+model: anthropic/claude-haiku-4-5
+---
+
+You produce concrete output files for the current eval task.
+
+Follow the mounted skill instructions closely. Produce concrete output files only; do not score your own work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ It uses `session.prompt(..., { result: schema })` so Flue performs structured-ou
 The model-backed path is intentionally split:
 
 1. **Researcher** (`skill-builder`, Sonnet): patches the candidate skill.
-2. **Producer** (`release-editor`, Haiku): runs the candidate skill and writes `output_files`.
-3. **Judge** (`release-notes-judge`, Sonnet): scores only producer output.
+2. **Producer** (`task-producer`, Haiku): runs the candidate skill and writes `output_files`.
+3. **Judge** (`eval-judge`, Sonnet): scores only producer output.
 
 This is important. Avoid collapsing producer and judge back into a single self-scoring call.
 

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -109,14 +109,14 @@ The important parts are not the exact directory names for every project, but tha
     }
   },
   "roles": {
-    "judge": "release-notes-judge",
+    "judge": "eval-judge",
     "skill_builder": "skill-builder"
   },
   "tracks": [
     {
       "id": "summarise",
       "eval_type": "summarise-changelog",
-      "role": "release-editor",
+      "role": "task-producer",
       "target_skill": "release-summary"
     }
   ]

--- a/fixtures/projects/release-notes-alpha/config.json
+++ b/fixtures/projects/release-notes-alpha/config.json
@@ -24,14 +24,14 @@
     }
   },
   "roles": {
-    "judge": "release-notes-judge",
+    "judge": "eval-judge",
     "skill_builder": "skill-builder"
   },
   "tracks": [
     {
       "id": "summarise",
       "eval_type": "summarise-changelog",
-      "role": "release-editor",
+      "role": "task-producer",
       "target_skill": "release-summary",
       "requires_description": false
     }

--- a/tests/e2e-dry-run.test.ts
+++ b/tests/e2e-dry-run.test.ts
@@ -65,10 +65,10 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
   expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 1 });
   expect(client.requests.map((request) => request.system)).toEqual([
-    "release-editor",
+    "task-producer",
     "judge",
     "skill-builder",
-    "release-editor",
+    "task-producer",
     "judge"
   ]);
 

--- a/tests/flue-harness.test.ts
+++ b/tests/flue-harness.test.ts
@@ -43,8 +43,8 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
   const result = await new FlueEvalAgent(session).run({
     evalCase,
     track: trackForEval(syntheticConfig, evalCase.eval_type),
-    role: "release-editor",
-    modelRoles: { judge: "release-notes-judge" },
+    role: "task-producer",
+    modelRoles: { judge: "eval-judge" },
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: {
       producer: { provider: "anthropic", name: "claude-haiku-4-5" },
@@ -58,7 +58,7 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
     "anthropic/claude-haiku-4-5",
     "anthropic/claude-sonnet-4-6"
   ]);
-  expect((session as any).prompts[1].role).toBe("release-notes-judge");
+  expect((session as any).prompts[1].role).toBe("eval-judge");
   await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Flue output\n");
 });
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -65,7 +65,7 @@ export const syntheticConfig = {
     {
       id: "summarise",
       eval_type: "summarise-changelog",
-      role: "release-editor",
+      role: "task-producer",
       target_skill: "release-summary",
       requires_description: false
     }

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -49,7 +49,7 @@ test("buildProduceModelRequest includes eval, mounted files, and target skill co
   const request = await buildProduceModelRequest({
     evalCase,
     track: trackForEval(syntheticConfig, evalCase.eval_type),
-    role: "release-editor",
+    role: "task-producer",
     targetSkill: "release-summary",
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: { producer: { provider: "anthropic", name: "claude-haiku-4-5" } },
@@ -63,7 +63,7 @@ test("buildProduceModelRequest includes eval, mounted files, and target skill co
     })
   });
 
-  expect(request.system).toBe("release-editor");
+  expect(request.system).toBe("task-producer");
   expect(request.model.name).toBe("claude-haiku-4-5");
   expect(request.prompt).toContain("CHANGELOG.md");
   expect(request.prompt).toContain("Added parser");
@@ -95,8 +95,8 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
   const result = await agent.run({
     evalCase,
     track: trackForEval(syntheticConfig, evalCase.eval_type),
-    role: "release-editor",
-    modelRoles: { judge: "release-notes-judge" },
+    role: "task-producer",
+    modelRoles: { judge: "eval-judge" },
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: {
       producer: { provider: "anthropic", name: "claude-haiku-4-5" },
@@ -109,11 +109,9 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
   expect(client.requests.map((request) => request.model.name)).toEqual(["claude-haiku-4-5", "claude-sonnet-4-6"]);
   await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Summarised changes\n");
   await expect(readFile(join(sandbox.outputDir, "producer-transcript.json"), "utf8")).resolves.toContain(
-    "release-editor"
+    "task-producer"
   );
-  await expect(readFile(join(sandbox.outputDir, "judge-transcript.json"), "utf8")).resolves.toContain(
-    "release-notes-judge"
-  );
+  await expect(readFile(join(sandbox.outputDir, "judge-transcript.json"), "utf8")).resolves.toContain("eval-judge");
 });
 
 test("parseModelProduceResponse requires output files and output writes reject unsafe paths", async () => {
@@ -133,8 +131,8 @@ test("buildJudgeModelRequest scores only producer output with judge model", asyn
     {
       evalCase,
       track: trackForEval(syntheticConfig, evalCase.eval_type),
-      role: "release-editor",
-      modelRoles: { judge: "release-notes-judge" },
+      role: "task-producer",
+      modelRoles: { judge: "eval-judge" },
       model: { provider: "anthropic", name: "claude-sonnet-4-6" },
       models: { judge: { provider: "anthropic", name: "claude-sonnet-4-6" } },
       sandbox: createEvalSandbox({
@@ -148,7 +146,7 @@ test("buildJudgeModelRequest scores only producer output with judge model", asyn
     [{ path: "RESULT.md", contents: "Output\n" }]
   );
 
-  expect(request.system).toBe("release-notes-judge");
+  expect(request.system).toBe("eval-judge");
   expect(request.prompt).toContain("Producer output files");
   expect(request.prompt).toContain("Score only the producer output");
 });

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -19,7 +19,7 @@ test("loads security and synthetic project fixtures without domain branches", as
   const synthetic = await loadProject(syntheticRoot);
 
   expect(trackForEval(security.config, "secure-author").target_skill).toBe("secure-authoring");
-  expect(trackForEval(synthetic.config, "summarise-changelog").role).toBe("release-editor");
+  expect(trackForEval(synthetic.config, "summarise-changelog").role).toBe("task-producer");
 });
 
 test("resolves default model and rejects unsupported providers", async () => {


### PR DESCRIPTION
## Summary

  - replace release-specific Flue roles with generic `task-producer` and `eval-judge` roles
  - update the alpha fixture, tests, and docs to use the generic role names
  - clarify project-root, multi-skill layout, and `origin_skill` vs `seedSkillDir` behavior in the user guide

  ## Validation

  - `pnpm run format:check`
  - `pnpm run lint`
  - `pnpm run typecheck`
  - `pnpm test`
  - `pnpm run flue:build`
  - `pnpm run alpha:smoke`