### PR TITLE
Harden Flue autoresearch prompts and update harness docs

### DIFF
--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -298,7 +298,7 @@ pnpm run alpha:smoke
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-pnpm exec flue run autoresearch --target node --workspace .flue --id my-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm exec flue run autoresearch --target node --root . --id my-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
 ```
 
 This command uses `pnpm exec` to run the `flue` binary from this repository's installed dependencies. It does not require a globally installed `flue` CLI.
@@ -307,7 +307,7 @@ The command parts are:
 
 - `pnpm exec flue run autoresearch`: runs the `autoresearch` Flue agent through the project-local `flue` dependency.
 - `--target node`: uses the Node.js target for the run.
-- `--workspace .flue`: stores Flue run state under the local `.flue/` workspace directory.
+- `--root .`: tells Flue to run from this harness checkout root. Flue reads source files from `<root>/.flue/` when that directory exists.
 - `--id my-smoke`: gives this Flue run a stable ID. Use a short name that identifies what you are checking.
 - `--payload '...'`: passes harness-specific options as JSON.
 
@@ -320,6 +320,20 @@ The payload fields are:
 
 This should return events ending with `research-loop-ready`.
 
+## Generate An Initial Baseline
+
+If your project does not have `workspace/baseline/` yet, run a model-backed baseline generation pass without `withBaseline` and with `runResearch:false`:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+```
+
+This should return events including `baseline-started`, `baseline-generated`, `aggregated`, and `research-loop-ready`. The generated score files and transcripts are written under:
+
+```text
+path/to/my-autoresearch-project/workspace/baseline/
+```
+
 ## Run Autoresearch
 
 To run autoresearch against the built-in alpha fixture in this repository:
@@ -331,7 +345,7 @@ pnpm run alpha:research
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --workspace .flue --id my-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
 ```
 
 This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run --` wraps the command so model credentials are available during the run.
