### PR TITLE
Add seed-as-reference research workflow

### DIFF
--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -21,7 +21,7 @@ Do not use this as proof that a model never needs guidance. It only answers the 
 
 If the baseline reaches `target_score`, the model likely does not need additional skill guidance for this eval set.
 
-If the baseline falls short, the scores and judge rationales help identify where domain guidance may help. You can then run the standard seed skill improvement workflow, or implement the future seed-as-reference workflow tracked in [issue #40](https://github.com/schalkneethling/skills-autoresearch-flue/issues/40).
+If the baseline falls short, the scores and judge rationales help identify where domain guidance may help. You can then run the standard seed skill improvement workflow, or enable seed-as-reference research by setting `research_start` to `"empty"`.
 
 ## Project Setup
 
@@ -109,8 +109,17 @@ baseline-target-score-reached
 
 and does not create `workspace/iterations/1`.
 
-## Current Limitation
+## Seed-As-Reference Research
 
-If the baseline falls short and research proceeds today, iteration 1 starts from the configured seed skill. The researcher does not yet start from an empty candidate skill while using the seed skill only as reference material.
+To start research from an empty candidate skill while using the seed skill only as reference material, add this to `config.json`:
 
-That future workflow is tracked in [issue #40](https://github.com/schalkneethling/skills-autoresearch-flue/issues/40).
+```json
+{
+  "origin_skill": "seed-skill",
+  "research_start": "empty"
+}
+```
+
+If `guidance_skill` is omitted, `origin_skill` is used as the immutable guidance skill. Iteration 1 starts from `workspace/empty-skill`; later iterations continue from the previous candidate skill.
+
+Model-backed research writes `workspace/guidance-ledger.json` when the researcher records which seed/reference sections were used, deferred, ignored, or requested. After iteration 1, prompts include that ledger and a compact seed/reference index instead of the full seed skill content by default.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -70,4 +70,4 @@ Review:
 
 Iteration 1 starts by copying the seed skill and applying the researcher's patch. Later iterations start from the previous candidate skill.
 
-If you need a workflow where iteration 1 starts from an empty skill and the seed is only reference material, follow [issue #40](https://github.com/schalkneethling/skills-autoresearch-flue/issues/40).
+If you need a workflow where iteration 1 starts from an empty skill and the seed is only reference material, set `research_start` to `"empty"` in `config.json`. The seed remains available as immutable guidance, and model-backed research records seed/reference usage in `workspace/guidance-ledger.json`.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -136,6 +136,8 @@ The important parts are not the exact directory names for every project, but tha
 Important fields:
 
 - `origin_skill`: default path to the seed skill directory, relative to the project root unless absolute.
+- `research_start`: optional. Use `"seed"` or omit it for the standard workflow; use `"empty"` when the first research iteration should start from an empty candidate skill.
+- `guidance_skill`: optional path to a skill used only as seed/reference guidance. Use this when the candidate should start from `origin_skill`, but the researcher should consult a different reference skill; or when `research_start` is `"empty"` and the guidance source should be different from `origin_skill`. When `research_start` is `"empty"` and `guidance_skill` is omitted, the harness uses `origin_skill` as the guidance skill.
 - `target_score`: normalized score required to stop early.
 - `max_iterations`: maximum candidate-improvement attempts.
 - `models.producer`: model that produces eval outputs. The default config uses a cheaper/smaller model here.
@@ -177,6 +179,31 @@ To improve the authoring skill without editing `config.json`, keep the config de
 ```
 
 Current alpha behavior improves one seed skill per run. For multi-skill projects, run the harness once per target skill.
+
+## Seed-As-Reference Research
+
+Use this workflow when you want to test whether the producer needs any skill guidance at all, then let the researcher selectively pull from an existing seed skill only if the baseline falls short.
+
+Configure the project like this:
+
+```json
+{
+  "origin_skill": "seed-skill",
+  "research_start": "empty"
+}
+```
+
+With this shape:
+
+- Baseline generation still runs with no mounted skill.
+- If the baseline reaches `target_score`, research stops before creating an iteration.
+- If research runs, iteration 1 starts from `workspace/empty-skill`.
+- The seed skill remains available to the researcher as immutable reference material.
+- Later iterations continue from the previous candidate skill, not from the seed skill.
+
+Model-backed research writes `workspace/guidance-ledger.json` when the researcher reports seed/reference guidance decisions. Iteration 1 includes the full seed/reference skill in the researcher prompt. Later iterations include the guidance ledger and a compact seed/reference index instead of repeatedly injecting the full seed skill content.
+
+Set `guidance_skill` only when the guidance source should differ from the starting skill. For example, `origin_skill` can point at a minimal house-style skill that should be copied into the first candidate, while `guidance_skill` points at a larger reference skill that should be consulted selectively. In the empty-start workflow, `origin_skill` can remain the default seed reference, while `guidance_skill` can point at a distilled or alternate guidance source for that run.
 
 ## Eval Cases
 

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -5,7 +5,10 @@ import {
   buildJudgeModelRequest,
   buildProduceModelRequest,
   buildResearchModelRequest,
-  parseModelJudgeResponse
+  formatResearchSummary,
+  parseModelJudgeResponse,
+  applySkillResearchPatch,
+  validateSkillResearchPatch
 } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, SkillResearcher } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
@@ -13,10 +16,8 @@ import {
   EvalScore,
   EvalScoreSchema,
   ModelProduceResponseSchema,
-  SkillResearchPatchSchema,
-  SkillResearchPatch
+  SkillResearchPatchSchema
 } from "./schemas.js";
-import { applySkillResearchPatch, validateSkillResearchPatch } from "./model-agent.js";
 import { cp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -108,16 +109,4 @@ export async function runFlueAutoresearch(options: FlueAutoresearchOptions) {
 async function writeTranscript(dir: string, fileName: string, value: unknown): Promise<void> {
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, fileName), `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
-}
-
-function formatResearchSummary(patch: SkillResearchPatch): string {
-  return [
-    "# Research Summary",
-    "",
-    patch.summary,
-    "",
-    "## Changed Files",
-    "",
-    ...patch.changes.map((change) => `- ${change.path}`)
-  ].join("\n");
 }

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -1,6 +1,7 @@
 import type { FlueSession } from "@flue/runtime/client";
 import {
   applyOutputFiles,
+  appendGuidanceLedger,
   buildJudgeModelRequest,
   buildProduceModelRequest,
   buildResearchModelRequest,
@@ -83,6 +84,7 @@ export class FlueSkillResearcher implements SkillResearcher {
     });
     await mkdir(request.candidateSkillDir, { recursive: true });
     await applySkillResearchPatch(request.candidateSkillDir, patch);
+    await appendGuidanceLedger(request.guidanceLedgerPath, request.iteration, patch);
     await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), { flag: "wx" });
     await writeTranscript(request.candidateSkillDir, ".autoresearch-flue-transcript.json", {
       request: modelRequest,

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -542,7 +542,7 @@ function validateEvalScore(score: EvalScore, evalCase: EvalCase, track: Track): 
   }
 }
 
