### PR TITLE
Isolate Flue eval and research workspaces

### DIFF
--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -237,8 +237,19 @@ The producer sees:
 The judge sees:
 
 - eval case JSON
+- rubric files
 - reference files
 - producer output files
+
+The researcher sees:
+
+- project config
+- eval and rubric files
+- reference files
+- previous aggregate, score, and baseline summaries
+- the previous skill files
+
+For Flue-backed runs, each phase executes from a small generated workspace containing only the files for that phase. These workspaces are written under `workspace/.phase-workspaces/` or the eval output directory's `.phase-workspaces/` folder and are also recorded in transcripts as `workspaceDir`. The judge workspace contains only `evals/rubric.md`, reference files, and producer output files; it does not mount the candidate skill or unrelated harness fixtures.
 
 The judge should not score skill instructions directly.
 

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -35,7 +35,8 @@ export class FlueEvalAgent implements EvalAgent {
     const { data: produced } = await this.#session.task(produceRequest.prompt, {
       schema: ModelProduceResponseSchema,
       role: produceRequest.system,
-      model: toFlueModel(produceRequest.model)
+      model: toFlueModel(produceRequest.model),
+      cwd: produceRequest.workspaceDir
     });
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
     await writeTranscript(request.sandbox.outputDir, "producer-flue-transcript.json", {
@@ -47,7 +48,8 @@ export class FlueEvalAgent implements EvalAgent {
     const { data: score } = await this.#session.task(judgeRequest.prompt, {
       schema: EvalScoreSchema,
       role: request.modelRoles?.judge,
-      model: toFlueModel(judgeRequest.model)
+      model: toFlueModel(judgeRequest.model),
+      cwd: judgeRequest.workspaceDir
     });
     const validated = parseModelJudgeResponse(JSON.stringify(score), request.evalCase, request.track);
     await writeTranscript(request.sandbox.outputDir, "judge-flue-transcript.json", {
@@ -70,7 +72,8 @@ export class FlueSkillResearcher implements SkillResearcher {
     const { data: patch } = await this.#session.task(modelRequest.prompt, {
       schema: SkillResearchPatchSchema,
       role: modelRequest.system,
-      model: toFlueModel(modelRequest.model)
+      model: toFlueModel(modelRequest.model),
+      cwd: modelRequest.workspaceDir
     });
     validateSkillResearchPatch(request.candidateSkillDir, patch);
     await cp(request.previousSkillDir, request.candidateSkillDir, {

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { SkillResearcher, SkillResearchRequest } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
@@ -24,6 +24,7 @@ export interface ModelRequest {
     name: string;
   };
   phase?: string;
+  workspaceDir?: string;
 }
 
 export interface ModelClient {
@@ -140,25 +141,24 @@ export class ModelSkillResearcher implements SkillResearcher {
 }
 
 export async function buildProduceModelRequest(request: EvalAgentRequest): Promise<ModelRequest> {
-  const inputFiles = await readFilesFromMount(
-    request.sandbox.mounts.find((mount) => mount.target === "/input")?.source
-  );
-  const referenceFiles = await readFilesFromMount(
-    request.sandbox.mounts.find((mount) => mount.target === "/reference")?.source
-  );
-  const skillFiles = await readFilesFromMount(
-    request.sandbox.mounts.find((mount) => mount.target === "/skill")?.source
-  );
+  const workspaceDir = await createPhaseWorkspace(request, "producer", ["/input", "/reference", "/skill"]);
+  const inputFiles = await readFilesFromMount(join(workspaceDir, "input"));
+  const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
+  const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
 
   return checkedModelRequest({
     model: roleModel(request, "producer"),
     system: request.role,
     phase: `producer eval ${request.evalCase.id}`,
+    workspaceDir,
     prompt: [
       `Run the target skill for "${request.evalCase.title}" (${request.evalCase.id}).`,
       `Eval type: ${request.evalCase.eval_type}`,
       `Track: ${request.track.id}`,
       request.targetSkill ? `Target skill: ${request.targetSkill}` : "Baseline run: no target skill is mounted.",
+      `Authoritative workspace root: ${workspaceDir}`,
+      "Only files under this workspace are authoritative for this producer phase.",
+      "Available paths: ./input, ./reference, ./skill when present.",
       "",
       "Eval case JSON:",
       fencedJson(request.evalCase),
@@ -191,27 +191,37 @@ export async function buildJudgeModelRequest(
   request: EvalAgentRequest,
   outputFiles: OutputFile[]
 ): Promise<ModelRequest> {
-  const referenceFiles = await readFilesFromMount(
-    request.sandbox.mounts.find((mount) => mount.target === "/reference")?.source
-  );
+  await applyOutputFiles(request.sandbox.outputDir, outputFiles);
+  const workspaceDir = await createPhaseWorkspace(request, "judge", ["/reference"]);
+  await applyOutputFiles(join(workspaceDir, "output"), outputFiles);
+  const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
+  const rubricFiles = await readFilesFromMount(join(workspaceDir, "evals"));
+  const workspaceOutputFiles = await readFilesFromMount(join(workspaceDir, "output"));
 
   return checkedModelRequest({
     model: roleModel(request, "judge"),
     system: request.modelRoles?.judge ?? "judge",
     phase: `judge eval ${request.evalCase.id}`,
+    workspaceDir,
     prompt: [
       `Judge output for "${request.evalCase.title}" (${request.evalCase.id}).`,
       `Eval type: ${request.evalCase.eval_type}`,
       `Track: ${request.track.id}`,
+      `Authoritative workspace root: ${workspaceDir}`,
+      "Only files under this workspace are authoritative for this judge phase.",
+      "Available paths: ./evals, ./reference, ./output.",
       "",
       "Eval case JSON:",
       fencedJson(request.evalCase),
+      "",
+      "Rubric files:",
+      formatFileSet(rubricFiles, `judge eval ${request.evalCase.id} rubric files`),
       "",
       "Reference files:",
       formatFileSet(referenceFiles, `judge eval ${request.evalCase.id} reference files`),
       "",
       "Producer output files:",
-      formatFileSet(outputFiles, `judge eval ${request.evalCase.id} producer output files`),
+      formatFileSet(workspaceOutputFiles, `judge eval ${request.evalCase.id} producer output files`),
       "",
       "Score only the producer output. Do not award credit for requirements merely stated in the skill instructions.",
       "Return only well-formed JSON matching the EvalScore schema. Do not include markdown, code fences, prose, or XML tags:",
@@ -231,6 +241,35 @@ export async function buildJudgeModelRequest(
       })
     ].join("\n")
   });
+}
+
+async function createPhaseWorkspace(
+  request: EvalAgentRequest,
+  phase: "producer" | "judge",
+  mountTargets: string[]
+): Promise<string> {
+  const workspaceDir = join(request.sandbox.outputDir, ".phase-workspaces", phase);
+  await rm(workspaceDir, { recursive: true, force: true });
+  await mkdir(workspaceDir, { recursive: true });
+
+  for (const target of mountTargets) {
+    const mount = request.sandbox.mounts.find((candidate) => candidate.target === target);
+    if (!mount || !(await exists(mount.source))) {
+      continue;
+    }
+    await cp(mount.source, join(workspaceDir, target.slice(1)), { recursive: true, force: false, errorOnExist: true });
+  }
+
+  const evalsMount = request.sandbox.mounts.find((candidate) => candidate.target === "/evals");
+  if (phase === "judge" && evalsMount && (await exists(evalsMount.source))) {
+    await mkdir(join(workspaceDir, "evals"), { recursive: true });
+    const rubricPath = join(evalsMount.source, "rubric.md");
+    if (await exists(rubricPath)) {
+      await cp(rubricPath, join(workspaceDir, "evals", "rubric.md"), { force: false, errorOnExist: true });
+    }
+  }
+
+  return workspaceDir;
 }
 
 export function parseModelProduceResponse(response: string): ModelProduceResponse {
@@ -260,17 +299,24 @@ export async function applyOutputFiles(outputDir: string, files: OutputFile[]): 
 }
 
 export async function buildResearchModelRequest(request: SkillResearchRequest): Promise<ModelRequest> {
-  const skillFiles = await readFilesFromMount(request.previousSkillDir);
+  const workspaceDir = await createResearchWorkspace(request);
+  const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
+  const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
+  const evalFiles = await readFilesFromMount(join(workspaceDir, "evals"));
   return checkedModelRequest({
     model: request.project.config.models?.researcher ??
       request.project.config.model ?? { provider: "anthropic", name: "claude-sonnet-4-6" },
     system: request.project.config.roles.skill_builder,
     phase: `research iteration ${request.iteration}`,
+    workspaceDir,
     prompt: [
       `Improve skill "${request.project.config.skill_name}" for iteration ${request.iteration}.`,
       `Topic group: ${request.project.config.topic_group}`,
       `Target normalized score: ${request.project.config.target_score}`,
       `Previous normalized score: ${request.previousAggregate.overall.normalizedScore}`,
+      `Authoritative workspace root: ${workspaceDir}`,
+      "Only files under this workspace are authoritative for this research phase.",
+      "Available paths: ./config.json, ./evals, ./reference, ./skill, ./scores.",
       "",
       "Previous aggregate:",
       fencedJson(request.previousAggregate),
@@ -284,6 +330,12 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
       "Current skill files:",
       formatFileSet(skillFiles, `research iteration ${request.iteration} skill files`),
       "",
+      "Eval and rubric files:",
+      formatFileSet(evalFiles, `research iteration ${request.iteration} eval files`),
+      "",
+      "Reference files:",
+      formatFileSet(referenceFiles, `research iteration ${request.iteration} reference files`),
+      "",
       "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
       fencedJson({
         summary: "Brief summary of the intended skill improvement.",
@@ -292,6 +344,46 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
       "Each change path must be relative to the skill directory."
     ].join("\n")
   });
+}
+
+async function createResearchWorkspace(request: SkillResearchRequest): Promise<string> {
+  const workspaceDir = join(request.project.root, "workspace", ".phase-workspaces", `research-${request.iteration}`);
+  await rm(workspaceDir, { recursive: true, force: true });
+  await mkdir(join(workspaceDir, "scores"), { recursive: true });
+  await cp(join(request.project.root, "config.json"), join(workspaceDir, "config.json"), {
+    force: false,
+    errorOnExist: true
+  });
+  await cp(join(request.project.root, "evals"), join(workspaceDir, "evals"), {
+    recursive: true,
+    force: false,
+    errorOnExist: true
+  });
+  if (await exists(request.project.referenceDir)) {
+    await cp(request.project.referenceDir, join(workspaceDir, "reference"), {
+      recursive: true,
+      force: false,
+      errorOnExist: true
+    });
+  }
+  await cp(request.previousSkillDir, join(workspaceDir, "skill"), {
+    recursive: true,
+    force: false,
+    errorOnExist: true
+  });
+  await writeFile(
+    join(workspaceDir, "scores", "previous-aggregate.json"),
+    `${JSON.stringify(request.previousAggregate, null, 2)}\n`
+  );
+  await writeFile(
+    join(workspaceDir, "scores", "previous-scores.json"),
+    `${JSON.stringify(request.previousScores, null, 2)}\n`
+  );
+  await writeFile(
+    join(workspaceDir, "scores", "baseline-scores.json"),
+    `${JSON.stringify(request.baselineScores, null, 2)}\n`
+  );
+  return workspaceDir;
 }
 
 function roleModel(request: EvalAgentRequest, role: "producer" | "judge"): ModelConfig {

--- a/tests/flue-harness.test.ts
+++ b/tests/flue-harness.test.ts
@@ -1,5 +1,5 @@
 import type { FlueSession } from "@flue/runtime/client";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { FlueEvalAgent, runFlueAutoresearch } from "../src/flue-harness.js";
 import { createEvalSandbox } from "../src/sandbox.js";
@@ -8,12 +8,12 @@ import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } fro
 
 class MockFlueSession {
   readonly id = "mock";
-  tasks: Array<{ text: string; schema: unknown; model?: string; role?: string }> = [];
+  tasks: Array<{ text: string; schema: unknown; model?: string; role?: string; cwd?: string }> = [];
 
   constructor(private readonly responses: unknown[]) {}
 
-  async task(text: string, options?: { schema?: unknown; model?: string; role?: string }) {
-    this.tasks.push({ text, schema: options?.schema, model: options?.model, role: options?.role });
+  async task(text: string, options?: { schema?: unknown; model?: string; role?: string; cwd?: string }) {
+    this.tasks.push({ text, schema: options?.schema, model: options?.model, role: options?.role, cwd: options?.cwd });
     const response = this.responses.shift();
     if (!response) {
       throw new Error("No queued Flue response");
@@ -60,6 +60,16 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
   ]);
   expect((session as any).tasks[0].role).toBe("task-producer");
   expect((session as any).tasks[1].role).toBe("eval-judge");
+  expect((session as any).tasks[0].cwd).toContain(join(sandbox.outputDir, ".phase-workspaces", "producer"));
+  expect((session as any).tasks[1].cwd).toContain(join(sandbox.outputDir, ".phase-workspaces", "judge"));
+  expect((session as any).tasks[1].text).toContain("Available paths: ./evals, ./reference, ./output.");
+  expect((session as any).tasks[1].text).not.toContain("release-notes-alpha");
+  await expect(
+    readFile(join(sandbox.outputDir, ".phase-workspaces", "judge", "output", "RESULT.md"), "utf8")
+  ).resolves.toBe("Flue output\n");
+  await expect(stat(join(sandbox.outputDir, ".phase-workspaces", "judge", "skill"))).rejects.toMatchObject({
+    code: "ENOENT"
+  });
   await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Flue output\n");
 });
 


### PR DESCRIPTION
## Summary
- Create per-phase generated workspaces for producer, judge, and researcher runs so Flue tasks execute from a narrowed cwd instead of the harness checkout root.
- Copy only the phase-specific files into those workspaces, and keep judge inputs limited to rubric/reference context plus producer outputs.
- Update docs and tests to describe and verify the restricted file visibility.

## Testing
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run lint`
- Scoped Prettier check on touched files passed
- Full `pnpm run format:check` still reports an existing formatting issue in `skill/skills-autoresearch/SKILL.md`