### PR TITLE
Stop research when the baseline already meets target score

### DIFF
--- a/.flue/agents/autoresearch.ts
+++ b/.flue/agents/autoresearch.ts
@@ -7,6 +7,7 @@ interface AutoresearchPayload {
   projectRoot?: string;
   withBaseline?: boolean;
   runResearch?: boolean;
+  forceResearch?: boolean;
   seedSkillDir?: string;
   sessionId?: string;
   model?: string;
@@ -24,6 +25,7 @@ export default async function ({ init, payload, env }: FlueContext<AutoresearchP
     projectRoot: payload.projectRoot ?? process.cwd(),
     withBaseline: payload.withBaseline,
     runResearch: payload.runResearch,
+    forceResearch: payload.forceResearch,
     seedSkillDir: payload.seedSkillDir
   });
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# Agent Guide
+
+This repository is an alpha Flue-based harness for autoresearching agent skills. It evaluates a seed skill against repeatable fixtures, asks a researcher model to improve the skill, then reruns evals against the candidate skill and persists enough artifacts to audit what happened.
+
+Keep this file short. Use it as orientation before reading deeper docs.
+
+## Start Here
+
+- User-facing harness guide: `docs/using-the-harness.md`
+- Contributor guide: `CONTRIBUTING.md`
+- Alpha run workflow: `docs/alpha-run.md`
+- Working fixture: `fixtures/projects/release-notes-alpha/`
+- Packaged skill: `skill/skills-autoresearch/SKILL.md`
+
+## Current Shape
+
+- Language/runtime: TypeScript ESM, Node `>=24`, pnpm.
+- Flue is the preferred alpha harness path; the CLI still exists but overlaps with the Flue entrypoint.
+- Models are split by responsibility:
+  - Researcher improves the candidate skill.
+  - Producer runs the target skill and writes eval outputs.
+  - Judge scores only the producer output.
+- Current committed config is Anthropic-focused and expects secrets through Varlock/1Password.
+
+## Key Code Paths
+
+- `.flue/agents/autoresearch.ts`: Flue agent entrypoint.
+- `.flue/roles/`: Flue roles for researcher, producer, and judge.
+- `src/orchestrator.ts`: baseline import/generation and research iteration loop.
+- `src/flue-harness.ts`: Flue session adapters and structured-result calls.
+- `src/model-agent.ts`: prompt builders, model response schemas, and artifact application.
+- `src/runner.ts`: eval execution and concurrency helper.
+- `src/schemas.ts`: Valibot schemas and public data contracts.
+- `src/project.ts`: project config and input loading.
+- `tests/`: unit, integration, and dry-run coverage.
+
+## Useful Commands
+
+```bash
+pnpm test
+pnpm run lint
+pnpm run format:check
+pnpm run typecheck
+pnpm run build
+pnpm run flue:build
+pnpm run alpha:smoke
+```
+
+Model-backed research requires credentials:
+
+```bash
+pnpm run env:check
+pnpm run alpha:research
+```
+
+`alpha:smoke` imports the committed baseline and should not call a model.
+
+## Project Fixture Layout
+
+Autoresearch project roots generally contain:
+
+```text
+config.json
+evals/eval-cases.json
+evals/rubric.md
+input/
+reference/
+seed-skill/SKILL.md
+workspace/baseline/
+```
+
+Generated research output lands under `workspace/iterations/<n>/`. Do not commit generated iterations unless the test or documentation intentionally needs a recorded run.
+
+## Guardrails
+
+- Keep Flue as the primary harness layer for alpha work.
+- Do not collapse producer and judge into one self-scoring model call.
+- Prefer schema-validated structured model output over ad hoc parsing.
+- Preserve auditability: output files, score JSON, summaries, and transcripts matter.
+- Keep fixtures small and deterministic.
+- Update docs and tests when config shape, artifact layout, commands, or model flow changes.
+- Never commit `.env`, resolved API keys, provider secrets, or transcripts containing secrets.
+- Score and summary writes often use exclusive file creation; rerun failures may indicate existing artifacts rather than logic failure.
+
+## What Is Still Alpha
+
+- Only Anthropic is supported by the committed model client/config.
+- Cross-provider judging is planned but not implemented.
+- Resume/retry behavior is basic.
+- The main fixture has one eval case and one track.
+- Multi-skill projects are documented conceptually, but the current alpha run improves one seed skill per invocation.
+
+## Testing Pointers
+
+- `tests/flue-harness.test.ts`: Flue adapter behavior and structured prompts.
+- `tests/e2e-dry-run.test.ts`: end-to-end orchestration with queued model responses.
+- `tests/model-agent.test.ts`: prompt builders, parsing, artifact writes, model client behavior.
+- `tests/sandbox-runner-orchestrator.test.ts`: sandbox, runner, and iteration loop behavior.
+- `tests/baseline-aggregate-score.test.ts`: baseline import, aggregation, and score parsing.
+
+For behavior changes, add focused tests at the lowest useful level. For cross-boundary changes, add or update a dry-run/integration test.

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -67,6 +67,8 @@ This runs the Flue agent with:
 }
 ```
 
+If the imported baseline already meets `target_score`, the run emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1`. Add `"forceResearch": true` to the payload only when you want to spend model calls on research anyway.
+
 ## Model Split
 
 The alpha fixture config assigns different models per phase:

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -316,6 +316,7 @@ The payload fields are:
 - `projectRoot`: path to the autoresearch project you want the harness to load. Relative paths are resolved from the directory where you run the command, so in this guide they are relative to the local `skills-autoresearch-flue` checkout root. Use an absolute path if the project lives somewhere else and you want to avoid ambiguity.
 - `withBaseline`: tells the harness to load or validate the baseline artifacts for the project.
 - `runResearch`: controls whether the researcher should patch the skill. `false` makes this a smoke run that stops before model-backed research.
