### PR TITLE
Add use-case docs for common autoresearch workflows

### DIFF
--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -1,0 +1,22 @@
+# Harness Use Cases
+
+Use-case docs explain why you would run the harness a certain way, then point to the commands and artifacts that support that workflow.
+
+The general operating guide is still [Using the Harness](../using-the-harness.md). Start there when you need the project layout, config shape, payload fields, or a full alpha run walkthrough.
+
+## Available Use Cases
+
+- [No-Skill Baseline Guidance Check](no-skill-baseline-guidance-check.md): determine whether a producer model can solve the domain task without any skill guidance.
+- [Seed Skill Improvement](seed-skill-improvement.md): improve an existing seed skill through the standard autoresearch loop.
+- [Compare Producer Models](compare-producer-models.md): run the same evals with different producer models to compare the need for skill guidance, cost, and output quality.
+- [Regression Test An Existing Skill](regression-test-existing-skill.md): use repeatable evals to check whether a known skill still performs as expected.
+
+## Choosing A Use Case
+
+Start with the no-skill baseline guidance check when you do not yet know whether the model needs a skill. If the baseline already reaches `target_score`, the model may be good enough for that eval set without extra domain guidance.
+
+Use seed skill improvement when you already have a skill and want the researcher to patch it based on score feedback.
+
+Use producer model comparison when model choice is part of the question. The same skill may be unnecessary for a stronger producer model and valuable for a smaller or cheaper one.
+
+Use regression testing when you care less about discovering new guidance and more about preserving known behavior across skill edits, model changes, or harness changes.