@@ -339,7 +353,7 @@ This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run 
 For a multi-skill project, point `seedSkillDir` at the specific skill you want that run to improve:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --workspace .flue --id security-audit-research --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id security-audit-research --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
 ```
 
 The run stops when either:

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
     "build": "tsc -p tsconfig.json",
-    "flue:run": "flue run autoresearch --target node --workspace .flue",
-    "flue:build": "flue build --target node --workspace .flue --output .flue-dist",
-    "alpha:smoke": "flue run autoresearch --target node --workspace .flue --id alpha-smoke --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
-    "alpha:research": "varlock run -- flue run autoresearch --target node --workspace .flue --id alpha-research --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
+    "flue:run": "flue run autoresearch --target node --root .",
+    "flue:build": "flue build --target node --root . --output .flue-dist",
+    "alpha:smoke": "flue run autoresearch --target node --root . --id alpha-smoke --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
+    "alpha:research": "varlock run -- flue run autoresearch --target node --root . --id alpha-research --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
     "env:check": "varlock load"
   },
   "dependencies": {
@@ -39,5 +39,5 @@
     "varlock": "^1.1.0",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/skill/skills-autoresearch/SKILL.md
+++ b/skill/skills-autoresearch/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: skills-autoresearch
+description: Use when converting an existing agent skill project or scaffolding a new project to run through the skills-autoresearch Flue harness, including project layout, config.json, eval cases, rubric, seed skill, baseline artifacts, and run commands.
+---
+
+# Skills Autoresearch
+
+Use this skill to prepare a project for the `skills-autoresearch` harness. The goal is to create a small, auditable autoresearch project that can evaluate a seed agent skill, let a researcher model improve it, run producer evals against the candidate skill, and have a separate judge model score only the producer output.
+
+## Required Workflow
+
+Follow these gates in order. Do not skip a gate, and do not tell the user the project is ready until the Final Validation Gate passes.
+
+1. **Discovery Gate**: Locate the harness checkout, read the harness docs/example, inspect the target project, and check git state.
+2. **Shape Gate**: Choose the single-skill or multi-skill project shape and create the required directories.
+3. **Skill Gate**: Create or move a valid seed skill with frontmatter and enough instructions to run.
+4. **Eval Gate**: Create `config.json`, `evals/eval-cases.json`, `evals/rubric.md`, input files, and reference files.
+5. **Baseline Gate**: Either import/hand-author `workspace/baseline/` or explicitly prepare the generated-baseline run path.
+6. **Final Validation Gate**: Validate files, paths, schemas, rubric wording, baseline state, and git status before handing off.
+
+## Discovery Gate
+
+1. Ask the user for the full path to the local `skills-autoresearch` checkout and read `README.md`, `docs/using-the-harness.md`, and the alpha fixture under `fixtures/projects/release-notes-alpha/`. 
+2. Inspect the project being converted before writing files. Identify the skill or workflow to improve, representative inputs, expected outputs, and any stable reference material.
+3. Preserve user work. Check `git status --short` before editing. If there are uncommitted changes, notify the user and pause to ask whether they want to proceed, stash, commit, or switch branches before starting.
+4. If appropriate, start a new feature branch.
+
+## Shape Gate
+
+For a single-skill project, create:
+
+```text
+project-root/
+  config.json
+  evals/
+    eval-cases.json
+    rubric.md
+  input/
+    ...
+  reference/
+    ...
+  seed-skill/
+    SKILL.md
+  workspace/
+    baseline/
+      ...
+```
+
+For a multi-skill project, keep shared config/evals/reference at the root and put target skills under `skills/`:
+
+```text
+project-root/
+  config.json
+  program.md
+  evals/
+    eval-cases.json
+    rubric.md
+  input/
+    ...
+  reference/
+    ...
+  skills/
+    skill-one/
+      SKILL.md
+    skill-two/
+      SKILL.md
+  workspace/
+    baseline/
+      ...
+```
+
+The current alpha harness improves one seed skill per run. For multi-skill projects, run once per target skill and pass `seedSkillDir` in the Flue payload.
+
+## Skill Gate
+
+When scaffolding a new project:
+
+1. Create the directories shown above.
+2. Write a minimal valid seed `SKILL.md`. It must include YAML frontmatter with `name` and `description`, plus enough body guidance for a producer agent to attempt the target task.
+3. Add one or two small eval cases with concrete inputs and expectations.
+4. Add a direct rubric that describes high-quality output.
+5. Decide whether to import an existing baseline or generate one as the first harness run before model-backed research.
+
+A minimal seed skill can be intentionally imperfect, but it should be runnable as an agent skill:
+
+```md
+---
+name: my-skill
+description: Use when producing the target output for this autoresearch project.
+---
+
+# My Skill
+
+Use the provided task input and reference material to produce the requested output.
+
+Write the result in the format requested by the eval task.
+```
+
+When converting an existing project:
+
+1. Move or copy the existing skill instructions into `seed-skill/SKILL.md` or `skills/<name>/SKILL.md`.
+2. Put task inputs under `input/`.
+3. Put stable background material, examples, API notes, policies, or domain facts under `reference/`.
+4. Convert existing tests, examples, or acceptance criteria into `evals/eval-cases.json` and `evals/rubric.md`.
+5. Import any known output as `workspace/baseline/`.
+6. If there is no existing baseline, ask the user whether they want to:
+   - Generate a baseline as the first `skills-autoresearch` harness run.
+   - Create a small baseline by hand so the smoke run can validate loading and aggregation before spending model calls.
+
+## Eval Gate
+
+## Write `config.json`
+
+Use this as the starting point and adjust names, paths, target score, models, and tracks:
+
+```json
+{
+  "skill_name": "my-skill",
+  "topic_group": "my-topic",
+  "origin_skill": "seed-skill",
+  "target_score": 0.8,
+  "max_iterations": 1,
+  "max_concurrency": 1,
+  "model": {
+    "provider": "anthropic",
+    "name": "claude-sonnet-4-6"
+  },
+  "models": {
+    "producer": {
+      "provider": "anthropic",
+      "name": "claude-haiku-4-5"
+    },
+    "judge": {
+      "provider": "anthropic",
+      "name": "claude-sonnet-4-6"
+    },
+    "researcher": {
+      "provider": "anthropic",
+      "name": "claude-sonnet-4-6"
+    }
+  },
+  "roles": {
+    "judge": "eval-judge",
+    "skill_builder": "skill-builder"
+  },
+  "tracks": [
+    {
+      "id": "main",
+      "eval_type": "my-eval-type",
+      "role": "task-producer",
+      "target_skill": "my-skill",
+      "requires_description": false
+    }
+  ]
+}
+```
+
+Notes:
+
+- `origin_skill` is relative to the autoresearch project root unless absolute.
+- `models.producer` writes eval outputs.
+- `models.judge` scores producer outputs.
+- `models.researcher` patches the skill.
+- `tracks[].eval_type` must match the eval cases.
+- `tracks[].role` and `roles.judge` refer to Flue roles in the harness checkout under `.flue/roles/`.
+
+## Write Eval Cases
+
+Create `evals/eval-cases.json`:
+
+```json
+{
+  "evals": [
+    {
+      "id": "case-001",
+      "eval_type": "my-eval-type",
+      "title": "Short human-readable title",
+      "input": {
+        "file": "INPUT.md"
+      },
+      "expectations": {
+        "must_include": ["important requirement"]
+      },
+      "scoring_dimensions": [
+        {
+          "id": "correctness",
+          "label": "Correct and useful output",
+          "max_score": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+Keep early evals small, concrete, and easy to inspect. Prefer one or two targeted cases over a broad suite.
+
+## Write The Rubric
+
+Create `evals/rubric.md` with direct scoring guidance. The rubric should explain quality criteria and scoring expectations, but it must not instruct the judge to return a legacy or custom JSON shape.
+
+```md
+# Rubric
+
+A high-scoring answer:
+
+- Satisfies the concrete user request.
+- Uses the provided input and reference material accurately.
+- Avoids unsupported claims.
+- Produces the expected files or output format.
+```
+
+The judge should evaluate producer output against the eval case and rubric, not reward the candidate skill instructions directly.
+
+The Flue harness expects judge output to match this `EvalScore` shape:
+
+```json
+{
+  "eval_id": "case-001",
+  "eval_type": "my-eval-type",
+  "track_id": "main",
+  "total_score": 0.5,
+  "max_score": 1,
+  "dimensions": [
+    {
+      "id": "correctness",
+      "score": 0.5,
+      "max_score": 1,
+      "rationale": "Brief evidence-grounded rationale."
+    }
+  ],
+  "summary": "Brief overall assessment."
+}
+```
+
+When converting an existing project, remove stale rubric instructions that mention legacy fields such as `focus_dimensions`, `scores`, `composite_score`, `expectations_met`, `expectations_missed`, `additional_observations`, or any output example that does not match `EvalScore`.
+
+## Baseline Gate
+
+The project can start with an imported baseline or create one as an initial harness run. Do not assume `workspace/baseline/` already exists.
+
+If the user wants to import or hand-author a baseline, create this shape:
+
+```text
+workspace/baseline/
+  scores-0.json
+  summary.json
+  case-001/
+    task.md
+    input/
+    output/
+```
+
+Each `scores-*.json` file should match:
+
+```json
+{
+  "eval_id": "case-001",
+  "eval_type": "my-eval-type",
+  "track_id": "main",
+  "total_score": 0.5,
+  "max_score": 1,
+  "dimensions": [
+    {
+      "id": "correctness",
+      "score": 0.5,
+      "max_score": 1,
+      "rationale": "Baseline is partially correct but misses an important requirement."
+    }
+  ],
+  "summary": "Baseline is usable but incomplete."
+}
+```
+
+`summary.json` should aggregate the baseline scores. Use the alpha fixture as the concrete example if the schema is unclear.
+
+If the user wants the harness to generate the baseline, run without `withBaseline` and with `runResearch:false`. This creates `workspace/baseline/` and does not count as a research iteration.
+
+## Run From The Harness Checkout
+
+Install and validate the harness:
+
+```bash
+pnpm install
+pnpm test
+pnpm run typecheck
+pnpm run build
+```
+
+Run a baseline smoke without model calls:
+
+```bash
+pnpm exec flue run autoresearch --target node --root . --id my-smoke --payload '{"projectRoot":"path/to/project-root","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+```
+
+Expected smoke events should end with `research-loop-ready`.
+
+To generate the initial baseline with the harness instead of importing one, validate credentials first:
+
+```bash
+pnpm run env:check
+```
+
+Then run without `withBaseline`:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/project-root","runResearch":false,"sessionId":"my-baseline"}'
+```
+
+Expected generated-baseline events include `baseline-started` and `baseline-generated`.
+
+For model-backed research after a baseline exists, run:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research --payload '{"projectRoot":"path/to/project-root","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/project-root/seed-skill","sessionId":"my-research"}'
+```
+
+For a multi-skill project, point `seedSkillDir` at the specific skill directory for this run, for example `path/to/project-root/skills/security-audit`.
+
+## Final Validation Gate
+
+Before reporting success, perform this validation and fix any failures.
+
+1. Re-run `git status --short` in the target project and report the changed, deleted, and untracked paths. If unexpected deletions or moves appear, pause and ask the user before continuing.
+2. Confirm these files exist:
+   - `config.json`
+   - `evals/eval-cases.json`
+   - `evals/rubric.md`
+   - `input/`
+   - `reference/`
+   - `seed-skill/SKILL.md` for single-skill projects, or the selected `skills/<name>/SKILL.md` for multi-skill projects
+3. Validate `config.json` against the harness fields:
+   - `skill_name`, `topic_group`, `target_score`, `max_iterations`, `max_concurrency`, `roles`, and at least one `tracks[]` entry are present.
+   - Every `tracks[].eval_type` is used by at least one eval case.
+   - `origin_skill` points to an existing skill directory unless the run will always pass `seedSkillDir`.
+4. Validate `evals/eval-cases.json`:
+   - The top-level object has an `evals` array.
+   - Every eval has `id`, `eval_type`, `title`, and at least one `scoring_dimensions[]` entry.
+   - Every `input.file` path resolves under `input/`.
+   - Every eval's `eval_type` has a matching track in `config.json`.
+5. Validate `evals/rubric.md`:
+   - It references `scoring_dimensions`, not `focus_dimensions`.
+   - It does not include legacy output examples using `scores`, `composite_score`, `expectations_met`, `expectations_missed`, or `additional_observations`.
+   - Any output-shape example matches `EvalScore`: `eval_id`, `eval_type`, `track_id`, `total_score`, `max_score`, `dimensions`, and `summary`.
+6. Validate the seed skill:
+   - `SKILL.md` has YAML frontmatter with `name` and `description`.
+   - The body gives enough task guidance for the producer to attempt the evals.
+   - Supporting references are colocated with the skill or under project `reference/` and are mentioned where useful.
+7. Validate baseline readiness:
+   - If `workspace/baseline/` exists, confirm it has `summary.json`, at least one `scores-*.json`, and one directory per eval id with `task.md`, `input/`, and `output/`.
+   - If `workspace/baseline/` does not exist, the next recommended command must be the generated-baseline command without `withBaseline` and with `runResearch:false`.
+8. Run a schema/path validation command if the harness checkout is available. A direct Node check is enough; do not rely only on visual inspection.
+
+## Inspect Results
+
+After research, inspect artifacts under the autoresearch project root:
+
+```text
+workspace/iterations/1/
+  skill/SKILL.md
+  skill/RESEARCH.md
+  skill/.autoresearch-flue-transcript.json
+  outputs/<eval-id>/RESULT.md
+  outputs/<eval-id>/producer-flue-transcript.json
+  outputs/<eval-id>/judge-flue-transcript.json
+  scores-0.json
+  summary.json
+```
+
+Check that:
+
+- The candidate `skill/SKILL.md` addresses observed baseline weaknesses without overfitting to one fixture.
+- Producer output is a real answer to the eval task.
+- Judge rationale cites producer output, not the skill instructions.
+- Scores improved for the intended reasons.
+- Transcripts do not leak secrets such as API keys or provider key prefixes.
+
+## Reruns
+
+Iteration artifacts are created with exclusive writes. To rerun from scratch, remove generated iterations in the autoresearch project:
+
+```bash
+rm -rf path/to/project-root/workspace/iterations
+```
+
+Do not remove baseline artifacts unless the user is intentionally replacing the baseline.

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -13,8 +13,7 @@ import {
   EvalScoreSchema,
   ModelProduceResponseSchema,
   SkillResearchPatchSchema,
-  SkillResearchPatch,
-  ModelProduceResponse
+  SkillResearchPatch
 } from "./schemas.js";
 import { applySkillResearchPatch, validateSkillResearchPatch } from "./model-agent.js";
 import { cp, mkdir, writeFile } from "node:fs/promises";
@@ -33,10 +32,11 @@ export class FlueEvalAgent implements EvalAgent {
 
   async run(request: EvalAgentRequest): Promise<EvalScore> {
     const produceRequest = await buildProduceModelRequest(request);
-    const produced = (await this.#session.prompt(produceRequest.prompt, {
-      result: ModelProduceResponseSchema,
+    const { data: produced } = await this.#session.task(produceRequest.prompt, {
+      schema: ModelProduceResponseSchema,
+      role: produceRequest.system,
       model: toFlueModel(produceRequest.model)
-    })) as ModelProduceResponse;
+    });
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
     await writeTranscript(request.sandbox.outputDir, "producer-flue-transcript.json", {
       request: produceRequest,
@@ -44,11 +44,11 @@ export class FlueEvalAgent implements EvalAgent {
     });
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
-    const score = (await this.#session.prompt(judgeRequest.prompt, {
-      result: EvalScoreSchema,
+    const { data: score } = await this.#session.task(judgeRequest.prompt, {
+      schema: EvalScoreSchema,
       role: request.modelRoles?.judge,
       model: toFlueModel(judgeRequest.model)
-    })) as EvalScore;
+    });
     const validated = parseModelJudgeResponse(JSON.stringify(score), request.evalCase, request.track);
     await writeTranscript(request.sandbox.outputDir, "judge-flue-transcript.json", {
       request: judgeRequest,
@@ -67,10 +67,11 @@ export class FlueSkillResearcher implements SkillResearcher {
 
   async improve(request: Parameters<SkillResearcher["improve"]>[0]): Promise<void> {
     const modelRequest = await buildResearchModelRequest(request);
-    const patch = (await this.#session.prompt(modelRequest.prompt, {
-      result: SkillResearchPatchSchema,
+    const { data: patch } = await this.#session.task(modelRequest.prompt, {
+      schema: SkillResearchPatchSchema,
+      role: modelRequest.system,
       model: toFlueModel(modelRequest.model)
-    })) as SkillResearchPatch;
+    });
     validateSkillResearchPatch(request.candidateSkillDir, patch);
     await cp(request.previousSkillDir, request.candidateSkillDir, {
       recursive: true,

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -451,14 +451,20 @@ function formatFileSet(files: Array<{ path: string; contents: string }>, label: 
   let omittedFiles = 0;
 
   for (const file of files) {
-    if (remainingChars <= 0) {
+    const separatorOverhead = formatted.length > 0 ? "\n\n".length : 0;
+    const heading = `### ${file.path}\n\n`;
+    const fenceOverhead = fenced("").length;
+    const renderedOverhead = separatorOverhead + heading.length + fenceOverhead;
+
+    if (remainingChars <= renderedOverhead) {
       omittedFiles++;
       continue;
     }
 
-    const contents = truncateText(file.contents, Math.min(MAX_FILE_CHARS, remainingChars), `${label}/${file.path}`);
-    remainingChars -= contents.length;
-    formatted.push(`### ${file.path}\n\n${fenced(contents)}`);
+    const maxContentsChars = Math.min(MAX_FILE_CHARS, remainingChars - renderedOverhead);
+    const contents = truncateText(file.contents, maxContentsChars, `${label}/${file.path}`);
+    remainingChars -= renderedOverhead + contents.length;
+    formatted.push(`${heading}${fenced(contents)}`);
   }
 
   if (omittedFiles > 0) {
@@ -478,9 +484,12 @@ function truncateText(contents: string, maxChars: number, label: string): string
   if (contents.length <= maxChars) {
     return contents;
   }
+  if (maxChars <= 0) {
+    return "";
+  }
   const keptChars = Math.max(0, maxChars - 128);
   const marker = `\n\n[truncated ${contents.length - keptChars} chars from ${label}; kept first ${keptChars} chars]\n`;
-  return `${contents.slice(0, keptChars)}${marker}`;
+  return `${contents.slice(0, keptChars)}${marker}`.slice(0, maxChars);
 }
 
 function fencedJson(value: unknown): string {

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -23,6 +23,7 @@ export interface ModelRequest {
     provider: string;
     name: string;
   };
+  phase?: string;
 }
 
 export interface ModelClient {
@@ -149,9 +150,10 @@ export async function buildProduceModelRequest(request: EvalAgentRequest): Promi
     request.sandbox.mounts.find((mount) => mount.target === "/skill")?.source
   );
 
-  return {
+  return checkedModelRequest({
     model: roleModel(request, "producer"),
     system: request.role,
+    phase: `producer eval ${request.evalCase.id}`,
     prompt: [
       `Run the target skill for "${request.evalCase.title}" (${request.evalCase.id}).`,
       `Eval type: ${request.evalCase.eval_type}`,
@@ -162,13 +164,13 @@ export async function buildProduceModelRequest(request: EvalAgentRequest): Promi
       fencedJson(request.evalCase),
       "",
       "Input files:",
-      formatFileSet(inputFiles),
+      formatFileSet(inputFiles, `producer eval ${request.evalCase.id} input files`),
       "",
       "Reference files:",
-      formatFileSet(referenceFiles),
+      formatFileSet(referenceFiles, `producer eval ${request.evalCase.id} reference files`),
       "",
       "Skill files:",
-      formatFileSet(skillFiles),
+      formatFileSet(skillFiles, `producer eval ${request.evalCase.id} skill files`),
       "",
       "Produce the concrete eval output files. Do not score your own work.",
       "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
@@ -182,7 +184,7 @@ export async function buildProduceModelRequest(request: EvalAgentRequest): Promi
       }),
       "Each output_files path must be relative to the eval output directory."
     ].join("\n")
-  };
+  });
 }
 
 export async function buildJudgeModelRequest(
@@ -193,9 +195,10 @@ export async function buildJudgeModelRequest(
     request.sandbox.mounts.find((mount) => mount.target === "/reference")?.source
   );
 
-  return {
+  return checkedModelRequest({
     model: roleModel(request, "judge"),
     system: request.modelRoles?.judge ?? "judge",
+    phase: `judge eval ${request.evalCase.id}`,
     prompt: [
       `Judge output for "${request.evalCase.title}" (${request.evalCase.id}).`,
       `Eval type: ${request.evalCase.eval_type}`,
@@ -205,10 +208,10 @@ export async function buildJudgeModelRequest(
       fencedJson(request.evalCase),
       "",
       "Reference files:",
-      formatFileSet(referenceFiles),
+      formatFileSet(referenceFiles, `judge eval ${request.evalCase.id} reference files`),
       "",
       "Producer output files:",
-      formatFileSet(outputFiles),
+      formatFileSet(outputFiles, `judge eval ${request.evalCase.id} producer output files`),
       "",
       "Score only the producer output. Do not award credit for requirements merely stated in the skill instructions.",
       "Return only well-formed JSON matching the EvalScore schema. Do not include markdown, code fences, prose, or XML tags:",
@@ -227,7 +230,7 @@ export async function buildJudgeModelRequest(
         summary: "Concise scoring summary."
       })
     ].join("\n")
-  };
+  });
 }
 
 export function parseModelProduceResponse(response: string): ModelProduceResponse {
@@ -258,10 +261,11 @@ export async function applyOutputFiles(outputDir: string, files: OutputFile[]): 
 
 export async function buildResearchModelRequest(request: SkillResearchRequest): Promise<ModelRequest> {
   const skillFiles = await readFilesFromMount(request.previousSkillDir);
-  return {
+  return checkedModelRequest({
     model: request.project.config.models?.researcher ??
       request.project.config.model ?? { provider: "anthropic", name: "claude-sonnet-4-6" },
     system: request.project.config.roles.skill_builder,
+    phase: `research iteration ${request.iteration}`,
     prompt: [
       `Improve skill "${request.project.config.skill_name}" for iteration ${request.iteration}.`,
       `Topic group: ${request.project.config.topic_group}`,
@@ -278,7 +282,7 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
       fencedJson(request.baselineScores),
       "",
       "Current skill files:",
-      formatFileSet(skillFiles),
+      formatFileSet(skillFiles, `research iteration ${request.iteration} skill files`),
       "",
       "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
       fencedJson({
@@ -287,7 +291,7 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
       }),
       "Each change path must be relative to the skill directory."
     ].join("\n")
-  };
+  });
 }
 
 function roleModel(request: EvalAgentRequest, role: "producer" | "judge"): ModelConfig {
@@ -413,15 +417,70 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
-function formatFileSet(files: Array<{ path: string; contents: string }>): string {
+const MAX_PROMPT_TOKENS = 180_000;
+const APPROX_CHARS_PER_TOKEN = 4;
+const MAX_FILE_CHARS = 80_000;
+const MAX_FILE_SET_CHARS = 240_000;
+
+function checkedModelRequest(request: ModelRequest): ModelRequest {
+  const estimatedTokens = estimateTokens(`${request.system}\n${request.prompt}`);
+  if (estimatedTokens <= MAX_PROMPT_TOKENS) {
+    return request;
+  }
+
+  const phase = request.phase ?? "model request";
+  throw new Error(
+    [
+      `[flue] prompt budget exceeded before ${phase}: estimated ${estimatedTokens} tokens > ${MAX_PROMPT_TOKENS} token budget`,
+      `Prompt size: ${request.prompt.length} chars. This was detected before submitting a provider request.`,
+      "Reduce the eval input/reference/skill/output artifacts for this phase or add a more compact summary."
+    ].join("\n")
+  );
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / APPROX_CHARS_PER_TOKEN);
+}
+
+function formatFileSet(files: Array<{ path: string; contents: string }>, label: string): string {
   if (files.length === 0) {
     return "(none)";
   }
-  return files.map((file) => `### ${file.path}\n\n${fenced(file.contents)}`).join("\n\n");
+  let remainingChars = MAX_FILE_SET_CHARS;
+  const formatted: string[] = [];
+  let omittedFiles = 0;
+
+  for (const file of files) {
+    if (remainingChars <= 0) {
+      omittedFiles++;
+      continue;
+    }
+
+    const contents = truncateText(file.contents, Math.min(MAX_FILE_CHARS, remainingChars), `${label}/${file.path}`);
+    remainingChars -= contents.length;
+    formatted.push(`### ${file.path}\n\n${fenced(contents)}`);
+  }
+
+  if (omittedFiles > 0) {
+    formatted.push(
+      `[${omittedFiles} file(s) omitted from ${label}; ${MAX_FILE_SET_CHARS} char file-set budget exhausted.]`
+    );
+  }
+
+  return formatted.join("\n\n");
 }
 
 function fenced(contents: string): string {
   return `\`\`\`\n${contents}\n\`\`\``;
+}
+
+function truncateText(contents: string, maxChars: number, label: string): string {
+  if (contents.length <= maxChars) {
+    return contents;
+  }
+  const keptChars = Math.max(0, maxChars - 128);
+  const marker = `\n\n[truncated ${contents.length - keptChars} chars from ${label}; kept first ${keptChars} chars]\n`;
+  return `${contents.slice(0, keptChars)}${marker}`;
 }
 
 function fencedJson(value: unknown): string {

--- a/tests/flue-harness.test.ts
+++ b/tests/flue-harness.test.ts
@@ -8,17 +8,17 @@ import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } fro
 
 class MockFlueSession {
   readonly id = "mock";
-  prompts: Array<{ text: string; result: unknown; model?: string; role?: string }> = [];
+  tasks: Array<{ text: string; schema: unknown; model?: string; role?: string }> = [];
 
   constructor(private readonly responses: unknown[]) {}
 
-  async prompt(text: string, options?: { result?: unknown; model?: string; role?: string }) {
-    this.prompts.push({ text, result: options?.result, model: options?.model, role: options?.role });
+  async task(text: string, options?: { schema?: unknown; model?: string; role?: string }) {
+    this.tasks.push({ text, schema: options?.schema, model: options?.model, role: options?.role });
     const response = this.responses.shift();
     if (!response) {
       throw new Error("No queued Flue response");
     }
-    return response;
+    return { data: response };
   }
 }
 
@@ -54,15 +54,16 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
   });
 
   expect(result.total_score).toBe(1);
-  expect((session as any).prompts.map((prompt: any) => prompt.model)).toEqual([
+  expect((session as any).tasks.map((task: any) => task.model)).toEqual([
     "anthropic/claude-haiku-4-5",
     "anthropic/claude-sonnet-4-6"
   ]);
-  expect((session as any).prompts[1].role).toBe("eval-judge");
+  expect((session as any).tasks[0].role).toBe("task-producer");
+  expect((session as any).tasks[1].role).toBe("eval-judge");
   await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Flue output\n");
 });
 
-test("runFlueAutoresearch executes the dry run through Flue session prompts", async () => {
+test("runFlueAutoresearch executes the dry run through detached Flue tasks", async () => {
   const root = await tempProject();
   const config = { ...syntheticConfig, target_score: 0.8, max_iterations: 1 };
   await writeFixture(root, config, syntheticEvals);
@@ -93,8 +94,8 @@ test("runFlueAutoresearch executes the dry run through Flue session prompts", as
   });
 
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
-  expect(session.prompts).toHaveLength(5);
-  expect(session.prompts.every((prompt) => prompt.result)).toBe(true);
+  expect(session.tasks).toHaveLength(5);
+  expect(session.tasks.every((task) => task.schema)).toBe(true);
   await expect(readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8")).resolves.toBe(
     "# Improved\n"
   );

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -151,6 +151,64 @@ test("buildJudgeModelRequest scores only producer output with judge model", asyn
   expect(request.prompt).toContain("Score only the producer output");
 });
 
+test("buildJudgeModelRequest bounds large producer outputs before judging", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  const evalCase = syntheticEvals.evals[0];
+  const request = await buildJudgeModelRequest(
+    {
+      evalCase,
+      track: trackForEval(syntheticConfig, evalCase.eval_type),
+      role: "task-producer",
+      model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+      sandbox: createEvalSandbox({
+        evalId: evalCase.id,
+        inputDir: join(root, "input"),
+        referenceDir: join(root, "reference"),
+        evalsDir: join(root, "evals"),
+        outputDir: join(root, "out")
+      })
+    },
+    [{ path: "RESULT.md", contents: "x".repeat(250_000) }]
+  );
+
+  expect(request.prompt.length).toBeLessThan(120_000);
+  expect(request.prompt).toContain("truncated");
+  expect(request.prompt).toContain("judge eval notes-001 producer output files/RESULT.md");
+});
+
+test("buildProduceModelRequest fails before provider calls when prompt budget is exceeded", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, {
+    evals: [
+      {
+        ...syntheticEvals.evals[0],
+        expectations: { huge: "x".repeat(800_000) }
+      }
+    ]
+  });
+  const evalCase = {
+    ...syntheticEvals.evals[0],
+    expectations: { huge: "x".repeat(800_000) }
+  };
+
+  await expect(
+    buildProduceModelRequest({
+      evalCase,
+      track: trackForEval(syntheticConfig, evalCase.eval_type),
+      role: "task-producer",
+      model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+      sandbox: createEvalSandbox({
+        evalId: evalCase.id,
+        inputDir: join(root, "input"),
+        referenceDir: join(root, "reference"),
+        evalsDir: join(root, "evals"),
+        outputDir: join(root, "out")
+      })
+    })
+  ).rejects.toThrow(/prompt budget exceeded before producer eval notes-001/);
+});
+
 test("ModelSkillResearcher snapshots the skill, applies patch changes, and records transcript", async () => {
   const root = await tempProject();
   await writeFixture(root, syntheticConfig, syntheticEvals);


### PR DESCRIPTION
## Summary
- Switch Flue agent calls to the structured `task(..., { schema })` flow and record the role for each phase
- Add prompt-budget checks plus file-set truncation to keep eval, judge, and research requests within bounds
- Update tests to cover structured Flue responses and prompt-budget failures
- Refresh the `skills-autoresearch` skill and harness docs to use the current `--root` CLI shape and the generated-baseline workflow

## Testing
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Flue harness usage documentation with new `--root` option syntax
  * Added guidance for generating initial baselines
  * Published comprehensive skill autoresearch guide with workflow requirements and validation checklists

* **Updates**
  * Bumped pnpm from 10.33.2 to 11.1.2

* **Bug Fixes**
  * Added prompt token budgeting to prevent oversized requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/skills-autoresearch-flue/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->