+- `forceResearch`: optional override for research runs. When omitted or `false`, `runResearch:true` stops before the researcher if the baseline aggregate score already meets `target_score`.
 - `sessionId`: run/session name used when writing harness artifacts. Keeping this aligned with `--id` makes outputs easier to correlate.
 
 This should return events ending with `research-loop-ready`.
@@ -356,7 +357,9 @@ For a multi-skill project, point `seedSkillDir` at the specific skill you want t
 varlock run -- pnpm exec flue run autoresearch --target node --root . --id security-audit-research --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
 ```
 
-The run stops when either:
+The run first scores the baseline. If the baseline aggregate `normalizedScore` is already greater than or equal to `target_score`, the harness emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1` or calling the researcher. To intentionally run improvements anyway, add `"forceResearch": true` to the payload.
+
+When research proceeds, the run stops when either:
 
 - `target_score` is reached, or
 - `max_iterations` is exhausted.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "env:check": "varlock load"
   },
   "dependencies": {
-    "@flue/sdk": "^0.6.2",
+    "@flue/sdk": "0.5.3",
     "valibot": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@flue/sdk':
-        specifier: ^0.6.2
-        version: 0.6.2
+        specifier: 0.5.3
+        version: 0.5.3(ws@8.20.1)(zod@4.4.3)
       valibot:
         specifier: ^1.4.0
         version: 1.4.0(typescript@6.0.3)
@@ -546,10 +546,6 @@ packages:
     peerDependenciesMeta:
       wrangler:
         optional: true
-
-  '@flue/sdk@0.6.2':
-    resolution: {integrity: sha512-DqXybBpxb17gwEppuHcpUR0K0/04kCPmNhm2kTfz+Yhrxiw3OeClF3zPK9BkMj2GN/2ZZnwPPEeh1gJ4CoACdw==}
-    engines: {node: '>=22.18.0'}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -2778,8 +2774,6 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
-
-  '@flue/sdk@0.6.2': {}
 
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ interface CliOptions {
   projectRoot: string;
   withBaseline: boolean;
   runResearch: boolean;
+  forceResearch: boolean;
   seedSkillDir?: string;
   scoreDir?: string;
   modelClient?: "anthropic";
@@ -23,6 +24,7 @@ function usage(): string {
     "  --project <dir>       Project root. Defaults to current directory.",
     "  --with-baseline       Import workspace/baseline instead of generating it.",
     "  --research            Run research iterations after baseline.",
+    "  --force-research      Run research even when the baseline already reaches target_score.",
     "  --seed-skill <dir>    Seed skill directory for research iterations.",
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
@@ -38,6 +40,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       project: { type: "string" },
       "with-baseline": { type: "boolean" },
       research: { type: "boolean" },
+      "force-research": { type: "boolean" },
       "seed-skill": { type: "string" },
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
@@ -57,6 +60,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     projectRoot: parsed.values.project ?? process.cwd(),
     withBaseline: parsed.values["with-baseline"] ?? false,
     runResearch: parsed.values.research ?? false,
+    forceResearch: parsed.values["force-research"] ?? false,
     seedSkillDir: parsed.values["seed-skill"],
     scoreDir: parsed.values["score-dir"],
     modelClient: parseModelClient(parsed.values["model-client"]),
@@ -94,6 +98,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     projectRoot: cli.projectRoot,
     withBaseline: cli.withBaseline,
     runResearch: cli.runResearch,
+    forceResearch: cli.forceResearch,
     seedSkillDir: cli.seedSkillDir,
     agent: modelClient
       ? new ModelEvalAgent(modelClient)
@@ -156,6 +161,11 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
       return {
         level: "log",
         message: `Iteration ${event.iteration} score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`
+      };
+    case "baseline-target-score-reached":
+      return {
+        level: "log",
+        message: `Baseline reached target: ${event.normalizedScore.toFixed(3)} >= ${event.targetScore.toFixed(3)}`
       };
     case "target-score-reached":
       return {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -14,6 +14,7 @@ export type RunEvent =
   | { type: "iteration-started"; iteration: number; previousSkillDir: string; candidateSkillDir: string }
   | { type: "iteration-generated"; iteration: number; candidateSkillDir: string }
   | { type: "iteration-scored"; iteration: number; scores: number; aggregate: AggregateReport }
+  | { type: "baseline-target-score-reached"; normalizedScore: number; targetScore: number }
   | { type: "target-score-reached"; iteration: number; normalizedScore: number; targetScore: number }
   | { type: "max-iterations-reached"; completedIterations: number; maxIterations: number }
   | { type: "research-loop-ready"; completedIterations: number; maxIterations: number }
@@ -56,6 +57,7 @@ export interface OrchestrateOptions {
   researcher?: SkillResearcher;
   withBaseline?: boolean;
   runResearch?: boolean;
+  forceResearch?: boolean;
   seedSkillDir?: string;
 }
 
@@ -71,6 +73,20 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
 
   const aggregate = aggregateScores(project.config, baselineScores);
   events.push({ type: "aggregated", aggregate });
+
+  if (
+    options.runResearch &&
+    !options.forceResearch &&
+    aggregate.overall.normalizedScore >= project.config.target_score
+  ) {
+    events.push({
+      type: "baseline-target-score-reached",
+      normalizedScore: aggregate.overall.normalizedScore,
+      targetScore: project.config.target_score
+    });
+    return { project, baselineScores, aggregate, completedIterations: 0, iterations: [], events };
+  }
+
   events.push({
     type: "research-loop-ready",
     completedIterations: 0,

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -20,6 +20,10 @@ test("parseCliArgs validates currently required adapters", () => {
     modelClient: "anthropic",
     runResearch: true
   });
+  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--force-research"])).toMatchObject({
+    forceResearch: true,
+    runResearch: true
+  });
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
     /Research iterations require --score-dir or --model-client/

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -65,3 +65,13 @@ test("formatEvent classifies target completion as a regular log", () => {
     })
   ).toEqual({ level: "log", message: "Target reached at iteration 2: 0.900" });
 });
+
+test("formatEvent explains baseline target completion", () => {
+  expect(
+    formatEvent({
+      type: "baseline-target-score-reached",
+      normalizedScore: 0.95,
+      targetScore: 0.8
+    })
+  ).toEqual({ level: "log", message: "Baseline reached target: 0.950 >= 0.800" });
+});

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createEvalSandbox } from "../src/sandbox.js";
 import { runEval, runWithConcurrency, EvalAgent } from "../src/runner.js";