--- a/docs/use-cases/compare-producer-models.md
+++ b/docs/use-cases/compare-producer-models.md
@@ -1,0 +1,53 @@
+# Compare Producer Models
+
+Use this workflow when you want to know whether different producer models need the same skill guidance.
+
+For example, a stronger producer model might pass the no-skill baseline while a cheaper producer model needs a skill to reach the same `target_score`.
+
+## When To Use This
+
+Use producer model comparison when:
+
+- You are choosing between model quality and cost.
+- You want to know whether a skill makes a smaller model viable.
+- You want separate baselines for each producer model.
+- You are checking whether a model upgrade reduces the need for domain guidance.
+
+## Suggested Setup
+
+Keep the eval cases, rubric, input, reference material, judge model, and `target_score` stable across runs. Change only `models.producer` in `config.json` or run against separate project copies with different producer settings.
+
+This makes the comparison easier to interpret.
+
+## Step 1: Run A No-Skill Baseline Per Producer
+
+For each producer model, generate a baseline:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id baseline-haiku --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"baseline-haiku"}'
+```
+
+Record:
+
+- producer model name,
+- `overall.normalizedScore`,
+- notable score rationales,
+- approximate cost and latency, if available.
+
+## Step 2: Compare Against Target
+
+If a producer reaches `target_score` without a skill, that model may not need additional guidance for the current eval set.
+
+If a producer falls short, run seed skill improvement for that model and compare the post-skill score against its baseline.
+
+## Step 3: Keep Artifacts Separate
+
+Baseline score writes use exclusive file creation. To avoid collisions, use separate project workspaces, clean generated artifacts between runs, or use a copied project root per producer comparison.
+
+Do not commit generated model transcripts if they contain secrets or sensitive data.
+
+## Interpretation Notes
+
+A lower no-skill baseline does not automatically mean the model is unsuitable. A good skill may close the gap enough to make a cheaper model the better operational choice.
+
+A high no-skill baseline does not prove the model is robust outside the eval set. Add evals before making a broad claim.

--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -1,0 +1,116 @@
+# No-Skill Baseline Guidance Check
+
+Use this workflow to answer a product question before investing in skill authoring:
+
+> Can this producer model already perform the domain task well enough without a skill?
+
+The harness can do this today because generated baseline runs mount no target skill. The producer receives the role, eval case, input files, reference files, and rubric context, but no `/skill` files.
+
+## When To Use This
+
+Use a no-skill baseline when:
+
+- You have evals for a domain task, but you are not sure whether skill guidance is needed.
+- You want to compare a model's natural behavior against a target score.
+- You want a clean before/after score before running autoresearch against a seed skill.
+- You are deciding whether to spend time writing or improving a skill.
+
+Do not use this as proof that a model never needs guidance. It only answers the question for the configured model, role, eval cases, rubric, and reference material.
+
+## What This Shows
+
+If the baseline reaches `target_score`, the model likely does not need additional skill guidance for this eval set.
+
+If the baseline falls short, the scores and judge rationales help identify where domain guidance may help. You can then run the standard seed skill improvement workflow, or implement the future seed-as-reference workflow tracked in [issue #40](https://github.com/schalkneethling/skills-autoresearch-flue/issues/40).
+
+## Project Setup
+
+Create or reuse an autoresearch project with:
+
+```text
+my-autoresearch-project/
+  config.json
+  evals/
+    eval-cases.json
+    rubric.md
+  input/
+    ...
+  reference/
+    ...
+  seed-skill/
+    SKILL.md
+  workspace/
+```
+
+The `seed-skill/` directory can exist even though the baseline will not mount it. The seed skill becomes relevant only if you continue into research.
+
+## Step 1: Generate The Baseline
+
+From the root of this harness checkout, run:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+```
+
+Omit `withBaseline` so the harness generates a fresh model-backed baseline. Use `runResearch:false` so the run stops after baseline generation and aggregation.
+
+Expected events include:
+
+```text
+baseline-started
+baseline-generated
+aggregated
+research-loop-ready
+```
+
+Generated artifacts are written under:
+
+```text
+path/to/my-autoresearch-project/workspace/baseline/
+```
+
+## Step 2: Inspect The Score
+
+Open:
+
+```text
+path/to/my-autoresearch-project/workspace/baseline/summary.json
+```
+
+Compare `overall.normalizedScore` with `target_score` from `config.json`.
+
+Also inspect each `scores-*.json` file. Judge rationales often matter more than the aggregate number because they explain what guidance the model lacked.
+
+## Step 3: Interpret The Result
+
+If `overall.normalizedScore >= target_score`, the model reached the goal without a skill. You can treat this as evidence that the configured producer model does not need extra domain guidance for the current eval set.
+
+If `overall.normalizedScore < target_score`, the model likely needs either:
+
+- better role or eval context,
+- better reference material,
+- a domain skill,
+- a stronger producer model, or
+- a more focused rubric/eval set.
+
+## Step 4: Optional Early-Exit Check
+
+After generating the baseline, you can run with `withBaseline:true` and `runResearch:true` to confirm the harness will stop before research when the baseline already passes:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research-check --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-check"}'
+```
+
+When the baseline passes, the run emits:
+
+```text
+baseline-target-score-reached
+```
+
+and does not create `workspace/iterations/1`.
+
+## Current Limitation
+
+If the baseline falls short and research proceeds today, iteration 1 starts from the configured seed skill. The researcher does not yet start from an empty candidate skill while using the seed skill only as reference material.
+
+That future workflow is tracked in [issue #40](https://github.com/schalkneethling/skills-autoresearch-flue/issues/40).

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -1,0 +1,68 @@
+# Regression Test An Existing Skill
+
+Use this workflow when you want repeatable evidence that a known skill still behaves as expected.
+
+This is useful after editing a skill, changing roles, upgrading models, or changing harness behavior.
+
+## When To Use This
+
+Use regression testing when:
+
+- You have a skill that already passes its evals.
+- You want to verify that a change did not reduce score.
+- You want a small deterministic fixture for review.
+- You want to compare candidate output against a committed baseline.
+
+## Step 1: Keep A Baseline
+
+Commit only intentional baseline fixtures. A baseline should include:
+
+```text
+workspace/baseline/
+  scores-0.json
+  summary.json
+  <eval-id>/
+    task.md
+    input/
+    output/
+```
+
+The baseline can be imported without model calls:
+
+```bash
+pnpm exec flue run autoresearch --target node --root . --id regression-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"regression-smoke"}'
+```
+
+This validates the project and imported score artifacts.
+
+## Step 2: Run A Candidate Pass
+
+To evaluate an updated seed skill through the normal research loop:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id regression-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"regression-research"}'
+```
+
+If the imported baseline already reaches `target_score`, the harness stops before research unless you set `forceResearch:true`.
+
+Use `forceResearch:true` only when you intentionally want a fresh candidate despite a passing baseline.
+
+## Step 3: Review The Difference
+
+Compare:
+
+- imported baseline `summary.json`,
+- latest iteration `summary.json`,
+- per-eval `scores-*.json`,
+- producer outputs under `workspace/iterations/<n>/outputs/`,
+- candidate skill changes under `workspace/iterations/<n>/skill/`.
+
+## Cleanup
+
+Generated iteration artifacts are written with exclusive file creation. Remove generated iterations before rerunning the same project from scratch:
+
+```bash
+rm -rf path/to/my-autoresearch-project/workspace/iterations
+```
+
+Only commit generated iterations when the fixture or documentation intentionally needs a recorded run.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -1,0 +1,73 @@
+# Seed Skill Improvement
+
+Use this workflow when you already have a seed skill and want the harness to improve it through scored iterations.
+
+The standard autoresearch loop is:
+
+1. Import or generate a baseline.
+2. Aggregate baseline scores.
+3. Stop early if the baseline reaches `target_score`.
+4. Ask the researcher to patch the seed skill when the baseline falls short.
+5. Run producer evals against the candidate skill.
+6. Ask the judge to score only the producer output.
+7. Repeat until `target_score` is reached or `max_iterations` is exhausted.
+
+## When To Use This
+
+Use seed skill improvement when:
+
+- You already have useful guidance in `seed-skill/SKILL.md`.
+- You want the researcher to preserve and refine that skill.
+- You want each candidate skill saved under `workspace/iterations/<n>/skill/`.
+- You want audit artifacts for outputs, scores, summaries, and transcripts.
+
+## Step 1: Prepare A Baseline
+
+If `workspace/baseline/` already exists, you can import it:
+
+```bash
+pnpm exec flue run autoresearch --target node --root . --id my-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+```
+
+If no baseline exists yet, generate one:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+```
+
+## Step 2: Run Research
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+```
+
+If the imported baseline already reaches `target_score`, the run stops with `baseline-target-score-reached`.
+
+If research proceeds, iteration artifacts land under:
+
+```text
+path/to/my-autoresearch-project/workspace/iterations/1/
+  outputs/
+  skill/
+    SKILL.md
+    RESEARCH.md
+    .autoresearch-transcript.json
+  scores-0.json
+  summary.json
+```
+
+## Step 3: Inspect The Candidate
+
+Review:
+
+- `skill/SKILL.md`: the candidate skill produced by the researcher.
+- `skill/RESEARCH.md`: the researcher's summary of intended changes.
+- `summary.json`: aggregate score for the iteration.
+- `scores-*.json`: judge scores and rationales for each eval.
+- `outputs/<eval-id>/`: producer output and transcripts.
+
+## Current Behavior
+
+Iteration 1 starts by copying the seed skill and applying the researcher's patch. Later iterations start from the previous candidate skill.
+
+If you need a workflow where iteration 1 starts from an empty skill and the seed is only reference material, follow [issue #40](https://github.com/schalkneethling/skills-autoresearch-flue/issues/40).

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -2,6 +2,8 @@
 
 This guide is for someone who has an agent skill and wants to use this repository to improve it through autoresearch.
 
+For goal-oriented examples, see [Harness Use Cases](use-cases/README.md).
+
 The current alpha flow is:
 
 1. Define a small autoresearch project for your skill.


### PR DESCRIPTION
## Summary
- Add a new `docs/use-cases/` section with an index and four workflow pages.
- Document the no-skill baseline guidance check, seed skill improvement, producer model comparison, and regression testing workflows.
- Link the use-case section from the main harness guide for easier discovery.

## Testing
- Verified the new docs files with Prettier.
- `pnpm run format:check` still reports an existing formatting warning in `skill/skills-autoresearch/SKILL.md`, outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive use-case documentation covering four key workflows for evaluating and improving producer models.
  * Includes detailed guidance on assessing no-skill baselines, iterative skill improvement, comparing different producer models, and regression testing existing skills.
  * Added a use-case landing page with navigation and workflow selection guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/skills-autoresearch-flue/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->