-function formatResearchSummary(patch: SkillResearchPatch): string {
+export function formatResearchSummary(patch: SkillResearchPatch): string {
   return [
     `# Research Summary`,
     "",

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -6,6 +6,8 @@ import {
   EvalCase,
   EvalScore,
   EvalScoreSchema,
+  GuidanceLedger,
+  GuidanceLedgerSchema,
   ModelConfig,
   ModelProduceResponse,
   ModelProduceResponseSchema,
@@ -15,6 +17,8 @@ import {
   Track,
   parseWithSchema
 } from "./schemas.js";
+
+type MountedFile = { path: string; contents: string };
 
 export interface ModelRequest {
   system: string;
@@ -135,6 +139,7 @@ export class ModelSkillResearcher implements SkillResearcher {
     });
     await mkdir(request.candidateSkillDir, { recursive: true });
     await applySkillResearchPatch(request.candidateSkillDir, patch);
+    await appendGuidanceLedger(request.guidanceLedgerPath, request.iteration, patch);
     await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), { flag: "wx" });
     await persistTranscript(join(request.candidateSkillDir, ".autoresearch-transcript.json"), modelRequest, response);
   }
@@ -302,7 +307,9 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
   const workspaceDir = await createResearchWorkspace(request);
   const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
   const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
+  const seedReferenceFiles = await readFilesFromMount(join(workspaceDir, "seed-reference"));
   const evalFiles = await readFilesFromMount(join(workspaceDir, "evals"));
+  const guidanceLedger = await readGuidanceLedger(request.guidanceLedgerPath);
   return checkedModelRequest({
     model: request.project.config.models?.researcher ??
       request.project.config.model ?? { provider: "anthropic", name: "claude-sonnet-4-6" },
@@ -317,6 +324,9 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
       `Authoritative workspace root: ${workspaceDir}`,
       "Only files under this workspace are authoritative for this research phase.",
       "Available paths: ./config.json, ./evals, ./reference, ./skill, ./scores.",
+      request.guidanceSkillDir
+        ? "Seed/reference skill guidance is available under ./seed-reference for this research phase."
+        : "No separate seed/reference skill guidance directory is configured for this research phase.",
       "",
       "Previous aggregate:",
       fencedJson(request.previousAggregate),
@@ -336,12 +346,25 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
       "Reference files:",
       formatFileSet(referenceFiles, `research iteration ${request.iteration} reference files`),
       "",
+      ...formatGuidanceContext(request.iteration, seedReferenceFiles, guidanceLedger),
+      "",
       "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
       fencedJson({
         summary: "Brief summary of the intended skill improvement.",
+        guidance: [
+          {
+            source: "seed-reference/SKILL.md",
+            section: "Optional section heading or concise location.",
+            action: "used",
+            reason: "Why this guidance was or was not needed for the current failures.",
+            appliedTo: "SKILL.md"
+          }
+        ],
         changes: [{ path: "SKILL.md", contents: "Complete replacement file contents." }]
       }),
-      "Each change path must be relative to the skill directory."
+      "Each change path must be relative to the skill directory.",
+      "Use guidance entries to update the guidance ledger whenever you inspect, use, defer, ignore, or need more seed/reference guidance.",
+      "After iteration 1, prefer the guidance ledger and seed/reference index first; pull exact seed/reference content only when the latest failures justify it."
     ].join("\n")
   });
 }