@@ -146,6 +146,74 @@ test("orchestrator generates initial baseline by default without counting it as 
   await expect(readFile(join(generateRoot, "workspace", "baseline", "scores-0.json"), "utf8")).resolves.toContain(
     "notes-001"
   );
+});
+
+test("orchestrator skips research when the baseline already reaches target score", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.95);
+    }
+  };
+  const researcher: SkillResearcher = {
+    async improve() {
+      throw new Error("researcher should not run when baseline reaches target");
+    }
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    agent,
+    researcher,
+    runResearch: true
+  });
+
+  expect(result.completedIterations).toBe(0);
+  expect(result.iterations).toEqual([]);
+  expect(result.aggregate.overall.normalizedScore).toBe(0.95);
+  expect(result.events.at(-1)).toMatchObject({
+    type: "baseline-target-score-reached",
+    normalizedScore: 0.95,
+    targetScore: syntheticConfig.target_score
+  });
+  await expect(stat(join(root, "workspace", "iterations", "1"))).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test("orchestrator can force research when the baseline already reaches target score", async () => {
+  const root = await tempProject();
+  const config = { ...syntheticConfig, max_iterations: 1 };
+  await writeFixture(root, config, syntheticEvals);
+  const seedSkill = join(root, "seed-skill");
+  await mkdir(seedSkill, { recursive: true });
+  await writeFile(join(seedSkill, "SKILL.md"), "# Release Summary\n");
+
+  const agent: EvalAgent = {
+    async run(request) {
+      return request.targetSkill
+        ? score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9)
+        : score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.95);
+    }
+  };
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+    }
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    agent,
+    researcher,
+    runResearch: true,
+    forceResearch: true,
+    seedSkillDir: seedSkill
+  });
+
+  expect(result.completedIterations).toBe(1);
+  expect(result.events.some((event) => event.type === "baseline-target-score-reached")).toBe(false);
+  expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 1 });
+  await expect(stat(join(root, "workspace", "iterations", "1", "skill"))).resolves.toBeTruthy();
 });
 
 test("orchestrator runs research iterations until target score is reached", async () => {


### PR DESCRIPTION
## Summary
- Stop before research iterations begin when the aggregated baseline score already meets `target_score`
- Add `baseline-target-score-reached` reporting and a `--force-research` override for intentional research runs
- Update the Flue entrypoint, CLI, docs, and tests to cover the new flow
- Pin `@flue/sdk` to the CLI-compatible runtime version so typecheck/build succeed again

## Testing
- Added unit/integration coverage for baseline early exit, forced research, CLI parsing, and event formatting
- `lint`, targeted Vitest coverage, `typecheck`, `build`, and Prettier checks passed