@@ -361,6 +384,13 @@ async function createResearchWorkspace(request: SkillResearchRequest): Promise<s
   });
   if (await exists(request.project.referenceDir)) {
     await cp(request.project.referenceDir, join(workspaceDir, "reference"), {
+      recursive: true,
+      force: false,
+      errorOnExist: true
+    });
+  }
+  if (request.guidanceSkillDir) {
+    await cp(request.guidanceSkillDir, join(workspaceDir, "seed-reference"), {
       recursive: true,
       force: false,
       errorOnExist: true
@@ -386,6 +416,43 @@ async function createResearchWorkspace(request: SkillResearchRequest): Promise<s
   return workspaceDir;
 }
 
+function formatGuidanceContext(iteration: number, seedReferenceFiles: MountedFile[], ledger: GuidanceLedger): string[] {
+  if (seedReferenceFiles.length === 0) {
+    return ["Seed/reference skill guidance:", "No seed/reference skill files are configured."];
+  }
+
+  if (iteration === 1) {
+    return [
+      "Seed/reference skill files:",
+      formatFileSet(seedReferenceFiles, `research iteration ${iteration} seed/reference skill files`),
+      "",
+      "Guidance ledger:",
+      fencedJson(ledger)
+    ];
+  }
+
+  return [
+    "Guidance ledger:",
+    fencedJson(ledger),
+    "",
+    "Seed/reference skill index:",
+    formatGuidanceIndex(seedReferenceFiles)
+  ];
+}
+
+function formatGuidanceIndex(files: MountedFile[]): string {
+  return files.map((file) => `- ${file.path}${formatHeadings(file.contents)}`).join("\n");
+}
+
+function formatHeadings(contents: string): string {
+  const headings = contents
+    .split(/\r?\n/)
+    .map((line) => line.match(/^(#{1,6})\s+(.+)$/)?.[2]?.trim())
+    .filter((heading): heading is string => Boolean(heading))
+    .slice(0, 8);
+  return headings.length > 0 ? ` (${headings.join("; ")})` : "";
+}
+
 function roleModel(request: EvalAgentRequest, role: "producer" | "judge"): ModelConfig {
   return request.models?.[role] ?? request.model;
 }
@@ -393,6 +460,32 @@ function roleModel(request: EvalAgentRequest, role: "producer" | "judge"): Model
 export function parseSkillResearchPatch(response: string): SkillResearchPatch {
   const raw = parseJson(response, "Research response");
   return parseWithSchema(SkillResearchPatchSchema, raw, "skill research patch");
+}
+
+export async function readGuidanceLedger(path: string | undefined): Promise<GuidanceLedger> {
+  if (!path || !(await exists(path))) {
+    return { entries: [] };
+  }
+  try {
+    const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
+    return parseWithSchema(GuidanceLedgerSchema, raw, "guidance ledger");
+  } catch (error) {
+    throw new Error(`Could not read guidance ledger at ${path}: ${(error as Error).message}`, { cause: error });
+  }
+}
+
+export async function appendGuidanceLedger(
+  path: string | undefined,
+  iteration: number,
+  patch: SkillResearchPatch
+): Promise<void> {
+  if (!path || patch.guidance.length === 0) {
+    return;
+  }
+  const ledger = await readGuidanceLedger(path);
+  ledger.entries.push(...patch.guidance.map((entry) => ({ ...entry, iteration })));
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(ledger, null, 2)}\n`, "utf8");
 }
 
 export async function applySkillResearchPatch(skillDir: string, patch: SkillResearchPatch): Promise<void> {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,5 @@
-import { cp, mkdir, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { cp, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
 import { loadProject, ProjectInputs } from "./project.js";
@@ -42,6 +42,8 @@ export interface SkillResearchRequest {
   iteration: number;
   previousSkillDir: string;
   candidateSkillDir: string;
+  guidanceSkillDir?: string;
+  guidanceLedgerPath?: string;
   baselineScores: EvalScore[];
   previousScores: EvalScore[];
   previousAggregate: AggregateReport;
@@ -59,6 +61,7 @@ export interface OrchestrateOptions {
   runResearch?: boolean;
   forceResearch?: boolean;
   seedSkillDir?: string;
+  guidanceSkillDir?: string;
 }
 
 export async function orchestrateBaseline(options: OrchestrateOptions): Promise<OrchestratorResult> {
@@ -196,8 +199,10 @@ async function runResearchIterations(
 
   const agent = options.agent;
   const seedSkillDir = await resolveSeedSkillDir(project, options.seedSkillDir);
+  const guidanceSkillDir = await resolveGuidanceSkillDir(project, options.guidanceSkillDir, seedSkillDir);
+  const guidanceLedgerPath = guidanceSkillDir ? join(project.root, "workspace", "guidance-ledger.json") : undefined;
   const iterations: IterationResult[] = [];
-  let previousSkillDir = seedSkillDir;
+  let previousSkillDir = await resolveInitialResearchSkillDir(project, seedSkillDir);
   let previousScores = baselineScores;
   let previousAggregate = baselineAggregate;
   let bestIteration: IterationResult | undefined;
@@ -214,6 +219,8 @@ async function runResearchIterations(
       iteration,
       previousSkillDir,
       candidateSkillDir,
+      guidanceSkillDir,
+      guidanceLedgerPath,
       baselineScores,
       previousScores,
       previousAggregate
@@ -282,6 +289,31 @@ async function resolveSeedSkillDir(project: ProjectInputs, seedSkillDir?: string
   }
   await assertExists(resolved, `Seed skill directory was not found: ${resolved}`);
   return resolved;
+}
+
+async function resolveGuidanceSkillDir(
+  project: ProjectInputs,
+  guidanceSkillDir: string | undefined,
+  seedSkillDir: string
+): Promise<string | undefined> {
+  const configured = guidanceSkillDir ?? project.config.guidance_skill;
+  const resolved = configured ?? (project.config.research_start === "empty" ? seedSkillDir : undefined);
+  if (!resolved) {
+    return undefined;
+  }
+  await assertExists(resolved, `Guidance skill directory was not found: ${resolved}`);
+  return resolved;
+}
+
+async function resolveInitialResearchSkillDir(project: ProjectInputs, seedSkillDir: string): Promise<string> {
+  if ((project.config.research_start ?? "seed") !== "empty") {
+    return seedSkillDir;
+  }
+
+  const emptySkillDir = resolve(project.root, "workspace", "empty-skill");
+  await rm(emptySkillDir, { recursive: true, force: true });
+  await mkdir(emptySkillDir, { recursive: true });
+  return emptySkillDir;
 }
 
 async function assertExists(path: string, message: string): Promise<void> {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -27,6 +27,8 @@ export const ProjectConfigSchema = v.object({
   skill_name: v.pipe(v.string(), v.minLength(1)),
   topic_group: v.pipe(v.string(), v.minLength(1)),
   origin_skill: v.optional(v.pipe(v.string(), v.minLength(1))),
+  research_start: v.optional(v.picklist(["seed", "empty"])),
+  guidance_skill: v.optional(v.pipe(v.string(), v.minLength(1))),
   target_score: v.pipe(v.number(), v.minValue(0)),
   max_iterations: v.pipe(v.number(), v.integer(), v.minValue(1)),
   max_concurrency: v.pipe(v.number(), v.integer(), v.minValue(1)),
@@ -96,8 +98,22 @@ export const SkillFileChangeSchema = v.object({
   contents: v.string()
 });
 
+export const GuidanceLedgerEntrySchema = v.object({
+  iteration: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  source: v.pipe(v.string(), v.minLength(1)),
+  action: v.picklist(["used", "deferred", "ignored", "requested"]),
+  reason: v.pipe(v.string(), v.minLength(1)),
+  section: v.optional(v.pipe(v.string(), v.minLength(1))),
+  appliedTo: v.optional(v.pipe(v.string(), v.minLength(1)))
+});
+
+export const GuidanceLedgerSchema = v.object({
+  entries: v.optional(v.array(GuidanceLedgerEntrySchema), [])
+});
+
 export const SkillResearchPatchSchema = v.object({
   summary: v.pipe(v.string(), v.minLength(1)),
+  guidance: v.optional(v.array(v.omit(GuidanceLedgerEntrySchema, ["iteration"])), []),
   changes: v.pipe(v.array(SkillFileChangeSchema), v.minLength(1))
 });
 
@@ -114,6 +130,8 @@ export type OutputFile = v.InferOutput<typeof OutputFileSchema>;
 export type ModelProduceResponse = v.InferOutput<typeof ModelProduceResponseSchema>;
 export type SkillMetadata = v.InferOutput<typeof SkillMetadataSchema>;
 export type SkillFileChange = v.InferOutput<typeof SkillFileChangeSchema>;
+export type GuidanceLedgerEntry = v.InferOutput<typeof GuidanceLedgerEntrySchema>;
+export type GuidanceLedger = v.InferOutput<typeof GuidanceLedgerSchema>;
 export type SkillResearchPatch = v.InferOutput<typeof SkillResearchPatchSchema>;
 
 export function parseWithSchema<TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>>(

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -11,6 +11,7 @@ import {
   ModelSkillResearcher,
   ModelRequest,
   parseModelProduceResponse,
+  readGuidanceLedger,
   parseSkillResearchPatch
 } from "../src/model-agent.js";
 import { createEvalSandbox } from "../src/sandbox.js";
@@ -264,6 +265,141 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
   await expect(readFile(join(candidateSkillDir, ".autoresearch-transcript.json"), "utf8")).resolves.toContain(
     "SKILL.md"
   );
+});
+
+test("buildResearchModelRequest uses full seed guidance first, then ledger and index", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, research_start: "empty" }, syntheticEvals);
+  const project = await loadProject(root);
+  const previousSkillDir = join(root, "previous-skill");
+  const guidanceSkillDir = join(root, "seed-skill");
+  const guidanceLedgerPath = join(root, "workspace", "guidance-ledger.json");
+  await mkdir(previousSkillDir, { recursive: true });
+  await mkdir(guidanceSkillDir, { recursive: true });
+  await writeFile(join(previousSkillDir, "SKILL.md"), "# Candidate\n");
+  await writeFile(
+    join(guidanceSkillDir, "SKILL.md"),
+    "# Seed Skill\n\n## Breaking changes\n\nMention risky changes.\n\n## Tone\n\nBe concise.\n"
+  );
+  await mkdir(join(root, "workspace"), { recursive: true });
+  await writeFile(
+    guidanceLedgerPath,
+    `${JSON.stringify(
+      {
+        entries: [
+          {
+            iteration: 1,
+            source: "seed-reference/SKILL.md",
+            section: "Breaking changes",
+            action: "used",
+            reason: "The first failure missed risk notes.",
+            appliedTo: "SKILL.md"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  const first = await buildResearchModelRequest({
+    project,
+    iteration: 1,
+    previousSkillDir,
+    candidateSkillDir: join(root, "candidate-1"),
+    guidanceSkillDir,
+    guidanceLedgerPath,
+    baselineScores: [],
+    previousScores: [],
+    previousAggregate: {
+      tracks: [],
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
+  });
+
+  expect(first.prompt).toContain("Seed/reference skill files");
+  expect(first.prompt).toContain("Mention risky changes.");
+
+  const second = await buildResearchModelRequest({
+    project,
+    iteration: 2,
+    previousSkillDir,
+    candidateSkillDir: join(root, "candidate-2"),
+    guidanceSkillDir,
+    guidanceLedgerPath,
+    baselineScores: [],
+    previousScores: [],
+    previousAggregate: {
+      tracks: [],
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
+  });
+
+  expect(second.prompt).toContain("Guidance ledger");
+  expect(second.prompt).toContain("Seed/reference skill index");
+  expect(second.prompt).toContain("Breaking changes");
+  expect(second.prompt).not.toContain("Mention risky changes.");
+});
+
+test("ModelSkillResearcher appends guidance decisions to the ledger", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  const project = await loadProject(root);
+  const previousSkillDir = join(root, "previous-skill");
+  const candidateSkillDir = join(root, "candidate-skill");
+  const guidanceLedgerPath = join(root, "workspace", "guidance-ledger.json");
+  await mkdir(previousSkillDir, { recursive: true });
+  await writeFile(join(previousSkillDir, "SKILL.md"), "# Previous\n");
+  const client = new MemoryModelClient(
+    JSON.stringify({
+      summary: "Apply relevant seed guidance.",
+      guidance: [
+        {
+          source: "seed-reference/SKILL.md",
+          section: "Breaking changes",
+          action: "used",
+          reason: "Judge rationale called out missing breaking-change risk.",
+          appliedTo: "SKILL.md"
+        }
+      ],
+      changes: [{ path: "SKILL.md", contents: "# Updated\n" }]
+    })
+  );
+  const researcher = new ModelSkillResearcher(client);
+
+  await researcher.improve({
+    project,
+    iteration: 2,
+    previousSkillDir,
+    candidateSkillDir,
+    guidanceLedgerPath,
+    baselineScores: [],
+    previousScores: [],
+    previousAggregate: {
+      tracks: [],
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
+  });
+
+  await expect(readGuidanceLedger(guidanceLedgerPath)).resolves.toMatchObject({
+    entries: [
+      {
+        iteration: 2,
+        source: "seed-reference/SKILL.md",
+        section: "Breaking changes",
+        action: "used"
+      }
+    ]
+  });
+});
+
+test("readGuidanceLedger reports invalid ledger files with context", async () => {
+  const root = await tempProject();
+  const guidanceLedgerPath = join(root, "workspace", "guidance-ledger.json");
+  await mkdir(join(root, "workspace"), { recursive: true });
+  await writeFile(guidanceLedgerPath, "{not json");
+
+  await expect(readGuidanceLedger(guidanceLedgerPath)).rejects.toThrow(/Could not read guidance ledger/);
 });
 
 test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail during research", async () => {

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createEvalSandbox } from "../src/sandbox.js";
 import { runEval, runWithConcurrency, EvalAgent } from "../src/runner.js";
@@ -259,6 +259,52 @@ test("orchestrator runs research iterations until target score is reached", asyn
   await expect(readFile(join(root, "workspace", "iterations", "2", "skill", "iteration-2.txt"), "utf8")).resolves.toBe(
     "candidate\n"
   );
+});
+
+test("orchestrator can start research from an empty skill while using the seed as guidance", async () => {
+  const root = await tempProject();
+  const seedSkill = join(root, "seed-skill");
+  const config = { ...syntheticConfig, origin_skill: seedSkill, research_start: "empty" as const };
+  await writeFixture(root, config, syntheticEvals);
+  await mkdir(seedSkill, { recursive: true });
+  await writeFile(join(seedSkill, "SKILL.md"), "# Seed Guidance\n");
+
+  let evalRuns = 0;
+  const previousSkillDirs: string[] = [];
+  const guidanceSkillDirs: Array<string | undefined> = [];
+  const agent: EvalAgent = {
+    async run(request) {
+      if (!request.targetSkill) {
+        return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
+      }
+      evalRuns++;
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, evalRuns === 1 ? 0.5 : 0.9);
+    }
+  };
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      previousSkillDirs.push(request.previousSkillDir);
+      guidanceSkillDirs.push(request.guidanceSkillDir);
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+      await writeFile(join(request.candidateSkillDir, `iteration-${request.iteration}.txt`), "candidate\n");
+    }
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    agent,
+    researcher,
+    runResearch: true
+  });
+
+  expect(result.completedIterations).toBe(2);
+  expect(previousSkillDirs[0]).toBe(join(root, "workspace", "empty-skill"));
+  expect(await readdir(previousSkillDirs[0])).toEqual([]);
+  expect(previousSkillDirs[1]).toBe(join(root, "workspace", "iterations", "1", "skill"));
+  expect(guidanceSkillDirs).toEqual([seedSkill, seedSkill]);
+  await expect(stat(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"))).rejects.toMatchObject({
+    code: "ENOENT"
+  });
 });
 
 test("orchestrator stops research at max iterations and keeps the best candidate", async () => {


### PR DESCRIPTION
## Summary
- Add `research_start: "empty"` support so iteration 1 can start from an empty candidate skill
- Introduce optional `guidance_skill` and a `workspace/guidance-ledger.json` artifact to track seed/reference usage across iterations
- Update researcher prompt shaping, orchestration, tests, and docs to keep the seed available as immutable guidance without copying it into every iteration

## Testing
- Added unit and orchestration coverage for empty-start runs, guidance ledger persistence, prompt shaping, and invalid ledger handling
- `pnpm test` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Seed-As-Reference Research" mode: start research from an empty candidate skill while using a separate seed skill as immutable guidance.
  * New configuration options: `research_start` ("empty" or "seed") and `guidance_skill` to enable guided research workflows.
  * Introduced guidance ledger to track how reference guidance influences iterations.

* **Documentation**
  * Updated guides with instructions for configuring and using seed-as-reference research mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/skills-autoresearch-flue/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->