### PR TITLE
Refine guidance prompts and stop on regressions

### DIFF
--- a/.flue/profiles.ts
+++ b/.flue/profiles.ts
@@ -1,0 +1,25 @@
+import { defineAgentProfile } from "@flue/runtime";
+
+export const producerProfile = defineAgentProfile({
+  name: "producer",
+  description: "Produces eval output files by following the mounted skill and eval task.",
+  instructions:
+    "You produce concrete output files for the current eval task. Follow the mounted skill instructions closely. Produce concrete output files only; do not score your own work.",
+});
+
+export const judgeProfile = defineAgentProfile({
+  name: "judge",
+  description:
+    "Scores eval outputs against the eval case, expectations, rubric, and reference material.",
+  instructions:
+    "You are an independent evaluator. Score only the producer output files against the eval case, expectations, and reference material. Do not give credit for requirements stated in a skill file unless the producer output actually satisfies them. Be specific in rationales. Penalize omissions, invented facts, regressions, unsafe assumptions, and unsupported claims.",
+});
+
+export const researcherProfile = defineAgentProfile({
+  name: "researcher",
+  description: "Improves skill instructions based on score feedback and previous outputs.",
+  instructions:
+    "You improve skill instructions based on evaluation results. Make the smallest effective change that addresses the observed score gap. Preserve the skill's intended scope and avoid overfitting to a single fixture.",
+});
+
+export const autoresearchProfiles = [producerProfile, judgeProfile, researcherProfile];

--- a/.flue/workflows/autoresearch.ts
+++ b/.flue/workflows/autoresearch.ts
@@ -1,8 +1,8 @@
-import type { FlueContext } from "@flue/runtime/client";
+import type { FlueContext } from "@flue/runtime";
+import { createAgent } from "@flue/runtime";
 import { local } from "@flue/runtime/node";
 import { runFlueAutoresearch } from "../../src/flue-harness.js";
-
-export const triggers = {};
+import { autoresearchProfiles } from "../profiles.js";
 
 interface AutoresearchPayload {
   projectRoot?: string;
@@ -10,30 +10,34 @@ interface AutoresearchPayload {
   runResearch?: boolean;
   forceResearch?: boolean;
   seedSkillDir?: string;
+  guidanceSkillDir?: string;
   sessionId?: string;
   model?: string;
 }
 
-export default async function ({ init, payload, env }: FlueContext<AutoresearchPayload>) {
+export async function run({ init, payload, env }: FlueContext<AutoresearchPayload>) {
   const model = payload.model ?? env.FLUE_MODEL ?? "anthropic/claude-sonnet-4-6";
-  const agent = await init({
+  const autoresearch = createAgent(() => ({
     sandbox: local(),
-    model
-  });
-  const session = await agent.session(payload.sessionId ?? "autoresearch");
+    model,
+    subagents: autoresearchProfiles,
+  }));
+  const harness = await init(autoresearch);
+  const session = await harness.session(payload.sessionId ?? "autoresearch");
   const result = await runFlueAutoresearch({
     session,
     projectRoot: payload.projectRoot ?? process.cwd(),
     withBaseline: payload.withBaseline,
     runResearch: payload.runResearch,
     forceResearch: payload.forceResearch,
-    seedSkillDir: payload.seedSkillDir
+    seedSkillDir: payload.seedSkillDir,
+    guidanceSkillDir: payload.guidanceSkillDir,
   });
 
   return {
     completedIterations: result.completedIterations,
     normalizedScore: result.aggregate.overall.normalizedScore,
     bestSkillDir: result.bestIteration?.skillDir,
-    events: result.events.map((event) => event.type)
+    events: result.events.map((event) => event.type),
   };
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The harness should:
 
 ```text
 .flue/
-  agents/autoresearch.ts      Flue agent entrypoint.
+  workflows/autoresearch.ts   Flue workflow entrypoint.
   roles/                      Flue roles for researcher, producer, and judge.
 docs/
   alpha-run.md                Alpha run and credential workflow.
@@ -47,10 +47,10 @@ tests/
 
 Flue is not incidental here; it is the harness layer.
 
-The runnable agent is:
+The runnable workflow is:
 
 ```text
-.flue/agents/autoresearch.ts
+.flue/workflows/autoresearch.ts
 ```
 
 It initializes Flue with a local sandbox and calls `runFlueAutoresearch()`.
@@ -61,7 +61,7 @@ The Flue adapter is:
 src/flue-harness.ts
 ```
 
-It uses `session.prompt(..., { result: schema })` so Flue performs structured-output validation before the harness writes artifacts or scores.
+It uses `session.task(..., { schema })` so Flue performs structured-output validation before the harness writes artifacts or scores.
 
 ## Research Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The harness should:
 ```text
 .flue/
   workflows/autoresearch.ts   Flue workflow entrypoint.
-  roles/                      Flue roles for researcher, producer, and judge.
+  profiles.ts                 Named producer, judge, and researcher subagent profiles.
 docs/
   alpha-run.md                Alpha run and credential workflow.
   using-the-harness.md        User guide for running custom skill projects.
@@ -61,15 +61,15 @@ The Flue adapter is:
 src/flue-harness.ts
 ```
 
-It uses `session.task(..., { schema })` so Flue performs structured-output validation before the harness writes artifacts or scores.
+It uses `session.task(..., { agent, result })` so Flue runs the named subagent profile and performs structured-output validation before the harness writes artifacts or scores.
 
 ## Research Flow
 
 The model-backed path is intentionally split:
 
-1. **Researcher** (`skill-builder`, Sonnet): patches the candidate skill.
-2. **Producer** (`task-producer`, Haiku): runs the candidate skill and writes `output_files`.
-3. **Judge** (`eval-judge`, Sonnet): scores only producer output.
+1. **Researcher** (`researcher`, Sonnet): patches the candidate skill.
+2. **Producer** (`producer`, Haiku): runs the candidate skill and writes `output_files`.
+3. **Judge** (`judge`, Sonnet): scores only producer output.
 
 This is important. Avoid collapsing producer and judge back into a single self-scoring call.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The harness evaluates a seed skill against project fixtures, asks a researcher m
 ## Current Architecture
 
 - **Flue workflow entrypoint:** `.flue/workflows/autoresearch.ts`
-- **Flue roles:** `.flue/roles/`
+- **Flue subagent profiles:** `.flue/profiles.ts`
 - **Core orchestration:** `src/orchestrator.ts`
 - **Flue adapters:** `src/flue-harness.ts`
 - **Prompt and artifact helpers:** `src/model-agent.ts`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The harness evaluates a seed skill against project fixtures, asks a researcher m
 
 ## Current Architecture
 
-- **Flue agent entrypoint:** `.flue/agents/autoresearch.ts`
+- **Flue workflow entrypoint:** `.flue/workflows/autoresearch.ts`
 - **Flue roles:** `.flue/roles/`
 - **Core orchestration:** `src/orchestrator.ts`
 - **Flue adapters:** `src/flue-harness.ts`

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -4,9 +4,9 @@ The model-backed alpha run uses Varlock to inject provider credentials into the 
 
 The current alpha harness is Flue-first:
 
-- `.flue/agents/autoresearch.ts` is the runnable Flue agent.
+- `.flue/workflows/autoresearch.ts` is the runnable Flue workflow.
 - `.flue/roles/` defines the model roles.
-- `src/flue-harness.ts` adapts Flue `session.prompt(..., { result })` calls into the autoresearch loop.
+- `src/flue-harness.ts` adapts Flue `session.task(..., { schema })` calls into the autoresearch loop.
 - `fixtures/projects/release-notes-alpha/` is the committed alpha fixture.
 
 ## 1Password Setup
@@ -55,7 +55,7 @@ This requires `ANTHROPIC_API_KEY` to resolve through Varlock.
 pnpm run alpha:research
 ```
 
-This runs the Flue agent with:
+This runs the Flue workflow with:
 
 ```json
 {
@@ -68,6 +68,8 @@ This runs the Flue agent with:
 ```
 
 If the imported baseline already meets `target_score`, the run emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1`. Add `"forceResearch": true` to the payload only when you want to spend model calls on research anyway.
+
+During research, an iteration that reaches the aggregate target but lowers any eval case below its baseline score emits `target-score-blocked-by-regression` and continues until a non-regressing candidate reaches the target or `max_iterations` is exhausted.
 
 ## Model Split
 

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -5,8 +5,8 @@ The model-backed alpha run uses Varlock to inject provider credentials into the 
 The current alpha harness is Flue-first:
 
 - `.flue/workflows/autoresearch.ts` is the runnable Flue workflow.
-- `.flue/roles/` defines the model roles.
-- `src/flue-harness.ts` adapts Flue `session.task(..., { schema })` calls into the autoresearch loop.
+- `.flue/profiles.ts` defines the named producer, judge, and researcher subagent profiles.
+- `src/flue-harness.ts` adapts Flue `session.task(..., { agent, result })` calls into the autoresearch loop.
 - `fixtures/projects/release-notes-alpha/` is the committed alpha fixture.
 
 ## 1Password Setup

--- a/docs/use-cases/compare-producer-models.md
+++ b/docs/use-cases/compare-producer-models.md
@@ -24,7 +24,7 @@ This makes the comparison easier to interpret.
 For each producer model, generate a baseline:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id baseline-haiku --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"baseline-haiku"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"baseline-haiku"}'
 ```
 
 Record:

--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -49,7 +49,7 @@ The `seed-skill/` directory can exist even though the baseline will not mount it
 From the root of this harness checkout, run:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 Omit `withBaseline` so the harness generates a fresh model-backed baseline. Use `runResearch:false` so the run stops after baseline generation and aggregation.
@@ -98,7 +98,7 @@ If `overall.normalizedScore < target_score`, the model likely needs either:
 After generating the baseline, you can run with `withBaseline:true` and `runResearch:true` to confirm the harness will stop before research when the baseline already passes:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research-check --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-check"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-check"}'
 ```
 
 When the baseline passes, the run emits:
@@ -122,4 +122,4 @@ To start research from an empty candidate skill while using the seed skill only 
 
 If `guidance_skill` is omitted, `origin_skill` is used as the immutable guidance skill. Iteration 1 starts from `workspace/empty-skill`; later iterations continue from the previous candidate skill.
 
-Model-backed research writes `workspace/guidance-ledger.json` when the researcher records which seed/reference sections were used, deferred, ignored, or requested. After iteration 1, prompts include that ledger and a compact seed/reference index instead of the full seed skill content by default.
+Model-backed research writes `workspace/guidance-ledger.json` when the researcher records which seed/reference sections were used, deferred, ignored, or requested. Research prompts include that ledger and a compact seed/reference index by default, and ask the researcher to pull exact seed/reference content only when the current score gaps justify it.

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -30,7 +30,7 @@ workspace/baseline/
 The baseline can be imported without model calls:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --id regression-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"regression-smoke"}'
+pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"regression-smoke"}'
 ```
 
 This validates the project and imported score artifacts.
@@ -40,7 +40,7 @@ This validates the project and imported score artifacts.
 To evaluate an updated seed skill through the normal research loop:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id regression-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"regression-research"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"regression-research"}'
 ```
 
 If the imported baseline already reaches `target_score`, the harness stops before research unless you set `forceResearch:true`.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -10,7 +10,7 @@ The standard autoresearch loop is:
 4. Ask the researcher to patch the seed skill when the baseline falls short.
 5. Run producer evals against the candidate skill.
 6. Ask the judge to score only the producer output.
-7. Repeat until `target_score` is reached or `max_iterations` is exhausted.
+7. Repeat until `target_score` is reached without an eval case regressing below baseline, or `max_iterations` is exhausted.
 
 ## When To Use This
 
@@ -26,19 +26,19 @@ Use seed skill improvement when:
 If `workspace/baseline/` already exists, you can import it:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --id my-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
 ```
 
 If no baseline exists yet, generate one:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 ## Step 2: Run Research
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
 ```
 
 If the imported baseline already reaches `target_score`, the run stops with `baseline-target-score-reached`.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -143,12 +143,12 @@ Important fields:
 - `models.producer`: model that produces eval outputs. The default config uses a cheaper/smaller model here.
 - `models.judge`: model that scores producer outputs. The default config uses a stronger model here.
 - `models.researcher`: model that patches the skill.
-- `roles.judge`: Flue role used for judging.
-- `tracks[].role`: Flue role used by the producer.
+- `roles.judge`: judge role label included in judge prompts.
+- `tracks[].role`: producer role label included in producer prompts.
 
 These role/model choices are starting suggestions, not requirements. Try different producer, judge, and researcher models for your project, then compare cost, speed, score stability, and the usefulness of the resulting candidate skill.
 
-Flue roles live under `.flue/roles/`. Add a new role file if your project needs a different producer or judge role.
+Flue subagent profiles live in `.flue/profiles.ts`. The configured role labels are still passed through prompts as project context, while Flue behavior comes from the named `producer`, `judge`, and `researcher` profiles.
 
 For a multi-skill project, use one track per skill or skill responsibility. For example, a security project might have an `audit` track that targets `skills/security-audit` and an `authoring` track that targets `skills/secure-authoring`.
 
@@ -356,7 +356,7 @@ The payload fields are:
 - `withBaseline`: tells the harness to load or validate the baseline artifacts for the project.
 - `runResearch`: controls whether the researcher should patch the skill. `false` makes this a smoke run that stops before model-backed research.
 - `forceResearch`: optional override for research runs. When omitted or `false`, `runResearch:true` stops before the researcher if the baseline aggregate score already meets `target_score`.
-- `sessionId`: run/session name used when writing harness artifacts. Keeping this aligned with `--id` makes outputs easier to correlate.
+- `sessionId`: run/session name passed in the payload and used when writing harness artifacts.
 
 This should return events ending with `research-loop-ready`.
 

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -96,7 +96,7 @@ The important parts are not the exact directory names for every project, but tha
 {
   "skill_name": "release-notes",
   "topic_group": "developer-communications",
-  "origin_skill": "fixtures/projects/release-notes-alpha/seed-skill",
+  "origin_skill": "seed-skill",
   "target_score": 0.8,
   "max_iterations": 1,
   "max_concurrency": 1,
@@ -137,7 +137,7 @@ Important fields:
 
 - `origin_skill`: default path to the seed skill directory, relative to the project root unless absolute.
 - `research_start`: optional. Use `"seed"` or omit it for the standard workflow; use `"empty"` when the first research iteration should start from an empty candidate skill.
-- `guidance_skill`: optional path to a skill used only as seed/reference guidance. Use this when the candidate should start from `origin_skill`, but the researcher should consult a different reference skill; or when `research_start` is `"empty"` and the guidance source should be different from `origin_skill`. When `research_start` is `"empty"` and `guidance_skill` is omitted, the harness uses `origin_skill` as the guidance skill.
+- `guidance_skill`: optional path to a skill used only as seed/reference guidance, relative to the project root unless absolute. Use this when the candidate should start from `origin_skill`, but the researcher should consult a different reference skill; or when `research_start` is `"empty"` and the guidance source should be different from `origin_skill`. When `research_start` is `"empty"` and `guidance_skill` is omitted, the harness uses `origin_skill` as the guidance skill.
 - `target_score`: normalized score required to stop early.
 - `max_iterations`: maximum candidate-improvement attempts.
 - `models.producer`: model that produces eval outputs. The default config uses a cheaper/smaller model here.
@@ -156,7 +156,7 @@ For a multi-skill project, use one track per skill or skill responsibility. For 
 
 `origin_skill` is the `config.json` field for the default seed skill. The harness uses this path when a run payload does not provide a skill override.
 
-`seedSkillDir` is the run payload override for one invocation. Do not add it to `config.json`; pass it in the JSON payload you send to the project-local Flue autoresearch command when you want that specific run to improve a different skill directory.
+`seedSkillDir` is the run payload override for one invocation. Payload overrides resolve relative to the shell working directory unless absolute. Do not add it to `config.json`; pass it in the JSON payload you send to the project-local Flue autoresearch command when you want that specific run to improve a different skill directory.
 
 For example, this config default improves the audit skill:
 
@@ -201,7 +201,7 @@ With this shape:
 - The seed skill remains available to the researcher as immutable reference material.
 - Later iterations continue from the previous candidate skill, not from the seed skill.
 
-Model-backed research writes `workspace/guidance-ledger.json` when the researcher reports seed/reference guidance decisions. Iteration 1 includes the full seed/reference skill in the researcher prompt. Later iterations include the guidance ledger and a compact seed/reference index instead of repeatedly injecting the full seed skill content.
+Model-backed research writes `workspace/guidance-ledger.json` when the researcher reports seed/reference guidance decisions. Research prompts include the guidance ledger and a compact seed/reference index, and instruct the researcher to consult exact seed/reference content only when the latest failures justify it. This keeps seed-as-reference runs closer to progressive disclosure instead of encouraging wholesale reconstruction of the reference skill.
 
 Set `guidance_skill` only when the guidance source should differ from the starting skill. For example, `origin_skill` can point at a minimal house-style skill that should be copied into the first candidate, while `guidance_skill` points at a larger reference skill that should be consulted selectively. In the empty-start workflow, `origin_skill` can remain the default seed reference, while `guidance_skill` can point at a distilled or alternate guidance source for that run.
 
@@ -338,17 +338,16 @@ pnpm run alpha:smoke
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --id my-smoke --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
 ```
 
 This command uses `pnpm exec` to run the `flue` binary from this repository's installed dependencies. It does not require a globally installed `flue` CLI.
 
 The command parts are:
 
-- `pnpm exec flue run autoresearch`: runs the `autoresearch` Flue agent through the project-local `flue` dependency.
+- `pnpm exec flue run autoresearch`: runs the `autoresearch` Flue workflow through the project-local `flue` dependency.
 - `--target node`: uses the Node.js target for the run.
 - `--root .`: tells Flue to run from this harness checkout root. Flue reads source files from `<root>/.flue/` when that directory exists.
-- `--id my-smoke`: gives this Flue run a stable ID. Use a short name that identifies what you are checking.
 - `--payload '...'`: passes harness-specific options as JSON.
 
 The payload fields are:
@@ -366,7 +365,7 @@ This should return events ending with `research-loop-ready`.
 If your project does not have `workspace/baseline/` yet, run a model-backed baseline generation pass without `withBaseline` and with `runResearch:false`:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 This should return events including `baseline-started`, `baseline-generated`, `aggregated`, and `research-loop-ready`. The generated score files and transcripts are written under:
@@ -386,7 +385,7 @@ pnpm run alpha:research
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
 ```
 
 This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run --` wraps the command so model credentials are available during the run.
@@ -394,14 +393,14 @@ This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run 
 For a multi-skill project, point `seedSkillDir` at the specific skill you want that run to improve:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id security-audit-research --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
 ```
 
 The run first scores the baseline. If the baseline aggregate `normalizedScore` is already greater than or equal to `target_score`, the harness emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1` or calling the researcher. To intentionally run improvements anyway, add `"forceResearch": true` to the payload.
 
 When research proceeds, the run stops when either:
 
-- `target_score` is reached, or
+- `target_score` is reached without any eval case regressing below its baseline `total_score`, or
 - `max_iterations` is exhausted.
 
 ## Inspect Results

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["dist/**", ".flue-dist/**", "node_modules/**", "fixtures/baseline/**"]
+    ignores: ["dist/**", ".flue-dist/**", "node_modules/**", "fixtures/baseline/**"],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -12,12 +12,12 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname
-      }
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-empty-object-type": "off"
-    }
-  }
+      "@typescript-eslint/no-empty-object-type": "off",
+    },
+  },
 );

--- a/fixtures/baseline/frontend-security/eval-4/input/security-middleware.js
+++ b/fixtures/baseline/frontend-security/eval-4/input/security-middleware.js
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import helmet from 'helmet';
 
 export function securityMiddleware(app) {

--- a/fixtures/baseline/frontend-security/eval-4/output/security-middleware.js
+++ b/fixtures/baseline/frontend-security/eval-4/output/security-middleware.js
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import helmet from 'helmet';
 
 export function securityMiddleware(app) {

--- a/fixtures/baseline/frontend-security/eval-6/output/widget.js
+++ b/fixtures/baseline/frontend-security/eval-6/output/widget.js
@@ -204,7 +204,7 @@
           continue;
         }
         // Strip all attributes except href on <a>
-        for (const attr of [...child.attributes]) {
+        for (const attr of Array.from(child.attributes)) {
           if (child.tagName === 'A' && attr.name === 'href') {
             // Only allow http/https/mailto hrefs
             if (!/^(https?:|mailto:)/i.test(attr.value)) {
@@ -264,7 +264,6 @@
     }
 
     _render() {
-      const t = THEMES[this._theme] || THEMES.light;
       const shadow = this._shadow;
 
       // Keep form values across re-renders if form exists
@@ -384,13 +383,13 @@
 
       form.addEventListener('submit', (e) => {
         e.preventDefault();
-        this._submitComment(authorInput.value.trim(), bodyInput.value.trim(), submit, bodyInput);
+        this._submitComment(authorInput.value.trim(), bodyInput.value.trim(), submit);
       });
 
       return form;
     }
 
-    async _submitComment(author, body, btn, bodyInput) {
+    async _submitComment(author, body, btn) {
       if (!author || !body) return;
 
       btn.disabled = true;

--- a/fixtures/baseline/frontend-security/eval-6/output/widget.js
+++ b/fixtures/baseline/frontend-security/eval-6/output/widget.js
@@ -383,13 +383,13 @@
 
       form.addEventListener('submit', (e) => {
         e.preventDefault();
-        this._submitComment(authorInput.value.trim(), bodyInput.value.trim(), submit);
+        this._submitComment(authorInput.value.trim(), bodyInput.value.trim(), submit, bodyInput);
       });
 
       return form;
     }
 
-    async _submitComment(author, body, btn) {
+    async _submitComment(author, body, btn, bodyInput) {
       if (!author || !body) return;
 
       btn.disabled = true;
@@ -416,6 +416,7 @@
           createdAt: data.createdAt ?? new Date().toISOString(),
         });
         this._submitError = null;
+        bodyInput.value = '';
         this._render();
 
         window.parent.postMessage(

--- a/fixtures/projects/release-notes-alpha/config.json
+++ b/fixtures/projects/release-notes-alpha/config.json
@@ -1,7 +1,7 @@
 {
   "skill_name": "release-notes",
   "topic_group": "developer-communications",
-  "origin_skill": "fixtures/projects/release-notes-alpha/seed-skill",
+  "origin_skill": "seed-skill",
   "target_score": 0.8,
   "max_iterations": 1,
   "max_concurrency": 1,

--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
   "name": "skills-autoresearch-flue",
   "version": "0.1.0",
-  "description": "Flue agent harness for autoresearching and evaluating agent skills.",
   "private": true,
-  "type": "module",
+  "description": "Flue agent harness for autoresearching and evaluating agent skills.",
   "bin": {
     "skills-autoresearch": "./dist/src/cli.js"
   },
-  "engines": {
-    "node": ">=24"
-  },
+  "type": "module",
   "scripts": {
     "test": "vitest run",
     "lint": "eslint .",
@@ -19,8 +16,8 @@
     "build": "tsc -p tsconfig.json",
     "flue:run": "flue run autoresearch --target node --root .",
     "flue:build": "flue build --target node --root . --output .flue-dist",
-    "alpha:smoke": "flue run autoresearch --target node --root . --id alpha-smoke --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
-    "alpha:research": "varlock run -- flue run autoresearch --target node --root . --id alpha-research --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
+    "alpha:smoke": "flue run autoresearch --target node --root . --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
+    "alpha:research": "varlock run -- flue run autoresearch --target node --root . --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
     "env:check": "varlock load"
   },
   "dependencies": {
@@ -38,6 +35,9 @@
     "typescript-eslint": "^8.60.0",
     "varlock": "^1.3.0",
     "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=24"
   },
   "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ allowBuilds:
   esbuild: true
   node-liblzma: true
   protobufjs: true
+  sharp: true
+  workerd: true

--- a/skill/skills-autoresearch/SKILL.md
+++ b/skill/skills-autoresearch/SKILL.md
@@ -20,7 +20,7 @@ Follow these gates in order. Do not skip a gate, and do not tell the user the pr
 
 ## Discovery Gate
 
-1. Ask the user for the full path to the local `skills-autoresearch` checkout and read `README.md`, `docs/using-the-harness.md`, and the alpha fixture under `fixtures/projects/release-notes-alpha/`. 
+1. Ask the user for the full path to the local `skills-autoresearch` checkout and read `README.md`, `docs/using-the-harness.md`, and the alpha fixture under `fixtures/projects/release-notes-alpha/`.
 2. Inspect the project being converted before writing files. Identify the skill or workflow to improve, representative inputs, expected outputs, and any stable reference material.
 3. Preserve user work. Check `git status --short` before editing. If there are uncommitted changes, notify the user and pause to ask whether they want to proceed, stash, commit, or switch branches before starting.
 4. If appropriate, start a new feature branch.

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -14,12 +14,12 @@ export class SnapshotResearcher implements SkillResearcher {
         {
           iteration: request.iteration,
           previousSkillDir: request.previousSkillDir,
-          previousNormalizedScore: request.previousAggregate.overall.normalizedScore
+          previousNormalizedScore: request.previousAggregate.overall.normalizedScore,
         },
         null,
-        2
+        2,
       )}\n`,
-      { flag: "wx" }
+      { flag: "wx" },
     );
   }
 }
@@ -44,7 +44,7 @@ export class FileScoreAgent implements EvalAgent {
     const candidates = [
       join(this.#scoreDir, `${key}-${count}.json`),
       join(this.#scoreDir, `${key}.json`),
-      join(this.#scoreDir, `scores-${count}.json`)
+      join(this.#scoreDir, `scores-${count}.json`),
     ];
 
     for (const path of candidates) {

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -22,7 +22,9 @@ export interface AggregateReport {
 
 export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): AggregateReport {
   const tracks = config.tracks.map((track) => {
-    const trackScores = scores.filter((score) => score.track_id === track.id || score.eval_type === track.eval_type);
+    const trackScores = scores.filter(
+      (score) => score.track_id === track.id || score.eval_type === track.eval_type,
+    );
     const score = trackScores.reduce((sum, item) => sum + item.total_score, 0);
     const maxScore = trackScores.reduce((sum, item) => sum + item.max_score, 0);
     return {
@@ -32,7 +34,7 @@ export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): Agg
       score,
       maxScore,
       normalizedScore: maxScore === 0 ? 0 : score / maxScore,
-      evalCount: trackScores.length
+      evalCount: trackScores.length,
     };
   });
 
@@ -46,7 +48,7 @@ export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): Agg
       score,
       maxScore,
       normalizedScore: maxScore === 0 ? 0 : score / maxScore,
-      evalCount
-    }
+      evalCount,
+    },
   };
 }

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -23,7 +23,9 @@ export interface AggregateReport {
 export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): AggregateReport {
   const tracks = config.tracks.map((track) => {
     const trackScores = scores.filter(
-      (score) => score.track_id === track.id || score.eval_type === track.eval_type,
+      (score) =>
+        score.track_id === track.id ||
+        ((score.track_id === null || score.track_id === undefined) && score.eval_type === track.eval_type)
     );
     const score = trackScores.reduce((sum, item) => sum + item.total_score, 0);
     const maxScore = trackScores.reduce((sum, item) => sum + item.max_score, 0);
@@ -34,7 +36,7 @@ export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): Agg
       score,
       maxScore,
       normalizedScore: maxScore === 0 ? 0 : score / maxScore,
-      evalCount: trackScores.length,
+      evalCount: trackScores.length
     };
   });
 
@@ -48,7 +50,7 @@ export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): Agg
       score,
       maxScore,
       normalizedScore: maxScore === 0 ? 0 : score / maxScore,
-      evalCount,
-    },
+      evalCount
+    }
   };
 }

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -45,9 +45,14 @@ function parseScoreFile(raw: unknown, filePath: string): EvalScore[] {
     return raw.map((item, index) => parseBaselineScore(item, `${filePath}[${index}]`));
   }
 
-  if (raw && typeof raw === "object" && "scores" in raw && Array.isArray((raw as { scores: unknown }).scores)) {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "scores" in raw &&
+    Array.isArray((raw as { scores: unknown }).scores)
+  ) {
     return (raw as { scores: unknown[] }).scores.map((item, index) =>
-      parseBaselineScore(item, `${filePath}.scores[${index}]`)
+      parseBaselineScore(item, `${filePath}.scores[${index}]`),
     );
   }
 
@@ -93,8 +98,14 @@ function normalizeLegacyBaselineScore(raw: unknown, filePath: string): EvalScore
   }
 
   const dimensions = Object.entries(score.scores as Record<string, unknown>).map(([id, value]) => {
-    if (!value || typeof value !== "object" || typeof (value as { score?: unknown }).score !== "number") {
-      throw new Error(`Invalid baseline score ${filePath}: dimension ${id} is missing numeric score`);
+    if (
+      !value ||
+      typeof value !== "object" ||
+      typeof (value as { score?: unknown }).score !== "number"
+    ) {
+      throw new Error(
+        `Invalid baseline score ${filePath}: dimension ${id} is missing numeric score`,
+      );
     }
     return {
       id,
@@ -103,14 +114,15 @@ function normalizeLegacyBaselineScore(raw: unknown, filePath: string): EvalScore
       rationale:
         typeof (value as { justification?: unknown }).justification === "string"
           ? (value as { justification: string }).justification
-          : "Imported baseline score"
+          : "Imported baseline score",
     };
   });
 
   const totalScore =
     typeof score.composite_score === "number"
       ? score.composite_score
-      : dimensions.reduce((sum, dimension) => sum + dimension.score, 0) / Math.max(1, dimensions.length);
+      : dimensions.reduce((sum, dimension) => sum + dimension.score, 0) /
+        Math.max(1, dimensions.length);
 
   return {
     eval_id: evalId,
@@ -119,11 +131,14 @@ function normalizeLegacyBaselineScore(raw: unknown, filePath: string): EvalScore
     total_score: totalScore,
     max_score: 3,
     dimensions,
-    summary: typeof score.eval_name === "string" ? score.eval_name : `Imported ${evalId}`
+    summary: typeof score.eval_name === "string" ? score.eval_name : `Imported ${evalId}`,
   };
 }
 
-export async function importBaselineArtefacts(baselineDir: string, expectedEvalIds: string[]): Promise<BaselineImport> {
+export async function importBaselineArtefacts(
+  baselineDir: string,
+  expectedEvalIds: string[],
+): Promise<BaselineImport> {
   const missing: string[] = [];
   const scores: EvalScore[] = [];
   const summaries: Record<string, unknown> = {};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ function usage(): string {
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
     "  --json                Print the full orchestrator result as JSON.",
-    "  -h, --help            Show this help."
+    "  -h, --help            Show this help.",
   ].join("\n");
 }
 
@@ -45,10 +45,10 @@ export function parseCliArgs(argv: string[]): CliOptions {
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
       json: { type: "boolean" },
-      help: { type: "boolean", short: "h" }
+      help: { type: "boolean", short: "h" },
     },
     strict: true,
-    allowPositionals: false
+    allowPositionals: false,
   });
 
   if (parsed.values.help) {
@@ -64,7 +64,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     seedSkillDir: parsed.values["seed-skill"],
     scoreDir: parsed.values["score-dir"],
     modelClient: parseModelClient(parsed.values["model-client"]),
-    json: parsed.values.json ?? false
+    json: parsed.values.json ?? false,
   };
 
   if (options.scoreDir && options.modelClient) {
@@ -109,7 +109,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       ? new ModelSkillResearcher(modelClient)
       : cli.runResearch
         ? new SnapshotResearcher()
-        : undefined
+        : undefined,
   };
 
   const result = await orchestrateBaseline(options);
@@ -122,7 +122,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   logger.write(
     "log",
     `Final score: ${result.aggregate.overall.normalizedScore.toFixed(3)} ` +
-      `(${result.aggregate.overall.score}/${result.aggregate.overall.maxScore})`
+      `(${result.aggregate.overall.score}/${result.aggregate.overall.maxScore})`,
   );
   if (result.bestIteration) {
     logger.write("log", `Best skill: ${result.bestIteration.skillDir}`);
@@ -147,33 +147,47 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
     case "baseline-generated":
       return { level: "log", message: `Generated baseline: ${event.scores} scores` };
     case "aggregated":
-      return { level: "log", message: `Aggregated score: ${event.aggregate.overall.normalizedScore.toFixed(3)}` };
+      return {
+        level: "log",
+        message: `Aggregated score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`,
+      };
     case "research-loop-ready":
       return {
         level: "debug",
-        message: `Research loop ready: ${event.completedIterations}/${event.maxIterations} iterations complete`
+        message: `Research loop ready: ${event.completedIterations}/${event.maxIterations} iterations complete`,
       };
     case "iteration-started":
       return { level: "log", message: `Iteration ${event.iteration} started` };
     case "iteration-generated":
-      return { level: "debug", message: `Iteration ${event.iteration} skill: ${event.candidateSkillDir}` };
+      return {
+        level: "debug",
+        message: `Iteration ${event.iteration} skill: ${event.candidateSkillDir}`,
+      };
     case "iteration-scored":
       return {
         level: "log",
-        message: `Iteration ${event.iteration} score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`
+        message: `Iteration ${event.iteration} score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`,
       };
     case "baseline-target-score-reached":
       return {
         level: "log",
-        message: `Baseline reached target: ${event.normalizedScore.toFixed(3)} >= ${event.targetScore.toFixed(3)}`
+        message: `Baseline reached target: ${event.normalizedScore.toFixed(3)} >= ${event.targetScore.toFixed(3)}`,
       };
     case "target-score-reached":
       return {
         level: "log",
-        message: `Target reached at iteration ${event.iteration}: ${event.normalizedScore.toFixed(3)}`
+        message: `Target reached at iteration ${event.iteration}: ${event.normalizedScore.toFixed(3)}`,
+      };
+    case "target-score-blocked-by-regression":
+      return {
+        level: "warn",
+        message: `Target score met at iteration ${event.iteration}, but ${event.regressions.length} eval(s) regressed from baseline`,
       };
     case "max-iterations-reached":
-      return { level: "warn", message: `Max iterations reached: ${event.completedIterations}/${event.maxIterations}` };
+      return {
+        level: "warn",
+        message: `Max iterations reached: ${event.completedIterations}/${event.maxIterations}`,
+      };
   }
 }
 

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -8,7 +8,7 @@ import {
   formatResearchSummary,
   parseModelJudgeResponse,
   applySkillResearchPatch,
-  validateSkillResearchPatch
+  validateSkillResearchPatch,
 } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, SkillResearcher } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
@@ -16,7 +16,7 @@ import {
   EvalScore,
   EvalScoreSchema,
   ModelProduceResponseSchema,
-  SkillResearchPatchSchema
+  SkillResearchPatchSchema,
 } from "./schemas.js";
 import { cp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -24,6 +24,10 @@ import { join } from "node:path";
 export interface FlueAutoresearchOptions extends Omit<OrchestrateOptions, "agent" | "researcher"> {
   session: FlueSession;
 }
+
+const PRODUCER_AGENT = "producer";
+const JUDGE_AGENT = "judge";
+const RESEARCHER_AGENT = "researcher";
 
 export class FlueEvalAgent implements EvalAgent {
   readonly #session: FlueSession;
@@ -35,28 +39,32 @@ export class FlueEvalAgent implements EvalAgent {
   async run(request: EvalAgentRequest): Promise<EvalScore> {
     const produceRequest = await buildProduceModelRequest(request);
     const { data: produced } = await this.#session.task(produceRequest.prompt, {
-      schema: ModelProduceResponseSchema,
-      role: produceRequest.system,
+      result: ModelProduceResponseSchema,
+      agent: PRODUCER_AGENT,
       model: toFlueModel(produceRequest.model),
-      cwd: produceRequest.workspaceDir
+      cwd: produceRequest.workspaceDir,
     });
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
     await writeTranscript(request.sandbox.outputDir, "producer-flue-transcript.json", {
       request: produceRequest,
-      response: produced
+      response: produced,
     });
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
     const { data: score } = await this.#session.task(judgeRequest.prompt, {
-      schema: EvalScoreSchema,
-      role: request.modelRoles?.judge,
+      result: EvalScoreSchema,
+      agent: JUDGE_AGENT,
       model: toFlueModel(judgeRequest.model),
-      cwd: judgeRequest.workspaceDir
+      cwd: judgeRequest.workspaceDir,
     });
-    const validated = parseModelJudgeResponse(JSON.stringify(score), request.evalCase, request.track);
+    const validated = parseModelJudgeResponse(
+      JSON.stringify(score),
+      request.evalCase,
+      request.track,
+    );
     await writeTranscript(request.sandbox.outputDir, "judge-flue-transcript.json", {
       request: judgeRequest,
-      response: validated
+      response: validated,
     });
     return validated;
   }
@@ -72,24 +80,26 @@ export class FlueSkillResearcher implements SkillResearcher {
   async improve(request: Parameters<SkillResearcher["improve"]>[0]): Promise<void> {
     const modelRequest = await buildResearchModelRequest(request);
     const { data: patch } = await this.#session.task(modelRequest.prompt, {
-      schema: SkillResearchPatchSchema,
-      role: modelRequest.system,
+      result: SkillResearchPatchSchema,
+      agent: RESEARCHER_AGENT,
       model: toFlueModel(modelRequest.model),
-      cwd: modelRequest.workspaceDir
+      cwd: modelRequest.workspaceDir,
     });
     validateSkillResearchPatch(request.candidateSkillDir, patch);
     await cp(request.previousSkillDir, request.candidateSkillDir, {
       recursive: true,
       errorOnExist: true,
-      force: false
+      force: false,
     });
     await mkdir(request.candidateSkillDir, { recursive: true });
     await applySkillResearchPatch(request.candidateSkillDir, patch);
     await appendGuidanceLedger(request.guidanceLedgerPath, request.iteration, patch);
-    await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), { flag: "wx" });
+    await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), {
+      flag: "wx",
+    });
     await writeTranscript(request.candidateSkillDir, ".autoresearch-flue-transcript.json", {
       request: modelRequest,
-      response: patch
+      response: patch,
     });
   }
 }
@@ -102,7 +112,7 @@ export async function runFlueAutoresearch(options: FlueAutoresearchOptions) {
   return orchestrateBaseline({
     ...options,
     agent: new FlueEvalAgent(options.session),
-    researcher: options.runResearch ? new FlueSkillResearcher(options.session) : undefined
+    researcher: options.runResearch ? new FlueSkillResearcher(options.session) : undefined,
   });
 }
 

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -8,17 +8,12 @@ import {
   formatResearchSummary,
   parseModelJudgeResponse,
   applySkillResearchPatch,
-  validateSkillResearchPatch,
+  validateSkillResearchPatch
 } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, SkillResearcher } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
-import {
-  EvalScore,
-  EvalScoreSchema,
-  ModelProduceResponseSchema,
-  SkillResearchPatchSchema,
-} from "./schemas.js";
-import { cp, mkdir, writeFile } from "node:fs/promises";
+import { EvalScore, EvalScoreSchema, ModelProduceResponseSchema, SkillResearchPatchSchema } from "./schemas.js";
+import { cp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 export interface FlueAutoresearchOptions extends Omit<OrchestrateOptions, "agent" | "researcher"> {
@@ -42,12 +37,12 @@ export class FlueEvalAgent implements EvalAgent {
       result: ModelProduceResponseSchema,
       agent: PRODUCER_AGENT,
       model: toFlueModel(produceRequest.model),
-      cwd: produceRequest.workspaceDir,
+      cwd: produceRequest.workspaceDir
     });
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
     await writeTranscript(request.sandbox.outputDir, "producer-flue-transcript.json", {
       request: produceRequest,
-      response: produced,
+      response: produced
     });
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
@@ -55,16 +50,12 @@ export class FlueEvalAgent implements EvalAgent {
       result: EvalScoreSchema,
       agent: JUDGE_AGENT,
       model: toFlueModel(judgeRequest.model),
-      cwd: judgeRequest.workspaceDir,
+      cwd: judgeRequest.workspaceDir
     });
-    const validated = parseModelJudgeResponse(
-      JSON.stringify(score),
-      request.evalCase,
-      request.track,
-    );
+    const validated = parseModelJudgeResponse(JSON.stringify(score), request.evalCase, request.track);
     await writeTranscript(request.sandbox.outputDir, "judge-flue-transcript.json", {
       request: judgeRequest,
-      response: validated,
+      response: validated
     });
     return validated;
   }
@@ -83,23 +74,24 @@ export class FlueSkillResearcher implements SkillResearcher {
       result: SkillResearchPatchSchema,
       agent: RESEARCHER_AGENT,
       model: toFlueModel(modelRequest.model),
-      cwd: modelRequest.workspaceDir,
+      cwd: modelRequest.workspaceDir
     });
     validateSkillResearchPatch(request.candidateSkillDir, patch);
     await cp(request.previousSkillDir, request.candidateSkillDir, {
       recursive: true,
       errorOnExist: true,
-      force: false,
+      force: false
     });
     await mkdir(request.candidateSkillDir, { recursive: true });
+    await removeGeneratedResearchFiles(request.candidateSkillDir);
     await applySkillResearchPatch(request.candidateSkillDir, patch);
     await appendGuidanceLedger(request.guidanceLedgerPath, request.iteration, patch);
     await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), {
-      flag: "wx",
+      flag: "wx"
     });
     await writeTranscript(request.candidateSkillDir, ".autoresearch-flue-transcript.json", {
       request: modelRequest,
-      response: patch,
+      response: patch
     });
   }
 }
@@ -112,11 +104,19 @@ export async function runFlueAutoresearch(options: FlueAutoresearchOptions) {
   return orchestrateBaseline({
     ...options,
     agent: new FlueEvalAgent(options.session),
-    researcher: options.runResearch ? new FlueSkillResearcher(options.session) : undefined,
+    researcher: options.runResearch ? new FlueSkillResearcher(options.session) : undefined
   });
 }
 
 async function writeTranscript(dir: string, fileName: string, value: unknown): Promise<void> {
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, fileName), `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+}
+
+async function removeGeneratedResearchFiles(skillDir: string): Promise<void> {
+  await Promise.all(
+    ["RESEARCH.md", ".autoresearch-transcript.json", ".autoresearch-flue-transcript.json"].map((fileName) =>
+      rm(join(skillDir, fileName), { force: true })
+    )
+  );
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,6 +17,6 @@ export function createLogger(sink: LogSink = console): Logger {
   return {
     write(level, message) {
       sink[level](message);
-    }
+    },
   };
 }

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -2,6 +2,9 @@ import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promi
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { SkillResearcher, SkillResearchRequest } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
+import { buildJudgePrompt } from "./prompts/judge-prompt.js";
+import { buildProducePrompt } from "./prompts/produce-prompt.js";
+import { buildResearchPrompt } from "./prompts/research-prompt.js";
 import {
   EvalCase,
   EvalScore,
@@ -15,10 +18,8 @@ import {
   SkillResearchPatch,
   SkillResearchPatchSchema,
   Track,
-  parseWithSchema
+  parseWithSchema,
 } from "./schemas.js";
-
-type MountedFile = { path: string; contents: string };
 
 export interface ModelRequest {
   system: string;
@@ -69,14 +70,14 @@ export class AnthropicMessagesClient implements ModelClient {
       headers: {
         "content-type": "application/json",
         "x-api-key": this.#apiKey,
-        "anthropic-version": this.#version
+        "anthropic-version": this.#version,
       },
       body: JSON.stringify({
         model: request.model.name,
         max_tokens: this.#maxTokens,
         system: request.system,
-        messages: [{ role: "user", content: request.prompt }]
-      })
+        messages: [{ role: "user", content: request.prompt }],
+      }),
     });
 
     if (!response.ok) {
@@ -108,14 +109,18 @@ export class ModelEvalAgent implements EvalAgent {
     await persistTranscript(
       join(request.sandbox.outputDir, "producer-transcript.json"),
       produceRequest,
-      produceResponse
+      produceResponse,
     );
     const produced = parseModelProduceResponse(produceResponse);
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
     const judgeResponse = await this.#client.complete(judgeRequest);
-    await persistTranscript(join(request.sandbox.outputDir, "judge-transcript.json"), judgeRequest, judgeResponse);
+    await persistTranscript(
+      join(request.sandbox.outputDir, "judge-transcript.json"),
+      judgeRequest,
+      judgeResponse,
+    );
     return parseModelJudgeResponse(judgeResponse, request.evalCase, request.track);
   }
 }
@@ -135,18 +140,28 @@ export class ModelSkillResearcher implements SkillResearcher {
     await cp(request.previousSkillDir, request.candidateSkillDir, {
       recursive: true,
       errorOnExist: true,
-      force: false
+      force: false,
     });
     await mkdir(request.candidateSkillDir, { recursive: true });
     await applySkillResearchPatch(request.candidateSkillDir, patch);
     await appendGuidanceLedger(request.guidanceLedgerPath, request.iteration, patch);
-    await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), { flag: "wx" });
-    await persistTranscript(join(request.candidateSkillDir, ".autoresearch-transcript.json"), modelRequest, response);
+    await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), {
+      flag: "wx",
+    });
+    await persistTranscript(
+      join(request.candidateSkillDir, ".autoresearch-transcript.json"),
+      modelRequest,
+      response,
+    );
   }
 }
 
 export async function buildProduceModelRequest(request: EvalAgentRequest): Promise<ModelRequest> {
-  const workspaceDir = await createPhaseWorkspace(request, "producer", ["/input", "/reference", "/skill"]);
+  const workspaceDir = await createPhaseWorkspace(request, "producer", [
+    "/input",
+    "/reference",
+    "/skill",
+  ]);
   const inputFiles = await readFilesFromMount(join(workspaceDir, "input"));
   const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
   const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
@@ -156,45 +171,13 @@ export async function buildProduceModelRequest(request: EvalAgentRequest): Promi
     system: request.role,
     phase: `producer eval ${request.evalCase.id}`,
     workspaceDir,
-    prompt: [
-      `Run the target skill for "${request.evalCase.title}" (${request.evalCase.id}).`,
-      `Eval type: ${request.evalCase.eval_type}`,
-      `Track: ${request.track.id}`,
-      request.targetSkill ? `Target skill: ${request.targetSkill}` : "Baseline run: no target skill is mounted.",
-      `Authoritative workspace root: ${workspaceDir}`,
-      "Only files under this workspace are authoritative for this producer phase.",
-      "Available paths: ./input, ./reference, ./skill when present.",
-      "",
-      "Eval case JSON:",
-      fencedJson(request.evalCase),
-      "",
-      "Input files:",
-      formatFileSet(inputFiles, `producer eval ${request.evalCase.id} input files`),
-      "",
-      "Reference files:",
-      formatFileSet(referenceFiles, `producer eval ${request.evalCase.id} reference files`),
-      "",
-      "Skill files:",
-      formatFileSet(skillFiles, `producer eval ${request.evalCase.id} skill files`),
-      "",
-      "Produce the concrete eval output files. Do not score your own work.",
-      "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
-      fencedJson({
-        output_files: [
-          {
-            path: "RESULT.md",
-            contents: "The concrete output produced for this eval."
-          }
-        ]
-      }),
-      "Each output_files path must be relative to the eval output directory."
-    ].join("\n")
+    prompt: buildProducePrompt({ request, workspaceDir, inputFiles, referenceFiles, skillFiles }),
   });
 }
 
 export async function buildJudgeModelRequest(
   request: EvalAgentRequest,
-  outputFiles: OutputFile[]
+  outputFiles: OutputFile[],
 ): Promise<ModelRequest> {
   await applyOutputFiles(request.sandbox.outputDir, outputFiles);
   const workspaceDir = await createPhaseWorkspace(request, "judge", ["/reference"]);
@@ -208,50 +191,20 @@ export async function buildJudgeModelRequest(
     system: request.modelRoles?.judge ?? "judge",
     phase: `judge eval ${request.evalCase.id}`,
     workspaceDir,
-    prompt: [
-      `Judge output for "${request.evalCase.title}" (${request.evalCase.id}).`,
-      `Eval type: ${request.evalCase.eval_type}`,
-      `Track: ${request.track.id}`,
-      `Authoritative workspace root: ${workspaceDir}`,
-      "Only files under this workspace are authoritative for this judge phase.",
-      "Available paths: ./evals, ./reference, ./output.",
-      "",
-      "Eval case JSON:",
-      fencedJson(request.evalCase),
-      "",
-      "Rubric files:",
-      formatFileSet(rubricFiles, `judge eval ${request.evalCase.id} rubric files`),
-      "",
-      "Reference files:",
-      formatFileSet(referenceFiles, `judge eval ${request.evalCase.id} reference files`),
-      "",
-      "Producer output files:",
-      formatFileSet(workspaceOutputFiles, `judge eval ${request.evalCase.id} producer output files`),
-      "",
-      "Score only the producer output. Do not award credit for requirements merely stated in the skill instructions.",
-      "Return only well-formed JSON matching the EvalScore schema. Do not include markdown, code fences, prose, or XML tags:",
-      fencedJson({
-        eval_id: request.evalCase.id,
-        eval_type: request.evalCase.eval_type,
-        track_id: request.track.id,
-        total_score: 0,
-        max_score: request.evalCase.scoring_dimensions.reduce((sum, dimension) => sum + dimension.max_score, 0),
-        dimensions: request.evalCase.scoring_dimensions.map((dimension) => ({
-          id: dimension.id,
-          score: 0,
-          max_score: dimension.max_score,
-          rationale: "Rationale grounded only in the producer output."
-        })),
-        summary: "Concise scoring summary."
-      })
-    ].join("\n")
+    prompt: buildJudgePrompt({
+      request,
+      workspaceDir,
+      referenceFiles,
+      rubricFiles,
+      workspaceOutputFiles,
+    }),
   });
 }
 
 async function createPhaseWorkspace(
   request: EvalAgentRequest,
   phase: "producer" | "judge",
-  mountTargets: string[]
+  mountTargets: string[],
 ): Promise<string> {
   const workspaceDir = join(request.sandbox.outputDir, ".phase-workspaces", phase);
   await rm(workspaceDir, { recursive: true, force: true });
@@ -262,7 +215,11 @@ async function createPhaseWorkspace(
     if (!mount || !(await exists(mount.source))) {
       continue;
     }
-    await cp(mount.source, join(workspaceDir, target.slice(1)), { recursive: true, force: false, errorOnExist: true });
+    await cp(mount.source, join(workspaceDir, target.slice(1)), {
+      recursive: true,
+      force: false,
+      errorOnExist: true,
+    });
   }
 
   const evalsMount = request.sandbox.mounts.find((candidate) => candidate.target === "/evals");
@@ -270,7 +227,10 @@ async function createPhaseWorkspace(
     await mkdir(join(workspaceDir, "evals"), { recursive: true });
     const rubricPath = join(evalsMount.source, "rubric.md");
     if (await exists(rubricPath)) {
-      await cp(rubricPath, join(workspaceDir, "evals", "rubric.md"), { force: false, errorOnExist: true });
+      await cp(rubricPath, join(workspaceDir, "evals", "rubric.md"), {
+        force: false,
+        errorOnExist: true,
+      });
     }
   }
 
@@ -281,12 +241,20 @@ export function parseModelProduceResponse(response: string): ModelProduceRespons
   return parseWithSchema(
     ModelProduceResponseSchema,
     parseJson(response, "Model producer response"),
-    "model producer response"
+    "model producer response",
   );
 }
 
-export function parseModelJudgeResponse(response: string, evalCase: EvalCase, track: Track): EvalScore {
-  const score = parseWithSchema(EvalScoreSchema, parseJson(response, "Model judge response"), "model judge response");
+export function parseModelJudgeResponse(
+  response: string,
+  evalCase: EvalCase,
+  track: Track,
+): EvalScore {
+  const score = parseWithSchema(
+    EvalScoreSchema,
+    parseJson(response, "Model judge response"),
+    "model judge response",
+  );
   validateEvalScore(score, evalCase, track);
   return score;
 }
@@ -303,7 +271,9 @@ export async function applyOutputFiles(outputDir: string, files: OutputFile[]): 
   }
 }
 
-export async function buildResearchModelRequest(request: SkillResearchRequest): Promise<ModelRequest> {
+export async function buildResearchModelRequest(
+  request: SkillResearchRequest,
+): Promise<ModelRequest> {
   const workspaceDir = await createResearchWorkspace(request);
   const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
   const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
@@ -316,141 +286,68 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
     system: request.project.config.roles.skill_builder,
     phase: `research iteration ${request.iteration}`,
     workspaceDir,
-    prompt: [
-      `Improve skill "${request.project.config.skill_name}" for iteration ${request.iteration}.`,
-      `Topic group: ${request.project.config.topic_group}`,
-      `Target normalized score: ${request.project.config.target_score}`,
-      `Previous normalized score: ${request.previousAggregate.overall.normalizedScore}`,
-      `Authoritative workspace root: ${workspaceDir}`,
-      "Only files under this workspace are authoritative for this research phase.",
-      "Available paths: ./config.json, ./evals, ./reference, ./skill, ./scores.",
-      request.guidanceSkillDir
-        ? "Seed/reference skill guidance is available under ./seed-reference for this research phase."
-        : "No separate seed/reference skill guidance directory is configured for this research phase.",
-      "",
-      "Previous aggregate:",
-      fencedJson(request.previousAggregate),
-      "",
-      "Previous scores:",
-      fencedJson(request.previousScores),
-      "",
-      "Baseline scores:",
-      fencedJson(request.baselineScores),
-      "",
-      "Current skill files:",
-      formatFileSet(skillFiles, `research iteration ${request.iteration} skill files`),
-      "",
-      "Eval and rubric files:",
-      formatFileSet(evalFiles, `research iteration ${request.iteration} eval files`),
-      "",
-      "Reference files:",
-      formatFileSet(referenceFiles, `research iteration ${request.iteration} reference files`),
-      "",
-      ...formatGuidanceContext(request.iteration, seedReferenceFiles, guidanceLedger),
-      "",
-      "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
-      fencedJson({
-        summary: "Brief summary of the intended skill improvement.",
-        guidance: [
-          {
-            source: "seed-reference/SKILL.md",
-            section: "Optional section heading or concise location.",
-            action: "used",
-            reason: "Why this guidance was or was not needed for the current failures.",
-            appliedTo: "SKILL.md"
-          }
-        ],
-        changes: [{ path: "SKILL.md", contents: "Complete replacement file contents." }]
-      }),
-      "Each change path must be relative to the skill directory.",
-      "Use guidance entries to update the guidance ledger whenever you inspect, use, defer, ignore, or need more seed/reference guidance.",
-      "After iteration 1, prefer the guidance ledger and seed/reference index first; pull exact seed/reference content only when the latest failures justify it."
-    ].join("\n")
+    prompt: buildResearchPrompt({
+      request,
+      workspaceDir,
+      skillFiles,
+      referenceFiles,
+      seedReferenceFiles,
+      evalFiles,
+      guidanceLedger,
+    }),
   });
 }
 
 async function createResearchWorkspace(request: SkillResearchRequest): Promise<string> {
-  const workspaceDir = join(request.project.root, "workspace", ".phase-workspaces", `research-${request.iteration}`);
+  const workspaceDir = join(
+    request.project.root,
+    "workspace",
+    ".phase-workspaces",
+    `research-${request.iteration}`,
+  );
   await rm(workspaceDir, { recursive: true, force: true });
   await mkdir(join(workspaceDir, "scores"), { recursive: true });
   await cp(join(request.project.root, "config.json"), join(workspaceDir, "config.json"), {
     force: false,
-    errorOnExist: true
+    errorOnExist: true,
   });
   await cp(join(request.project.root, "evals"), join(workspaceDir, "evals"), {
     recursive: true,
     force: false,
-    errorOnExist: true
+    errorOnExist: true,
   });
   if (await exists(request.project.referenceDir)) {
     await cp(request.project.referenceDir, join(workspaceDir, "reference"), {
       recursive: true,
       force: false,
-      errorOnExist: true
+      errorOnExist: true,
     });
   }
   if (request.guidanceSkillDir) {
     await cp(request.guidanceSkillDir, join(workspaceDir, "seed-reference"), {
       recursive: true,
       force: false,
-      errorOnExist: true
+      errorOnExist: true,
     });
   }
   await cp(request.previousSkillDir, join(workspaceDir, "skill"), {
     recursive: true,
     force: false,
-    errorOnExist: true
+    errorOnExist: true,
   });
   await writeFile(
     join(workspaceDir, "scores", "previous-aggregate.json"),
-    `${JSON.stringify(request.previousAggregate, null, 2)}\n`
+    `${JSON.stringify(request.previousAggregate, null, 2)}\n`,
   );
   await writeFile(
     join(workspaceDir, "scores", "previous-scores.json"),
-    `${JSON.stringify(request.previousScores, null, 2)}\n`
+    `${JSON.stringify(request.previousScores, null, 2)}\n`,
   );
   await writeFile(
     join(workspaceDir, "scores", "baseline-scores.json"),
-    `${JSON.stringify(request.baselineScores, null, 2)}\n`
+    `${JSON.stringify(request.baselineScores, null, 2)}\n`,
   );
   return workspaceDir;
-}
-
-function formatGuidanceContext(iteration: number, seedReferenceFiles: MountedFile[], ledger: GuidanceLedger): string[] {
-  if (seedReferenceFiles.length === 0) {
-    return ["Seed/reference skill guidance:", "No seed/reference skill files are configured."];
-  }
-
-  if (iteration === 1) {
-    return [
-      "Seed/reference skill files:",
-      formatFileSet(seedReferenceFiles, `research iteration ${iteration} seed/reference skill files`),
-      "",
-      "Guidance ledger:",
-      fencedJson(ledger)
-    ];
-  }
-
-  return [
-    "Guidance ledger:",
-    fencedJson(ledger),
-    "",
-    "Seed/reference skill index:",
-    formatGuidanceIndex(seedReferenceFiles)
-  ];
-}
-
-function formatGuidanceIndex(files: MountedFile[]): string {
-  return files.map((file) => `- ${file.path}${formatHeadings(file.contents)}`).join("\n");
-}
-
-function formatHeadings(contents: string): string {
-  const headings = contents
-    .split(/\r?\n/)
-    .map((line) => line.match(/^(#{1,6})\s+(.+)$/)?.[2]?.trim())
-    .filter((heading): heading is string => Boolean(heading))
-    .slice(0, 8);
-  return headings.length > 0 ? ` (${headings.join("; ")})` : "";
 }
 
 function roleModel(request: EvalAgentRequest, role: "producer" | "judge"): ModelConfig {
@@ -470,14 +367,16 @@ export async function readGuidanceLedger(path: string | undefined): Promise<Guid
     const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
     return parseWithSchema(GuidanceLedgerSchema, raw, "guidance ledger");
   } catch (error) {
-    throw new Error(`Could not read guidance ledger at ${path}: ${(error as Error).message}`, { cause: error });
+    throw new Error(`Could not read guidance ledger at ${path}: ${(error as Error).message}`, {
+      cause: error,
+    });
   }
 }
 
 export async function appendGuidanceLedger(
   path: string | undefined,
   iteration: number,
-  patch: SkillResearchPatch
+  patch: SkillResearchPatch,
 ): Promise<void> {
   if (!path || patch.guidance.length === 0) {
     return;
@@ -488,7 +387,10 @@ export async function appendGuidanceLedger(
   await writeFile(path, `${JSON.stringify(ledger, null, 2)}\n`, "utf8");
 }
 
-export async function applySkillResearchPatch(skillDir: string, patch: SkillResearchPatch): Promise<void> {
+export async function applySkillResearchPatch(
+  skillDir: string,
+  patch: SkillResearchPatch,
+): Promise<void> {
   for (const change of patch.changes) {
     const destination = resolveSkillPath(skillDir, change.path);
     await mkdir(dirname(destination), { recursive: true });
@@ -532,13 +434,17 @@ function validateEvalScore(score: EvalScore, evalCase: EvalCase, track: Track): 
     throw new Error(`Judge score eval_id "${score.eval_id}" does not match "${evalCase.id}"`);
   }
   if (score.eval_type !== evalCase.eval_type) {
-    throw new Error(`Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`);
+    throw new Error(
+      `Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`,
+    );
   }
   if (score.track_id !== track.id) {
     throw new Error(`Judge score track_id "${score.track_id}" does not match "${track.id}"`);
   }
   if (unknown.length > 0) {
-    throw new Error(`Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`);
+    throw new Error(
+      `Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`,
+    );
   }
 }
 
@@ -550,16 +456,22 @@ export function formatResearchSummary(patch: SkillResearchPatch): string {
     "",
     "## Changed Files",
     "",
-    ...patch.changes.map((change) => `- ${change.path}`)
+    ...patch.changes.map((change) => `- ${change.path}`),
   ].join("\n");
 }
 
-async function persistTranscript(path: string, request: ModelRequest, response: string): Promise<void> {
+async function persistTranscript(
+  path: string,
+  request: ModelRequest,
+  response: string,
+): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, `${JSON.stringify({ request, response }, null, 2)}\n`, { flag: "wx" });
 }
 
-async function readFilesFromMount(root: string | undefined): Promise<Array<{ path: string; contents: string }>> {
+async function readFilesFromMount(
+  root: string | undefined,
+): Promise<Array<{ path: string; contents: string }>> {
   if (!root || !(await exists(root))) {
     return [];
   }
@@ -567,8 +479,8 @@ async function readFilesFromMount(root: string | undefined): Promise<Array<{ pat
   return Promise.all(
     files.map(async (path) => ({
       path: relative(root, path),
-      contents: await readFile(path, "utf8")
-    }))
+      contents: await readFile(path, "utf8"),
+    })),
   );
 }
 
@@ -584,7 +496,7 @@ async function listTextFiles(root: string): Promise<string[]> {
         return [path];
       }
       return [];
-    })
+    }),
   );
   return nested.flat().sort();
 }
@@ -604,8 +516,6 @@ async function exists(path: string): Promise<boolean> {
 
 const MAX_PROMPT_TOKENS = 180_000;
 const APPROX_CHARS_PER_TOKEN = 4;
-const MAX_FILE_CHARS = 80_000;
-const MAX_FILE_SET_CHARS = 240_000;
 
 function checkedModelRequest(request: ModelRequest): ModelRequest {
   const estimatedTokens = estimateTokens(`${request.system}\n${request.prompt}`);
@@ -618,65 +528,11 @@ function checkedModelRequest(request: ModelRequest): ModelRequest {
     [
       `[flue] prompt budget exceeded before ${phase}: estimated ${estimatedTokens} tokens > ${MAX_PROMPT_TOKENS} token budget`,
       `Prompt size: ${request.prompt.length} chars. This was detected before submitting a provider request.`,
-      "Reduce the eval input/reference/skill/output artifacts for this phase or add a more compact summary."
-    ].join("\n")
+      "Reduce the eval input/reference/skill/output artifacts for this phase or add a more compact summary.",
+    ].join("\n"),
   );
 }
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / APPROX_CHARS_PER_TOKEN);
-}
-
-function formatFileSet(files: Array<{ path: string; contents: string }>, label: string): string {
-  if (files.length === 0) {
-    return "(none)";
-  }
-  let remainingChars = MAX_FILE_SET_CHARS;
-  const formatted: string[] = [];
-  let omittedFiles = 0;
-
-  for (const file of files) {
-    const separatorOverhead = formatted.length > 0 ? "\n\n".length : 0;
-    const heading = `### ${file.path}\n\n`;
-    const fenceOverhead = fenced("").length;
-    const renderedOverhead = separatorOverhead + heading.length + fenceOverhead;
-
-    if (remainingChars <= renderedOverhead) {
-      omittedFiles++;
-      continue;
-    }
-
-    const maxContentsChars = Math.min(MAX_FILE_CHARS, remainingChars - renderedOverhead);
-    const contents = truncateText(file.contents, maxContentsChars, `${label}/${file.path}`);
-    remainingChars -= renderedOverhead + contents.length;
-    formatted.push(`${heading}${fenced(contents)}`);
-  }
-
-  if (omittedFiles > 0) {
-    formatted.push(
-      `[${omittedFiles} file(s) omitted from ${label}; ${MAX_FILE_SET_CHARS} char file-set budget exhausted.]`
-    );
-  }
-
-  return formatted.join("\n\n");
-}
-
-function fenced(contents: string): string {
-  return `\`\`\`\n${contents}\n\`\`\``;
-}
-
-function truncateText(contents: string, maxChars: number, label: string): string {
-  if (contents.length <= maxChars) {
-    return contents;
-  }
-  if (maxChars <= 0) {
-    return "";
-  }
-  const keptChars = Math.max(0, maxChars - 128);
-  const marker = `\n\n[truncated ${contents.length - keptChars} chars from ${label}; kept first ${keptChars} chars]\n`;
-  return `${contents.slice(0, keptChars)}${marker}`.slice(0, maxChars);
-}
-
-function fencedJson(value: unknown): string {
-  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
 }

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -18,7 +18,7 @@ import {
   SkillResearchPatch,
   SkillResearchPatchSchema,
   Track,
-  parseWithSchema,
+  parseWithSchema
 } from "./schemas.js";
 
 export interface ModelRequest {
@@ -70,14 +70,14 @@ export class AnthropicMessagesClient implements ModelClient {
       headers: {
         "content-type": "application/json",
         "x-api-key": this.#apiKey,
-        "anthropic-version": this.#version,
+        "anthropic-version": this.#version
       },
       body: JSON.stringify({
         model: request.model.name,
         max_tokens: this.#maxTokens,
         system: request.system,
-        messages: [{ role: "user", content: request.prompt }],
-      }),
+        messages: [{ role: "user", content: request.prompt }]
+      })
     });
 
     if (!response.ok) {
@@ -109,18 +109,14 @@ export class ModelEvalAgent implements EvalAgent {
     await persistTranscript(
       join(request.sandbox.outputDir, "producer-transcript.json"),
       produceRequest,
-      produceResponse,
+      produceResponse
     );
     const produced = parseModelProduceResponse(produceResponse);
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
     const judgeResponse = await this.#client.complete(judgeRequest);
-    await persistTranscript(
-      join(request.sandbox.outputDir, "judge-transcript.json"),
-      judgeRequest,
-      judgeResponse,
-    );
+    await persistTranscript(join(request.sandbox.outputDir, "judge-transcript.json"), judgeRequest, judgeResponse);
     return parseModelJudgeResponse(judgeResponse, request.evalCase, request.track);
   }
 }
@@ -140,28 +136,21 @@ export class ModelSkillResearcher implements SkillResearcher {
     await cp(request.previousSkillDir, request.candidateSkillDir, {
       recursive: true,
       errorOnExist: true,
-      force: false,
+      force: false
     });
     await mkdir(request.candidateSkillDir, { recursive: true });
+    await removeGeneratedResearchFiles(request.candidateSkillDir);
     await applySkillResearchPatch(request.candidateSkillDir, patch);
     await appendGuidanceLedger(request.guidanceLedgerPath, request.iteration, patch);
     await writeFile(join(request.candidateSkillDir, "RESEARCH.md"), formatResearchSummary(patch), {
-      flag: "wx",
+      flag: "wx"
     });
-    await persistTranscript(
-      join(request.candidateSkillDir, ".autoresearch-transcript.json"),
-      modelRequest,
-      response,
-    );
+    await persistTranscript(join(request.candidateSkillDir, ".autoresearch-transcript.json"), modelRequest, response);
   }
 }
 
 export async function buildProduceModelRequest(request: EvalAgentRequest): Promise<ModelRequest> {
-  const workspaceDir = await createPhaseWorkspace(request, "producer", [
-    "/input",
-    "/reference",
-    "/skill",
-  ]);
+  const workspaceDir = await createPhaseWorkspace(request, "producer", ["/input", "/reference", "/skill"]);
   const inputFiles = await readFilesFromMount(join(workspaceDir, "input"));
   const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
   const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
@@ -171,13 +160,13 @@ export async function buildProduceModelRequest(request: EvalAgentRequest): Promi
     system: request.role,
     phase: `producer eval ${request.evalCase.id}`,
     workspaceDir,
-    prompt: buildProducePrompt({ request, workspaceDir, inputFiles, referenceFiles, skillFiles }),
+    prompt: buildProducePrompt({ request, workspaceDir, inputFiles, referenceFiles, skillFiles })
   });
 }
 
 export async function buildJudgeModelRequest(
   request: EvalAgentRequest,
-  outputFiles: OutputFile[],
+  outputFiles: OutputFile[]
 ): Promise<ModelRequest> {
   await applyOutputFiles(request.sandbox.outputDir, outputFiles);
   const workspaceDir = await createPhaseWorkspace(request, "judge", ["/reference"]);
@@ -196,15 +185,15 @@ export async function buildJudgeModelRequest(
       workspaceDir,
       referenceFiles,
       rubricFiles,
-      workspaceOutputFiles,
-    }),
+      workspaceOutputFiles
+    })
   });
 }
 
 async function createPhaseWorkspace(
   request: EvalAgentRequest,
   phase: "producer" | "judge",
-  mountTargets: string[],
+  mountTargets: string[]
 ): Promise<string> {
   const workspaceDir = join(request.sandbox.outputDir, ".phase-workspaces", phase);
   await rm(workspaceDir, { recursive: true, force: true });
@@ -218,7 +207,7 @@ async function createPhaseWorkspace(
     await cp(mount.source, join(workspaceDir, target.slice(1)), {
       recursive: true,
       force: false,
-      errorOnExist: true,
+      errorOnExist: true
     });
   }
 
@@ -229,7 +218,7 @@ async function createPhaseWorkspace(
     if (await exists(rubricPath)) {
       await cp(rubricPath, join(workspaceDir, "evals", "rubric.md"), {
         force: false,
-        errorOnExist: true,
+        errorOnExist: true
       });
     }
   }
@@ -241,20 +230,12 @@ export function parseModelProduceResponse(response: string): ModelProduceRespons
   return parseWithSchema(
     ModelProduceResponseSchema,
     parseJson(response, "Model producer response"),
-    "model producer response",
+    "model producer response"
   );
 }
 
-export function parseModelJudgeResponse(
-  response: string,
-  evalCase: EvalCase,
-  track: Track,
-): EvalScore {
-  const score = parseWithSchema(
-    EvalScoreSchema,
-    parseJson(response, "Model judge response"),
-    "model judge response",
-  );
+export function parseModelJudgeResponse(response: string, evalCase: EvalCase, track: Track): EvalScore {
+  const score = parseWithSchema(EvalScoreSchema, parseJson(response, "Model judge response"), "model judge response");
   validateEvalScore(score, evalCase, track);
   return score;
 }
@@ -271,9 +252,7 @@ export async function applyOutputFiles(outputDir: string, files: OutputFile[]): 
   }
 }
 
-export async function buildResearchModelRequest(
-  request: SkillResearchRequest,
-): Promise<ModelRequest> {
+export async function buildResearchModelRequest(request: SkillResearchRequest): Promise<ModelRequest> {
   const workspaceDir = await createResearchWorkspace(request);
   const skillFiles = await readFilesFromMount(join(workspaceDir, "skill"));
   const referenceFiles = await readFilesFromMount(join(workspaceDir, "reference"));
@@ -293,59 +272,54 @@ export async function buildResearchModelRequest(
       referenceFiles,
       seedReferenceFiles,
       evalFiles,
-      guidanceLedger,
-    }),
+      guidanceLedger
+    })
   });
 }
 
 async function createResearchWorkspace(request: SkillResearchRequest): Promise<string> {
-  const workspaceDir = join(
-    request.project.root,
-    "workspace",
-    ".phase-workspaces",
-    `research-${request.iteration}`,
-  );
+  const workspaceDir = join(request.project.root, "workspace", ".phase-workspaces", `research-${request.iteration}`);
   await rm(workspaceDir, { recursive: true, force: true });
   await mkdir(join(workspaceDir, "scores"), { recursive: true });
   await cp(join(request.project.root, "config.json"), join(workspaceDir, "config.json"), {
     force: false,
-    errorOnExist: true,
+    errorOnExist: true
   });
   await cp(join(request.project.root, "evals"), join(workspaceDir, "evals"), {
     recursive: true,
     force: false,
-    errorOnExist: true,
+    errorOnExist: true
   });
   if (await exists(request.project.referenceDir)) {
     await cp(request.project.referenceDir, join(workspaceDir, "reference"), {
       recursive: true,
       force: false,
-      errorOnExist: true,
+      errorOnExist: true
     });
   }
   if (request.guidanceSkillDir) {
     await cp(request.guidanceSkillDir, join(workspaceDir, "seed-reference"), {
       recursive: true,
       force: false,
-      errorOnExist: true,
+      errorOnExist: true
     });
   }
   await cp(request.previousSkillDir, join(workspaceDir, "skill"), {
     recursive: true,
     force: false,
-    errorOnExist: true,
+    errorOnExist: true
   });
   await writeFile(
     join(workspaceDir, "scores", "previous-aggregate.json"),
-    `${JSON.stringify(request.previousAggregate, null, 2)}\n`,
+    `${JSON.stringify(request.previousAggregate, null, 2)}\n`
   );
   await writeFile(
     join(workspaceDir, "scores", "previous-scores.json"),
-    `${JSON.stringify(request.previousScores, null, 2)}\n`,
+    `${JSON.stringify(request.previousScores, null, 2)}\n`
   );
   await writeFile(
     join(workspaceDir, "scores", "baseline-scores.json"),
-    `${JSON.stringify(request.baselineScores, null, 2)}\n`,
+    `${JSON.stringify(request.baselineScores, null, 2)}\n`
   );
   return workspaceDir;
 }
@@ -368,7 +342,7 @@ export async function readGuidanceLedger(path: string | undefined): Promise<Guid
     return parseWithSchema(GuidanceLedgerSchema, raw, "guidance ledger");
   } catch (error) {
     throw new Error(`Could not read guidance ledger at ${path}: ${(error as Error).message}`, {
-      cause: error,
+      cause: error
     });
   }
 }
@@ -376,7 +350,7 @@ export async function readGuidanceLedger(path: string | undefined): Promise<Guid
 export async function appendGuidanceLedger(
   path: string | undefined,
   iteration: number,
-  patch: SkillResearchPatch,
+  patch: SkillResearchPatch
 ): Promise<void> {
   if (!path || patch.guidance.length === 0) {
     return;
@@ -387,10 +361,7 @@ export async function appendGuidanceLedger(
   await writeFile(path, `${JSON.stringify(ledger, null, 2)}\n`, "utf8");
 }
 
-export async function applySkillResearchPatch(
-  skillDir: string,
-  patch: SkillResearchPatch,
-): Promise<void> {
+export async function applySkillResearchPatch(skillDir: string, patch: SkillResearchPatch): Promise<void> {
   for (const change of patch.changes) {
     const destination = resolveSkillPath(skillDir, change.path);
     await mkdir(dirname(destination), { recursive: true });
@@ -434,17 +405,13 @@ function validateEvalScore(score: EvalScore, evalCase: EvalCase, track: Track): 
     throw new Error(`Judge score eval_id "${score.eval_id}" does not match "${evalCase.id}"`);
   }
   if (score.eval_type !== evalCase.eval_type) {
-    throw new Error(
-      `Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`,
-    );
+    throw new Error(`Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`);
   }
   if (score.track_id !== track.id) {
     throw new Error(`Judge score track_id "${score.track_id}" does not match "${track.id}"`);
   }
   if (unknown.length > 0) {
-    throw new Error(
-      `Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`,
-    );
+    throw new Error(`Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`);
   }
 }
 
@@ -456,22 +423,24 @@ export function formatResearchSummary(patch: SkillResearchPatch): string {
     "",
     "## Changed Files",
     "",
-    ...patch.changes.map((change) => `- ${change.path}`),
+    ...patch.changes.map((change) => `- ${change.path}`)
   ].join("\n");
 }
 
-async function persistTranscript(
-  path: string,
-  request: ModelRequest,
-  response: string,
-): Promise<void> {
+async function persistTranscript(path: string, request: ModelRequest, response: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, `${JSON.stringify({ request, response }, null, 2)}\n`, { flag: "wx" });
 }
 
-async function readFilesFromMount(
-  root: string | undefined,
-): Promise<Array<{ path: string; contents: string }>> {
+async function removeGeneratedResearchFiles(skillDir: string): Promise<void> {
+  await Promise.all(
+    ["RESEARCH.md", ".autoresearch-transcript.json", ".autoresearch-flue-transcript.json"].map((fileName) =>
+      rm(join(skillDir, fileName), { force: true })
+    )
+  );
+}
+
+async function readFilesFromMount(root: string | undefined): Promise<Array<{ path: string; contents: string }>> {
   if (!root || !(await exists(root))) {
     return [];
   }
@@ -479,8 +448,8 @@ async function readFilesFromMount(
   return Promise.all(
     files.map(async (path) => ({
       path: relative(root, path),
-      contents: await readFile(path, "utf8"),
-    })),
+      contents: await readFile(path, "utf8")
+    }))
   );
 }
 
@@ -496,7 +465,7 @@ async function listTextFiles(root: string): Promise<string[]> {
         return [path];
       }
       return [];
-    }),
+    })
   );
   return nested.flat().sort();
 }
@@ -528,8 +497,8 @@ function checkedModelRequest(request: ModelRequest): ModelRequest {
     [
       `[flue] prompt budget exceeded before ${phase}: estimated ${estimatedTokens} tokens > ${MAX_PROMPT_TOKENS} token budget`,
       `Prompt size: ${request.prompt.length} chars. This was detected before submitting a provider request.`,
-      "Reduce the eval input/reference/skill/output artifacts for this phase or add a more compact summary.",
-    ].join("\n"),
+      "Reduce the eval input/reference/skill/output artifacts for this phase or add a more compact summary."
+    ].join("\n")
   );
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,7 +2,7 @@ import { ModelConfig, ProjectConfig } from "./schemas.js";
 
 export const DEFAULT_MODEL: ModelConfig = {
   provider: "anthropic",
-  name: "claude-sonnet-4-6"
+  name: "claude-sonnet-4-6",
 };
 
 export interface ModelOverride {
@@ -23,7 +23,7 @@ export function resolveModel(config: ProjectConfig, override?: ModelOverride): M
 
   const model: ModelConfig = {
     provider,
-    name
+    name,
   };
 
   return model;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,5 @@
 import { cp, mkdir, rm, stat, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
 import { loadProject, ProjectInputs } from "./project.js";
@@ -11,14 +11,37 @@ export type RunEvent =
   | { type: "baseline-imported"; scores: number; missing: string[] }
   | { type: "baseline-started"; evals: number; countsTowardIterations: false }
   | { type: "baseline-generated"; scores: number }
-  | { type: "iteration-started"; iteration: number; previousSkillDir: string; candidateSkillDir: string }
+  | {
+      type: "iteration-started";
+      iteration: number;
+      previousSkillDir: string;
+      candidateSkillDir: string;
+    }
   | { type: "iteration-generated"; iteration: number; candidateSkillDir: string }
   | { type: "iteration-scored"; iteration: number; scores: number; aggregate: AggregateReport }
   | { type: "baseline-target-score-reached"; normalizedScore: number; targetScore: number }
-  | { type: "target-score-reached"; iteration: number; normalizedScore: number; targetScore: number }
+  | {
+      type: "target-score-reached";
+      iteration: number;
+      normalizedScore: number;
+      targetScore: number;
+    }
+  | {
+      type: "target-score-blocked-by-regression";
+      iteration: number;
+      normalizedScore: number;
+      targetScore: number;
+      regressions: ScoreRegression[];
+    }
   | { type: "max-iterations-reached"; completedIterations: number; maxIterations: number }
   | { type: "research-loop-ready"; completedIterations: number; maxIterations: number }
   | { type: "aggregated"; aggregate: AggregateReport };
+
+export interface ScoreRegression {
+  evalId: string;
+  baselineScore: number;
+  candidateScore: number;
+}
 
 export interface IterationResult {
   iteration: number;
@@ -64,7 +87,9 @@ export interface OrchestrateOptions {
   guidanceSkillDir?: string;
 }
 
-export async function orchestrateBaseline(options: OrchestrateOptions): Promise<OrchestratorResult> {
+export async function orchestrateBaseline(
+  options: OrchestrateOptions,
+): Promise<OrchestratorResult> {
   const events: RunEvent[] = [];
   const project = await loadProject(options.projectRoot);
   events.push({ type: "project-loaded", root: project.root });
@@ -85,7 +110,7 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
     events.push({
       type: "baseline-target-score-reached",
       normalizedScore: aggregate.overall.normalizedScore,
-      targetScore: project.config.target_score
+      targetScore: project.config.target_score,
     });
     return { project, baselineScores, aggregate, completedIterations: 0, iterations: [], events };
   }
@@ -93,7 +118,7 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
   events.push({
     type: "research-loop-ready",
     completedIterations: 0,
-    maxIterations: project.config.max_iterations
+    maxIterations: project.config.max_iterations,
   });
 
   if (!options.runResearch) {
@@ -109,31 +134,37 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
     completedIterations: research.iterations.length,
     iterations: research.iterations,
     bestIteration: research.bestIteration,
-    events
+    events,
   };
 }
 
 async function importRequiredBaseline(
   project: ProjectInputs,
   expectedEvalIds: string[],
-  events: RunEvent[]
+  events: RunEvent[],
 ): Promise<EvalScore[]> {
   if (!project.baselineDir) {
     throw new Error(
-      "Run was started with --with-baseline, but workspace/baseline was not found. Remove --with-baseline to generate an initial baseline run."
+      "Run was started with --with-baseline, but workspace/baseline was not found. Remove --with-baseline to generate an initial baseline run.",
     );
   }
 
   const baseline = await importBaselineArtefacts(project.baselineDir, expectedEvalIds);
-  events.push({ type: "baseline-imported", scores: baseline.scores.length, missing: baseline.missing });
+  events.push({
+    type: "baseline-imported",
+    scores: baseline.scores.length,
+    missing: baseline.missing,
+  });
 
-  const missingScores = expectedEvalIds.filter((evalId) => !baseline.scores.some((score) => score.eval_id === evalId));
+  const missingScores = expectedEvalIds.filter(
+    (evalId) => !baseline.scores.some((score) => score.eval_id === evalId),
+  );
   if (missingScores.length > 0 || baseline.missing.length > 0) {
     throw new Error(
       `Run was started with --with-baseline, but baseline artefacts are incomplete. Missing: ${[
         ...missingScores.map((evalId) => `score:${evalId}`),
-        ...baseline.missing
-      ].join(", ")}`
+        ...baseline.missing,
+      ].join(", ")}`,
     );
   }
 
@@ -143,7 +174,7 @@ async function importRequiredBaseline(
 async function generateInitialBaseline(
   project: ProjectInputs,
   agent: EvalAgent | undefined,
-  events: RunEvent[]
+  events: RunEvent[],
 ): Promise<EvalScore[]> {
   if (!agent) {
     throw new Error("No eval agent was provided to generate the initial baseline run");
@@ -152,21 +183,24 @@ async function generateInitialBaseline(
   events.push({
     type: "baseline-started",
     evals: project.evals.evals.length,
-    countsTowardIterations: false
+    countsTowardIterations: false,
   });
 
   const outputRoot = join(project.root, "workspace", "baseline");
-  const baselineScores = await runWithConcurrency(project.evals.evals, project.config.max_concurrency, (evalCase) =>
-    runEval(
-      {
-        config: project.config,
-        projectRoot: project.root,
-        evalCase,
-        baseline: true,
-        outputRoot
-      },
-      agent
-    )
+  const baselineScores = await runWithConcurrency(
+    project.evals.evals,
+    project.config.max_concurrency,
+    (evalCase) =>
+      runEval(
+        {
+          config: project.config,
+          projectRoot: project.root,
+          evalCase,
+          baseline: true,
+          outputRoot,
+        },
+        agent,
+      ),
   );
   await persistBaselineScores(project.root, baselineScores);
   events.push({ type: "baseline-generated", scores: baselineScores.length });
@@ -178,8 +212,10 @@ async function persistBaselineScores(projectRoot: string, scores: EvalScore[]): 
   await mkdir(baselineDir, { recursive: true });
   await Promise.all(
     scores.map((score, index) =>
-      writeFile(join(baselineDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, { flag: "wx" })
-    )
+      writeFile(join(baselineDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
+        flag: "wx",
+      }),
+    ),
   );
 }
 
@@ -188,7 +224,7 @@ async function runResearchIterations(
   baselineScores: EvalScore[],
   baselineAggregate: AggregateReport,
   options: OrchestrateOptions,
-  events: RunEvent[]
+  events: RunEvent[],
 ): Promise<{ iterations: IterationResult[]; bestIteration?: IterationResult }> {
   if (!options.agent) {
     throw new Error("No eval agent was provided to run research iterations");
@@ -199,8 +235,14 @@ async function runResearchIterations(
 
   const agent = options.agent;
   const seedSkillDir = await resolveSeedSkillDir(project, options.seedSkillDir);
-  const guidanceSkillDir = await resolveGuidanceSkillDir(project, options.guidanceSkillDir, seedSkillDir);
-  const guidanceLedgerPath = guidanceSkillDir ? join(project.root, "workspace", "guidance-ledger.json") : undefined;
+  const guidanceSkillDir = await resolveGuidanceSkillDir(
+    project,
+    options.guidanceSkillDir,
+    seedSkillDir,
+  );
+  const guidanceLedgerPath = guidanceSkillDir
+    ? join(project.root, "workspace", "guidance-ledger.json")
+    : undefined;
   const iterations: IterationResult[] = [];
   let previousSkillDir = await resolveInitialResearchSkillDir(project, seedSkillDir);
   let previousScores = baselineScores;
@@ -223,26 +265,29 @@ async function runResearchIterations(
       guidanceLedgerPath,
       baselineScores,
       previousScores,
-      previousAggregate
+      previousAggregate,
     });
     await assertExists(
       candidateSkillDir,
-      `Researcher did not create candidate skill directory for iteration ${iteration}`
+      `Researcher did not create candidate skill directory for iteration ${iteration}`,
     );
     events.push({ type: "iteration-generated", iteration, candidateSkillDir });
 
-    const scores = await runWithConcurrency(project.evals.evals, project.config.max_concurrency, (evalCase) =>
-      runEval(
-        {
-          config: project.config,
-          projectRoot: project.root,
-          evalCase,
-          baseline: false,
-          targetSkillDir: candidateSkillDir,
-          outputRoot: join(iterationDir, "outputs")
-        },
-        agent
-      )
+    const scores = await runWithConcurrency(
+      project.evals.evals,
+      project.config.max_concurrency,
+      (evalCase) =>
+        runEval(
+          {
+            config: project.config,
+            projectRoot: project.root,
+            evalCase,
+            baseline: false,
+            targetSkillDir: candidateSkillDir,
+            outputRoot: join(iterationDir, "outputs"),
+          },
+          agent,
+        ),
     );
     await persistIterationScores(iterationDir, scores);
 
@@ -252,18 +297,32 @@ async function runResearchIterations(
     iterations.push(result);
     events.push({ type: "iteration-scored", iteration, scores: scores.length, aggregate });
 
-    if (!bestIteration || aggregate.overall.normalizedScore > bestIteration.aggregate.overall.normalizedScore) {
+    if (
+      !bestIteration ||
+      aggregate.overall.normalizedScore > bestIteration.aggregate.overall.normalizedScore
+    ) {
       bestIteration = result;
     }
     if (aggregate.overall.normalizedScore >= project.config.target_score) {
-      events.push({
-        type: "target-score-reached",
-        iteration,
-        normalizedScore: aggregate.overall.normalizedScore,
-        targetScore: project.config.target_score
-      });
-      reachedTarget = true;
-      break;
+      const regressions = findScoreRegressions(baselineScores, scores);
+      if (regressions.length > 0) {
+        events.push({
+          type: "target-score-blocked-by-regression",
+          iteration,
+          normalizedScore: aggregate.overall.normalizedScore,
+          targetScore: project.config.target_score,
+          regressions,
+        });
+      } else {
+        events.push({
+          type: "target-score-reached",
+          iteration,
+          normalizedScore: aggregate.overall.normalizedScore,
+          targetScore: project.config.target_score,
+        });
+        reachedTarget = true;
+        break;
+      }
     }
 
     previousSkillDir = candidateSkillDir;
@@ -275,18 +334,43 @@ async function runResearchIterations(
     events.push({
       type: "max-iterations-reached",
       completedIterations: iterations.length,
-      maxIterations: project.config.max_iterations
+      maxIterations: project.config.max_iterations,
     });
   }
 
   return { iterations, bestIteration };
 }
 
+function findScoreRegressions(
+  baselineScores: EvalScore[],
+  candidateScores: EvalScore[],
+): ScoreRegression[] {
+  const baselineByEval = new Map(baselineScores.map((score) => [score.eval_id, score]));
+  return candidateScores
+    .map((candidate) => {
+      const baseline = baselineByEval.get(candidate.eval_id);
+      if (!baseline || candidate.total_score >= baseline.total_score) {
+        return undefined;
+      }
+      return {
+        evalId: candidate.eval_id,
+        baselineScore: baseline.total_score,
+        candidateScore: candidate.total_score,
+      };
+    })
+    .filter((regression): regression is ScoreRegression => Boolean(regression));
+}
+
 async function resolveSeedSkillDir(project: ProjectInputs, seedSkillDir?: string): Promise<string> {
-  const resolved = seedSkillDir ?? project.config.origin_skill;
-  if (!resolved) {
-    throw new Error("No seed skill directory was provided. Set origin_skill in config.json or pass seedSkillDir.");
+  const configured = seedSkillDir ?? project.config.origin_skill;
+  if (!configured) {
+    throw new Error(
+      "No seed skill directory was provided. Set origin_skill in config.json or pass seedSkillDir.",
+    );
   }
+  const resolved = seedSkillDir
+    ? resolve(seedSkillDir)
+    : resolveProjectConfigPath(project, configured);
   await assertExists(resolved, `Seed skill directory was not found: ${resolved}`);
   return resolved;
 }
@@ -294,10 +378,9 @@ async function resolveSeedSkillDir(project: ProjectInputs, seedSkillDir?: string
 async function resolveGuidanceSkillDir(
   project: ProjectInputs,
   guidanceSkillDir: string | undefined,
-  seedSkillDir: string
+  seedSkillDir: string,
 ): Promise<string | undefined> {
-  const configured = guidanceSkillDir ?? project.config.guidance_skill;
-  const resolved = configured ?? (project.config.research_start === "empty" ? seedSkillDir : undefined);
+  const resolved = resolveConfiguredGuidanceSkillDir(project, guidanceSkillDir, seedSkillDir);
   if (!resolved) {
     return undefined;
   }
@@ -305,7 +388,24 @@ async function resolveGuidanceSkillDir(
   return resolved;
 }
 
-async function resolveInitialResearchSkillDir(project: ProjectInputs, seedSkillDir: string): Promise<string> {
+function resolveConfiguredGuidanceSkillDir(
+  project: ProjectInputs,
+  guidanceSkillDir: string | undefined,
+  seedSkillDir: string,
+): string | undefined {
+  if (guidanceSkillDir) {
+    return resolve(guidanceSkillDir);
+  }
+  if (project.config.guidance_skill) {
+    return resolveProjectConfigPath(project, project.config.guidance_skill);
+  }
+  return project.config.research_start === "empty" ? seedSkillDir : undefined;
+}
+
+async function resolveInitialResearchSkillDir(
+  project: ProjectInputs,
+  seedSkillDir: string,
+): Promise<string> {
   if ((project.config.research_start ?? "seed") !== "empty") {
     return seedSkillDir;
   }
@@ -314,6 +414,10 @@ async function resolveInitialResearchSkillDir(project: ProjectInputs, seedSkillD
   await rm(emptySkillDir, { recursive: true, force: true });
   await mkdir(emptySkillDir, { recursive: true });
   return emptySkillDir;
+}
+
+function resolveProjectConfigPath(project: ProjectInputs, path: string): string {
+  return isAbsolute(path) ? path : resolve(project.root, path);
 }
 
 async function assertExists(path: string, message: string): Promise<void> {
@@ -327,8 +431,10 @@ async function assertExists(path: string, message: string): Promise<void> {
 async function persistIterationScores(iterationDir: string, scores: EvalScore[]): Promise<void> {
   await Promise.all(
     scores.map((score, index) =>
-      writeFile(join(iterationDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, { flag: "wx" })
-    )
+      writeFile(join(iterationDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
+        flag: "wx",
+      }),
+    ),
   );
 }
 
@@ -340,6 +446,6 @@ export async function copySkillSnapshot(from: string, to: string): Promise<void>
   await cp(from, to, {
     recursive: true,
     errorOnExist: true,
-    force: false
+    force: false,
   });
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,6 +1,12 @@
 import { mkdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { EvalCasesFile, EvalCasesFileSchema, ProjectConfig, ProjectConfigSchema, parseWithSchema } from "./schemas.js";
+import {
+  EvalCasesFile,
+  EvalCasesFileSchema,
+  ProjectConfig,
+  ProjectConfigSchema,
+  parseWithSchema,
+} from "./schemas.js";
 
 export interface ProjectInputs {
   root: string;
@@ -23,7 +29,9 @@ async function exists(path: string): Promise<boolean> {
 export async function loadProject(rootPath: string): Promise<ProjectInputs> {
   const root = resolve(rootPath);
   const configJson = JSON.parse(await readFile(join(root, "config.json"), "utf8")) as unknown;
-  const evalCasesJson = JSON.parse(await readFile(join(root, "evals", "eval-cases.json"), "utf8")) as unknown;
+  const evalCasesJson = JSON.parse(
+    await readFile(join(root, "evals", "eval-cases.json"), "utf8"),
+  ) as unknown;
   const rubric = await readFile(join(root, "evals", "rubric.md"), "utf8");
   const referenceDir = join(root, "reference");
   const baselineDir = join(root, "workspace", "baseline");
@@ -38,7 +46,7 @@ export async function loadProject(rootPath: string): Promise<ProjectInputs> {
     evals: parseWithSchema(EvalCasesFileSchema, evalCasesJson, "eval-cases.json"),
     rubric,
     referenceDir,
-    baselineDir: (await exists(baselineDir)) ? baselineDir : undefined
+    baselineDir: (await exists(baselineDir)) ? baselineDir : undefined,
   };
 }
 

--- a/src/prompts/judge-prompt.ts
+++ b/src/prompts/judge-prompt.ts
@@ -1,0 +1,61 @@
+import { EvalAgentRequest } from "../runner.js";
+import { formatFileSet, fencedJson, MountedFile } from "./shared.js";
+
+export interface JudgePromptInput {
+  request: EvalAgentRequest;
+  workspaceDir: string;
+  referenceFiles: MountedFile[];
+  rubricFiles: MountedFile[];
+  workspaceOutputFiles: MountedFile[];
+}
+
+export function buildJudgePrompt({
+  request,
+  workspaceDir,
+  referenceFiles,
+  rubricFiles,
+  workspaceOutputFiles,
+}: JudgePromptInput): string {
+  // Base judge behavior lives in the Flue subagent profile at .flue/profiles.ts.
+  return [
+    `Judge output for "${request.evalCase.title}" (${request.evalCase.id}).`,
+    `Eval type: ${request.evalCase.eval_type}`,
+    `Track: ${request.track.id}`,
+    `Judge role: ${request.modelRoles?.judge ?? "judge"}`,
+    `Authoritative workspace root: ${workspaceDir}`,
+    "Only files under this workspace are authoritative for this judge phase.",
+    "Available paths: ./evals, ./reference, ./output.",
+    "",
+    "Eval case JSON:",
+    fencedJson(request.evalCase),
+    "",
+    "Rubric files:",
+    formatFileSet(rubricFiles, `judge eval ${request.evalCase.id} rubric files`),
+    "",
+    "Reference files:",
+    formatFileSet(referenceFiles, `judge eval ${request.evalCase.id} reference files`),
+    "",
+    "Producer output files:",
+    formatFileSet(workspaceOutputFiles, `judge eval ${request.evalCase.id} producer output files`),
+    "",
+    "Score only the producer output. Do not award credit for requirements merely stated in the skill instructions.",
+    "Return only well-formed JSON matching the EvalScore schema. Do not include markdown, code fences, prose, or XML tags:",
+    fencedJson({
+      eval_id: request.evalCase.id,
+      eval_type: request.evalCase.eval_type,
+      track_id: request.track.id,
+      total_score: 0,
+      max_score: request.evalCase.scoring_dimensions.reduce(
+        (sum, dimension) => sum + dimension.max_score,
+        0,
+      ),
+      dimensions: request.evalCase.scoring_dimensions.map((dimension) => ({
+        id: dimension.id,
+        score: 0,
+        max_score: dimension.max_score,
+        rationale: "Rationale grounded only in the producer output.",
+      })),
+      summary: "Concise scoring summary.",
+    }),
+  ].join("\n");
+}

--- a/src/prompts/produce-prompt.ts
+++ b/src/prompts/produce-prompt.ts
@@ -1,0 +1,55 @@
+import { EvalAgentRequest } from "../runner.js";
+import { formatFileSet, fencedJson, MountedFile } from "./shared.js";
+
+export interface ProducePromptInput {
+  request: EvalAgentRequest;
+  workspaceDir: string;
+  inputFiles: MountedFile[];
+  referenceFiles: MountedFile[];
+  skillFiles: MountedFile[];
+}
+
+export function buildProducePrompt({
+  request,
+  workspaceDir,
+  inputFiles,
+  referenceFiles,
+  skillFiles,
+}: ProducePromptInput): string {
+  return [
+    `Run the target skill for "${request.evalCase.title}" (${request.evalCase.id}).`,
+    `Eval type: ${request.evalCase.eval_type}`,
+    `Track: ${request.track.id}`,
+    `Producer role: ${request.role}`,
+    request.targetSkill
+      ? `Target skill: ${request.targetSkill}`
+      : "Baseline run: no target skill is mounted.",
+    `Authoritative workspace root: ${workspaceDir}`,
+    "Only files under this workspace are authoritative for this producer phase.",
+    "Available paths: ./input, ./reference, ./skill when present.",
+    "",
+    "Eval case JSON:",
+    fencedJson(request.evalCase),
+    "",
+    "Input files:",
+    formatFileSet(inputFiles, `producer eval ${request.evalCase.id} input files`),
+    "",
+    "Reference files:",
+    formatFileSet(referenceFiles, `producer eval ${request.evalCase.id} reference files`),
+    "",
+    "Skill files:",
+    formatFileSet(skillFiles, `producer eval ${request.evalCase.id} skill files`),
+    "",
+    "Produce the concrete eval output files. Do not score your own work.",
+    "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
+    fencedJson({
+      output_files: [
+        {
+          path: "RESULT.md",
+          contents: "The concrete output produced for this eval.",
+        },
+      ],
+    }),
+    "Each output_files path must be relative to the eval output directory.",
+  ].join("\n");
+}

--- a/src/prompts/research-prompt.ts
+++ b/src/prompts/research-prompt.ts
@@ -1,0 +1,159 @@
+import { AggregateReport } from "../aggregate.js";
+import { SkillResearchRequest } from "../orchestrator.js";
+import { EvalScore, GuidanceLedger } from "../schemas.js";
+import { formatFileSet, fencedJson, MountedFile } from "./shared.js";
+
+export interface ResearchPromptInput {
+  request: SkillResearchRequest;
+  workspaceDir: string;
+  skillFiles: MountedFile[];
+  referenceFiles: MountedFile[];
+  seedReferenceFiles: MountedFile[];
+  evalFiles: MountedFile[];
+  guidanceLedger: GuidanceLedger;
+}
+
+export function buildResearchPrompt({
+  request,
+  workspaceDir,
+  skillFiles,
+  referenceFiles,
+  seedReferenceFiles,
+  evalFiles,
+  guidanceLedger,
+}: ResearchPromptInput): string {
+  return [
+    `Improve skill "${request.project.config.skill_name}" for iteration ${request.iteration}.`,
+    `Topic group: ${request.project.config.topic_group}`,
+    `Target normalized score: ${request.project.config.target_score}`,
+    `Previous normalized score: ${request.previousAggregate.overall.normalizedScore}`,
+    `Authoritative workspace root: ${workspaceDir}`,
+    "Only files under this workspace are authoritative for this research phase.",
+    "Available paths: ./config.json, ./evals, ./reference, ./skill, ./scores.",
+    request.guidanceSkillDir
+      ? "Seed/reference skill guidance is available under ./seed-reference for this research phase."
+      : "No separate seed/reference skill guidance directory is configured for this research phase.",
+    "",
+    ...formatRegressionContext(
+      request.baselineScores,
+      request.previousScores,
+      request.previousAggregate,
+    ),
+    "",
+    "Previous aggregate:",
+    fencedJson(request.previousAggregate),
+    "",
+    "Previous scores:",
+    fencedJson(request.previousScores),
+    "",
+    "Baseline scores:",
+    fencedJson(request.baselineScores),
+    "",
+    "Current skill files:",
+    formatFileSet(skillFiles, `research iteration ${request.iteration} skill files`),
+    "",
+    "Eval and rubric files:",
+    formatFileSet(evalFiles, `research iteration ${request.iteration} eval files`),
+    "",
+    "Reference files:",
+    formatFileSet(referenceFiles, `research iteration ${request.iteration} reference files`),
+    "",
+    ...formatGuidanceContext(seedReferenceFiles, guidanceLedger),
+    "",
+    "Return only well-formed JSON with this shape. Do not include markdown, code fences, prose, or XML tags:",
+    fencedJson({
+      summary: "Brief summary of the intended skill improvement.",
+      guidance: [
+        {
+          source: "seed-reference/SKILL.md",
+          section: "Optional section heading or concise location.",
+          action: "used",
+          reason: "Why this guidance was or was not needed for the current failures.",
+          appliedTo: "SKILL.md",
+        },
+      ],
+      changes: [{ path: "SKILL.md", contents: "Complete replacement file contents." }],
+    }),
+    "Each change path must be relative to the skill directory.",
+    "Use guidance entries to update the guidance ledger whenever you inspect, use, defer, ignore, or need more seed/reference guidance.",
+    "Prefer the smallest effective change over recreating or expanding the whole reference skill.",
+    "Do not copy seed/reference files wholesale unless the scores show the current candidate is missing that entire file's behavior.",
+    "If the aggregate target is already close, focus on the specific score gaps and avoid changes that could regress stronger eval cases.",
+    "After iteration 1, prefer the guidance ledger and seed/reference index first; pull exact seed/reference content only when the latest failures justify it.",
+  ].join("\n");
+}
+
+function formatRegressionContext(
+  baselineScores: EvalScore[],
+  previousScores: EvalScore[],
+  previousAggregate: AggregateReport,
+): string[] {
+  const regressions = scoreRegressions(baselineScores, previousScores);
+  if (regressions.length === 0) {
+    return [
+      "Regression guard:",
+      "No previous eval total-score regressions are currently known relative to the baseline.",
+    ];
+  }
+
+  return [
+    "Regression guard:",
+    `The previous candidate score ${previousAggregate.overall.normalizedScore} is not enough on its own if an eval regressed from baseline.`,
+    "Fix these regressions while preserving the aggregate gains:",
+    ...regressions.map(
+      (regression) =>
+        `- ${regression.evalId}: baseline ${regression.baselineScore}/${regression.baselineMaxScore}, previous ${regression.previousScore}/${regression.previousMaxScore}`,
+    ),
+  ];
+}
+
+function scoreRegressions(baselineScores: EvalScore[], previousScores: EvalScore[]) {
+  const baselineByEval = new Map(baselineScores.map((score) => [score.eval_id, score]));
+  return previousScores
+    .map((previous) => {
+      const baseline = baselineByEval.get(previous.eval_id);
+      if (!baseline || previous.total_score >= baseline.total_score) {
+        return undefined;
+      }
+      return {
+        evalId: previous.eval_id,
+        baselineScore: baseline.total_score,
+        baselineMaxScore: baseline.max_score,
+        previousScore: previous.total_score,
+        previousMaxScore: previous.max_score,
+      };
+    })
+    .filter((regression): regression is NonNullable<typeof regression> => Boolean(regression));
+}
+
+function formatGuidanceContext(
+  seedReferenceFiles: MountedFile[],
+  ledger: GuidanceLedger,
+): string[] {
+  if (seedReferenceFiles.length === 0) {
+    return ["Seed/reference skill guidance:", "No seed/reference skill files are configured."];
+  }
+
+  return [
+    "Guidance ledger:",
+    fencedJson(ledger),
+    "",
+    "Seed/reference skill index:",
+    formatGuidanceIndex(seedReferenceFiles),
+    "",
+    "Use the seed/reference files as progressive guidance. Start from the index and ledger; only consult or copy exact seed/reference content when a current score gap clearly justifies that section.",
+  ];
+}
+
+function formatGuidanceIndex(files: MountedFile[]): string {
+  return files.map((file) => `- ${file.path}${formatHeadings(file.contents)}`).join("\n");
+}
+
+function formatHeadings(contents: string): string {
+  const headings = contents
+    .split(/\r?\n/)
+    .map((line) => line.match(/^(#{1,6})\s+(.+)$/)?.[2]?.trim())
+    .filter((heading): heading is string => Boolean(heading))
+    .slice(0, 8);
+  return headings.length > 0 ? ` (${headings.join("; ")})` : "";
+}

--- a/src/prompts/research-prompt.ts
+++ b/src/prompts/research-prompt.ts
@@ -20,7 +20,7 @@ export function buildResearchPrompt({
   referenceFiles,
   seedReferenceFiles,
   evalFiles,
-  guidanceLedger,
+  guidanceLedger
 }: ResearchPromptInput): string {
   return [
     `Improve skill "${request.project.config.skill_name}" for iteration ${request.iteration}.`,
@@ -34,11 +34,7 @@ export function buildResearchPrompt({
       ? "Seed/reference skill guidance is available under ./seed-reference for this research phase."
       : "No separate seed/reference skill guidance directory is configured for this research phase.",
     "",
-    ...formatRegressionContext(
-      request.baselineScores,
-      request.previousScores,
-      request.previousAggregate,
-    ),
+    ...formatRegressionContext(request.baselineScores, request.previousScores, request.previousAggregate),
     "",
     "Previous aggregate:",
     fencedJson(request.previousAggregate),
@@ -69,30 +65,30 @@ export function buildResearchPrompt({
           section: "Optional section heading or concise location.",
           action: "used",
           reason: "Why this guidance was or was not needed for the current failures.",
-          appliedTo: "SKILL.md",
-        },
+          appliedTo: "SKILL.md"
+        }
       ],
-      changes: [{ path: "SKILL.md", contents: "Complete replacement file contents." }],
+      changes: [{ path: "SKILL.md", contents: "Complete replacement file contents." }]
     }),
     "Each change path must be relative to the skill directory.",
     "Use guidance entries to update the guidance ledger whenever you inspect, use, defer, ignore, or need more seed/reference guidance.",
     "Prefer the smallest effective change over recreating or expanding the whole reference skill.",
     "Do not copy seed/reference files wholesale unless the scores show the current candidate is missing that entire file's behavior.",
     "If the aggregate target is already close, focus on the specific score gaps and avoid changes that could regress stronger eval cases.",
-    "After iteration 1, prefer the guidance ledger and seed/reference index first; pull exact seed/reference content only when the latest failures justify it.",
+    "After iteration 1, prefer the guidance ledger and seed/reference index first; pull exact seed/reference content only when the latest failures justify it."
   ].join("\n");
 }
 
 function formatRegressionContext(
   baselineScores: EvalScore[],
   previousScores: EvalScore[],
-  previousAggregate: AggregateReport,
+  previousAggregate: AggregateReport
 ): string[] {
   const regressions = scoreRegressions(baselineScores, previousScores);
   if (regressions.length === 0) {
     return [
       "Regression guard:",
-      "No previous eval total-score regressions are currently known relative to the baseline.",
+      "No previous eval total-score regressions are currently known relative to the baseline."
     ];
   }
 
@@ -102,34 +98,31 @@ function formatRegressionContext(
     "Fix these regressions while preserving the aggregate gains:",
     ...regressions.map(
       (regression) =>
-        `- ${regression.evalId}: baseline ${regression.baselineScore}/${regression.baselineMaxScore}, previous ${regression.previousScore}/${regression.previousMaxScore}`,
-    ),
+        `- ${regression.evalId}: baseline ${regression.baselineScore}/${regression.baselineMaxScore}, previous ${regression.previousScore}/${regression.previousMaxScore}`
+    )
   ];
 }
 
 function scoreRegressions(baselineScores: EvalScore[], previousScores: EvalScore[]) {
-  const baselineByEval = new Map(baselineScores.map((score) => [score.eval_id, score]));
-  return previousScores
-    .map((previous) => {
-      const baseline = baselineByEval.get(previous.eval_id);
-      if (!baseline || previous.total_score >= baseline.total_score) {
+  const previousByEval = new Map(previousScores.map((score) => [score.eval_id, score]));
+  return baselineScores
+    .map((baseline) => {
+      const previous = previousByEval.get(baseline.eval_id);
+      if (previous && previous.total_score >= baseline.total_score) {
         return undefined;
       }
       return {
-        evalId: previous.eval_id,
+        evalId: baseline.eval_id,
         baselineScore: baseline.total_score,
         baselineMaxScore: baseline.max_score,
-        previousScore: previous.total_score,
-        previousMaxScore: previous.max_score,
+        previousScore: previous?.total_score ?? 0,
+        previousMaxScore: previous?.max_score ?? 0
       };
     })
     .filter((regression): regression is NonNullable<typeof regression> => Boolean(regression));
 }
 
-function formatGuidanceContext(
-  seedReferenceFiles: MountedFile[],
-  ledger: GuidanceLedger,
-): string[] {
+function formatGuidanceContext(seedReferenceFiles: MountedFile[], ledger: GuidanceLedger): string[] {
   if (seedReferenceFiles.length === 0) {
     return ["Seed/reference skill guidance:", "No seed/reference skill files are configured."];
   }
@@ -141,7 +134,7 @@ function formatGuidanceContext(
     "Seed/reference skill index:",
     formatGuidanceIndex(seedReferenceFiles),
     "",
-    "Use the seed/reference files as progressive guidance. Start from the index and ledger; only consult or copy exact seed/reference content when a current score gap clearly justifies that section.",
+    "Use the seed/reference files as progressive guidance. Start from the index and ledger; only consult or copy exact seed/reference content when a current score gap clearly justifies that section."
   ];
 }
 

--- a/src/prompts/shared.ts
+++ b/src/prompts/shared.ts
@@ -1,0 +1,58 @@
+export type MountedFile = { path: string; contents: string };
+
+const MAX_FILE_CHARS = 80_000;
+const MAX_FILE_SET_CHARS = 240_000;
+
+export function formatFileSet(files: MountedFile[], label: string): string {
+  if (files.length === 0) {
+    return "(none)";
+  }
+  let remainingChars = MAX_FILE_SET_CHARS;
+  const formatted: string[] = [];
+  let omittedFiles = 0;
+
+  for (const file of files) {
+    const separatorOverhead = formatted.length > 0 ? "\n\n".length : 0;
+    const heading = `### ${file.path}\n\n`;
+    const fenceOverhead = fenced("").length;
+    const renderedOverhead = separatorOverhead + heading.length + fenceOverhead;
+
+    if (remainingChars <= renderedOverhead) {
+      omittedFiles++;
+      continue;
+    }
+
+    const maxContentsChars = Math.min(MAX_FILE_CHARS, remainingChars - renderedOverhead);
+    const contents = truncateText(file.contents, maxContentsChars, `${label}/${file.path}`);
+    remainingChars -= renderedOverhead + contents.length;
+    formatted.push(`${heading}${fenced(contents)}`);
+  }
+
+  if (omittedFiles > 0) {
+    formatted.push(
+      `[${omittedFiles} file(s) omitted from ${label}; ${MAX_FILE_SET_CHARS} char file-set budget exhausted.]`,
+    );
+  }
+
+  return formatted.join("\n\n");
+}
+
+export function fencedJson(value: unknown): string {
+  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+function fenced(contents: string): string {
+  return `\`\`\`\n${contents}\n\`\`\``;
+}
+
+function truncateText(contents: string, maxChars: number, label: string): string {
+  if (contents.length <= maxChars) {
+    return contents;
+  }
+  if (maxChars <= 0) {
+    return "";
+  }
+  const keptChars = Math.max(0, maxChars - 128);
+  const marker = `\n\n[truncated ${contents.length - keptChars} chars from ${label}; kept first ${keptChars} chars]\n`;
+  return `${contents.slice(0, keptChars)}${marker}`.slice(0, maxChars);
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -63,7 +63,8 @@ export async function runWithConcurrency<TInput, TOutput>(
   limit: number,
   worker: (input: TInput, index: number) => Promise<TOutput>
 ): Promise<TOutput[]> {
-  const results = new Array<TOutput>(inputs.length);
+  const results: TOutput[] = [];
+  results.length = inputs.length;
   let cursor = 0;
 
   async function runNext(): Promise<void> {

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -46,7 +46,7 @@ export function createEvalSandbox(options: CreateEvalSandboxOptions): EvalSandbo
     { source: resolve(options.inputDir), target: "/input", readOnly: true },
     { source: resolve(options.referenceDir), target: "/reference", readOnly: true },
     { source: resolve(options.evalsDir), target: "/evals", readOnly: true },
-    { source: outputDir, target: "/output", readOnly: false }
+    { source: outputDir, target: "/output", readOnly: false },
   ];
 
   if (options.skillDir) {
@@ -55,7 +55,9 @@ export function createEvalSandbox(options: CreateEvalSandboxOptions): EvalSandbo
 
   const assertWritable = (path: string) => {
     const absolute = resolve(path);
-    const readOnlyMount = mounts.find((mount) => mount.readOnly && isWithin(mount.source, absolute));
+    const readOnlyMount = mounts.find(
+      (mount) => mount.readOnly && isWithin(mount.source, absolute),
+    );
     if (readOnlyMount) {
       throw erofs(path);
     }
@@ -99,6 +101,6 @@ export function createEvalSandbox(options: CreateEvalSandboxOptions): EvalSandbo
       assertWritable(path);
       const { chmod } = await import("node:fs/promises");
       await chmod(path, mode);
-    }
+    },
   };
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4,23 +4,26 @@ export const ModelProviderSchema = v.picklist(["anthropic"]);
 
 export const ModelConfigSchema = v.object({
   provider: ModelProviderSchema,
-  name: v.pipe(v.string(), v.minLength(1))
+  name: v.pipe(v.string(), v.minLength(1)),
 });
 
 export const RoleModelsSchema = v.object({
   producer: v.optional(ModelConfigSchema),
   judge: v.optional(ModelConfigSchema),
-  researcher: v.optional(ModelConfigSchema)
+  researcher: v.optional(ModelConfigSchema),
 });
 
-export const RolesConfigSchema = v.record(v.pipe(v.string(), v.minLength(1)), v.pipe(v.string(), v.minLength(1)));
+export const RolesConfigSchema = v.record(
+  v.pipe(v.string(), v.minLength(1)),
+  v.pipe(v.string(), v.minLength(1)),
+);
 
 export const TrackSchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   eval_type: v.pipe(v.string(), v.minLength(1)),
   role: v.pipe(v.string(), v.minLength(1)),
   target_skill: v.pipe(v.string(), v.minLength(1)),
-  requires_description: v.optional(v.boolean(), false)
+  requires_description: v.optional(v.boolean(), false),
 });
 
 export const ProjectConfigSchema = v.object({
@@ -35,13 +38,13 @@ export const ProjectConfigSchema = v.object({
   model: v.optional(ModelConfigSchema),
   models: v.optional(RoleModelsSchema),
   roles: RolesConfigSchema,
-  tracks: v.pipe(v.array(TrackSchema), v.minLength(1))
+  tracks: v.pipe(v.array(TrackSchema), v.minLength(1)),
 });
 
 export const ScoreDimensionSchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   label: v.pipe(v.string(), v.minLength(1)),
-  max_score: v.pipe(v.number(), v.minValue(0))
+  max_score: v.pipe(v.number(), v.minValue(0)),
 });
 
 export const EvalExpectationSchema = v.record(v.string(), v.unknown());
@@ -52,18 +55,18 @@ export const EvalCaseSchema = v.object({
   title: v.pipe(v.string(), v.minLength(1)),
   input: v.optional(v.record(v.string(), v.unknown()), {}),
   expectations: v.optional(EvalExpectationSchema, {}),
-  scoring_dimensions: v.pipe(v.array(ScoreDimensionSchema), v.minLength(1))
+  scoring_dimensions: v.pipe(v.array(ScoreDimensionSchema), v.minLength(1)),
 });
 
 export const EvalCasesFileSchema = v.object({
-  evals: v.pipe(v.array(EvalCaseSchema), v.minLength(1))
+  evals: v.pipe(v.array(EvalCaseSchema), v.minLength(1)),
 });
 
 export const EvalScoreDimensionSchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   score: v.pipe(v.number(), v.minValue(0)),
   max_score: v.pipe(v.number(), v.minValue(0)),
-  rationale: v.pipe(v.string(), v.minLength(1))
+  rationale: v.pipe(v.string(), v.minLength(1)),
 });
 
 export const EvalScoreSchema = v.object({
@@ -73,16 +76,16 @@ export const EvalScoreSchema = v.object({
   total_score: v.pipe(v.number(), v.minValue(0)),
   max_score: v.pipe(v.number(), v.minValue(0)),
   dimensions: v.pipe(v.array(EvalScoreDimensionSchema), v.minLength(1)),
-  summary: v.pipe(v.string(), v.minLength(1))
+  summary: v.pipe(v.string(), v.minLength(1)),
 });
 
 export const OutputFileSchema = v.object({
   path: v.pipe(v.string(), v.minLength(1)),
-  contents: v.string()
+  contents: v.string(),
 });
 
 export const ModelProduceResponseSchema = v.object({
-  output_files: v.pipe(v.array(OutputFileSchema), v.minLength(1))
+  output_files: v.pipe(v.array(OutputFileSchema), v.minLength(1)),
 });
 
 export const SkillMetadataSchema = v.object({
@@ -90,12 +93,12 @@ export const SkillMetadataSchema = v.object({
   description: v.pipe(v.string(), v.minLength(1)),
   contentHash: v.pipe(v.string(), v.minLength(1)),
   constructionNotes: v.optional(v.string(), ""),
-  changelog: v.optional(v.array(v.string()), [])
+  changelog: v.optional(v.array(v.string()), []),
 });
 
 export const SkillFileChangeSchema = v.object({
   path: v.pipe(v.string(), v.minLength(1)),
-  contents: v.string()
+  contents: v.string(),
 });
 
 export const GuidanceLedgerEntrySchema = v.object({
@@ -104,17 +107,17 @@ export const GuidanceLedgerEntrySchema = v.object({
   action: v.picklist(["used", "deferred", "ignored", "requested"]),
   reason: v.pipe(v.string(), v.minLength(1)),
   section: v.optional(v.pipe(v.string(), v.minLength(1))),
-  appliedTo: v.optional(v.pipe(v.string(), v.minLength(1)))
+  appliedTo: v.optional(v.pipe(v.string(), v.minLength(1))),
 });
 
 export const GuidanceLedgerSchema = v.object({
-  entries: v.optional(v.array(GuidanceLedgerEntrySchema), [])
+  entries: v.optional(v.array(GuidanceLedgerEntrySchema), []),
 });
 
 export const SkillResearchPatchSchema = v.object({
   summary: v.pipe(v.string(), v.minLength(1)),
   guidance: v.optional(v.array(v.omit(GuidanceLedgerEntrySchema, ["iteration"])), []),
-  changes: v.pipe(v.array(SkillFileChangeSchema), v.minLength(1))
+  changes: v.pipe(v.array(SkillFileChangeSchema), v.minLength(1)),
 });
 
 export type ModelProvider = v.InferOutput<typeof ModelProviderSchema>;
@@ -134,16 +137,16 @@ export type GuidanceLedgerEntry = v.InferOutput<typeof GuidanceLedgerEntrySchema
 export type GuidanceLedger = v.InferOutput<typeof GuidanceLedgerSchema>;
 export type SkillResearchPatch = v.InferOutput<typeof SkillResearchPatchSchema>;
 
-export function parseWithSchema<TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>>(
-  schema: TSchema,
-  value: unknown,
-  label: string
-): v.InferOutput<TSchema> {
+export function parseWithSchema<
+  TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+>(schema: TSchema, value: unknown, label: string): v.InferOutput<TSchema> {
   const result = v.safeParse(schema, value);
   if (result.success) {
     return result.output;
   }
 
-  const details = result.issues.map((issue) => `${issue.path?.map((p) => p.key).join(".") || label}: ${issue.message}`);
+  const details = result.issues.map(
+    (issue) => `${issue.path?.map((p) => p.key).join(".") || label}: ${issue.message}`,
+  );
   throw new Error(`Invalid ${label}: ${details.join("; ")}`);
 }

--- a/src/score.ts
+++ b/src/score.ts
@@ -4,7 +4,9 @@ export function extractScoreJson(response: string): unknown {
   try {
     return JSON.parse(response.trim());
   } catch (error) {
-    throw new Error(`Judge response was not valid JSON: ${(error as Error).message}`, { cause: error });
+    throw new Error(`Judge response was not valid JSON: ${(error as Error).message}`, {
+      cause: error,
+    });
   }
 }
 
@@ -17,13 +19,17 @@ export function parseEvalScore(response: string, evalCase: EvalCase, track: Trac
     throw new Error(`Judge score eval_id "${score.eval_id}" does not match "${evalCase.id}"`);
   }
   if (score.eval_type !== evalCase.eval_type) {
-    throw new Error(`Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`);
+    throw new Error(
+      `Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`,
+    );
   }
   if (score.track_id !== track.id) {
     throw new Error(`Judge score track_id "${score.track_id}" does not match "${track.id}"`);
   }
   if (unknown.length > 0) {
-    throw new Error(`Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`);
+    throw new Error(
+      `Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`,
+    );
   }
 
   return score;

--- a/tests/baseline-aggregate-score.test.ts
+++ b/tests/baseline-aggregate-score.test.ts
@@ -14,7 +14,10 @@ test("imports baseline artefacts and reports missing files without overwriting",
   await writeFile(join(baseline, "eval-1", "task.md"), "Task");
   await writeFile(join(baseline, "eval-1", "input", "SPEC.md"), "Input");
   await writeFile(join(baseline, "eval-1", "output", "SPEC.md"), "Output");
-  await writeFile(join(baseline, "scores-0.json"), JSON.stringify(score("eval-1", "summarise-changelog", "summarise")));
+  await writeFile(
+    join(baseline, "scores-0.json"),
+    JSON.stringify(score("eval-1", "summarise-changelog", "summarise")),
+  );
   await writeFile(join(baseline, "summary.json"), JSON.stringify({ average: 1 }));
   await writeFile(join(baseline, "summary-summarise.json"), JSON.stringify({ average: 1 }));
   await writeFile(join(baseline, "analysis-summarise.md"), "Analysis");
@@ -36,7 +39,7 @@ test("imports the real frontend-security baseline fixture", async () => {
     "eval-3",
     "eval-4",
     "eval-5",
-    "eval-6"
+    "eval-6",
   ]);
 
   expect(imported.missing).toEqual([]);
@@ -45,12 +48,12 @@ test("imports the real frontend-security baseline fixture", async () => {
     eval_id: "eval-1",
     eval_type: "detect-and-fix",
     total_score: 3,
-    max_score: 3
+    max_score: 3,
   });
   expect(imported.scores[4]).toMatchObject({
     eval_id: "eval-5",
     eval_type: "secure-author",
-    total_score: 1
+    total_score: 1,
   });
   expect(imported.summaries.summary).toMatchObject({ overall_composite: 2.25 });
   expect(imported.summaries["summary-audit"]).toMatchObject({ eval_type: "detect-and-fix" });
@@ -62,7 +65,7 @@ test("imports the real frontend-security baseline fixture", async () => {
 test("aggregates arbitrary configured tracks", () => {
   const report = aggregateScores(securityConfig, [
     score("xss-001", "detect-and-fix", "audit", 2, 2),
-    score("author-001", "secure-author", "authoring", 2, 3)
+    score("author-001", "secure-author", "authoring", 2, 3),
   ]);
 
   expect(report.tracks.map((track) => track.trackId)).toEqual(["audit", "authoring"]);
@@ -79,12 +82,14 @@ test("parses judge score JSON and rejects unknown dimensions", () => {
     total_score: 2,
     max_score: 2,
     dimensions: [{ id: "finding", score: 2, max_score: 2, rationale: "Found it" }],
-    summary: "Pass"
+    summary: "Pass",
   });
 
   expect(parseEvalScore(response, evalCase, track).total_score).toBe(2);
 
   const bad = response.replace("finding", "unknown");
   expect(() => parseEvalScore(bad, evalCase, track)).toThrow(/unknown dimensions/);
-  expect(() => parseEvalScore(`\`\`\`json\n${response}\n\`\`\``, evalCase, track)).toThrow(/not valid JSON/);
+  expect(() => parseEvalScore(`\`\`\`json\n${response}\n\`\`\``, evalCase, track)).toThrow(
+    /not valid JSON/,
+  );
 });

--- a/tests/baseline-aggregate-score.test.ts
+++ b/tests/baseline-aggregate-score.test.ts
@@ -14,10 +14,7 @@ test("imports baseline artefacts and reports missing files without overwriting",
   await writeFile(join(baseline, "eval-1", "task.md"), "Task");
   await writeFile(join(baseline, "eval-1", "input", "SPEC.md"), "Input");
   await writeFile(join(baseline, "eval-1", "output", "SPEC.md"), "Output");
-  await writeFile(
-    join(baseline, "scores-0.json"),
-    JSON.stringify(score("eval-1", "summarise-changelog", "summarise")),
-  );
+  await writeFile(join(baseline, "scores-0.json"), JSON.stringify(score("eval-1", "summarise-changelog", "summarise")));
   await writeFile(join(baseline, "summary.json"), JSON.stringify({ average: 1 }));
   await writeFile(join(baseline, "summary-summarise.json"), JSON.stringify({ average: 1 }));
   await writeFile(join(baseline, "analysis-summarise.md"), "Analysis");
@@ -39,7 +36,7 @@ test("imports the real frontend-security baseline fixture", async () => {
     "eval-3",
     "eval-4",
     "eval-5",
-    "eval-6",
+    "eval-6"
   ]);
 
   expect(imported.missing).toEqual([]);
@@ -48,12 +45,12 @@ test("imports the real frontend-security baseline fixture", async () => {
     eval_id: "eval-1",
     eval_type: "detect-and-fix",
     total_score: 3,
-    max_score: 3,
+    max_score: 3
   });
   expect(imported.scores[4]).toMatchObject({
     eval_id: "eval-5",
     eval_type: "secure-author",
-    total_score: 1,
+    total_score: 1
   });
   expect(imported.summaries.summary).toMatchObject({ overall_composite: 2.25 });
   expect(imported.summaries["summary-audit"]).toMatchObject({ eval_type: "detect-and-fix" });
@@ -65,11 +62,26 @@ test("imports the real frontend-security baseline fixture", async () => {
 test("aggregates arbitrary configured tracks", () => {
   const report = aggregateScores(securityConfig, [
     score("xss-001", "detect-and-fix", "audit", 2, 2),
-    score("author-001", "secure-author", "authoring", 2, 3),
+    score("author-001", "secure-author", "authoring", 2, 3)
   ]);
 
   expect(report.tracks.map((track) => track.trackId)).toEqual(["audit", "authoring"]);
   expect(report.overall.normalizedScore).toBe(0.8);
+});
+
+test("aggregates by track id before falling back to eval type", () => {
+  const report = aggregateScores(securityConfig, [
+    score("audit-001", "detect-and-fix", "audit", 2, 2),
+    score("legacy-001", "detect-and-fix", undefined as unknown as string, 1, 2),
+    score("other-001", "detect-and-fix", "other", 2, 2)
+  ]);
+
+  expect(report.tracks.find((track) => track.trackId === "audit")).toMatchObject({
+    score: 3,
+    maxScore: 4,
+    evalCount: 2
+  });
+  expect(report.overall.evalCount).toBe(2);
 });
 
 test("parses judge score JSON and rejects unknown dimensions", () => {
@@ -82,14 +94,12 @@ test("parses judge score JSON and rejects unknown dimensions", () => {
     total_score: 2,
     max_score: 2,
     dimensions: [{ id: "finding", score: 2, max_score: 2, rationale: "Found it" }],
-    summary: "Pass",
+    summary: "Pass"
   });
 
   expect(parseEvalScore(response, evalCase, track).total_score).toBe(2);
 
   const bad = response.replace("finding", "unknown");
   expect(() => parseEvalScore(bad, evalCase, track)).toThrow(/unknown dimensions/);
-  expect(() => parseEvalScore(`\`\`\`json\n${response}\n\`\`\``, evalCase, track)).toThrow(
-    /not valid JSON/,
-  );
+  expect(() => parseEvalScore(`\`\`\`json\n${response}\n\`\`\``, evalCase, track)).toThrow(/not valid JSON/);
 });

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -9,26 +9,32 @@ test("parseCliArgs validates currently required adapters", () => {
   expect(parseCliArgs(["--project", "/tmp/project", "--with-baseline"])).toMatchObject({
     projectRoot: "/tmp/project",
     withBaseline: true,
-    runResearch: false
+    runResearch: false,
   });
-  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--seed-skill", "/tmp/skill"])).toMatchObject({
+  expect(
+    parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--seed-skill", "/tmp/skill"]),
+  ).toMatchObject({
     scoreDir: "/tmp/scores",
     runResearch: true,
-    seedSkillDir: "/tmp/skill"
+    seedSkillDir: "/tmp/skill",
   });
   expect(parseCliArgs(["--model-client", "anthropic", "--research"])).toMatchObject({
     modelClient: "anthropic",
-    runResearch: true
+    runResearch: true,
   });
-  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--force-research"])).toMatchObject({
+  expect(
+    parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--force-research"]),
+  ).toMatchObject({
     forceResearch: true,
-    runResearch: true
+    runResearch: true,
   });
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
-    /Research iterations require --score-dir or --model-client/
+    /Research iterations require --score-dir or --model-client/,
   );
-  expect(() => parseCliArgs(["--score-dir", "/tmp/scores", "--model-client", "anthropic"])).toThrow(/either/);
+  expect(() => parseCliArgs(["--score-dir", "/tmp/scores", "--model-client", "anthropic"])).toThrow(
+    /either/,
+  );
   expect(() => parseCliArgs(["--model-client", "unknown"])).toThrow(/Unsupported model client/);
   expect(() => parseCliArgs(["--project"])).toThrow(/argument missing/);
 });
@@ -37,7 +43,10 @@ test("FileScoreAgent returns eval scores from explicit files", async () => {
   const root = await tempProject();
   const scoreDir = join(root, "scores");
   await mkdir(scoreDir, { recursive: true });
-  await writeFile(join(scoreDir, "xss-001.json"), JSON.stringify(score("xss-001", "detect-and-fix", "audit", 2, 2)));
+  await writeFile(
+    join(scoreDir, "xss-001.json"),
+    JSON.stringify(score("xss-001", "detect-and-fix", "audit", 2, 2)),
+  );
 
   const evalCase = securityEvals.evals[0];
   const agent = new FileScoreAgent({ scoreDir });
@@ -46,7 +55,7 @@ test("FileScoreAgent returns eval scores from explicit files", async () => {
     track: trackForEval(securityConfig, evalCase.eval_type),
     role: "security-auditor",
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
-    sandbox: {} as never
+    sandbox: {} as never,
   });
 
   expect(result.total_score).toBe(2);
@@ -73,13 +82,13 @@ test("SnapshotResearcher copies the previous skill and writes iteration metadata
         score: 0,
         maxScore: 1,
         normalizedScore: syntheticConfig.target_score,
-        evalCount: 0
-      }
-    }
+        evalCount: 0,
+      },
+    },
   });
 
   await expect(readFile(join(candidateSkillDir, "SKILL.md"), "utf8")).resolves.toBe("# Skill\n");
-  await expect(readFile(join(candidateSkillDir, ".autoresearch-iteration.json"), "utf8")).resolves.toContain(
-    "previousNormalizedScore"
-  );
+  await expect(
+    readFile(join(candidateSkillDir, ".autoresearch-iteration.json"), "utf8"),
+  ).resolves.toContain("previousNormalizedScore");
 });

--- a/tests/e2e-dry-run.test.ts
+++ b/tests/e2e-dry-run.test.ts
@@ -1,6 +1,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { ModelClient, ModelEvalAgent, ModelRequest, ModelSkillResearcher } from "../src/model-agent.js";
+import {
+  ModelClient,
+  ModelEvalAgent,
+  ModelRequest,
+  ModelSkillResearcher,
+} from "../src/model-agent.js";
 import { orchestrateBaseline } from "../src/orchestrator.js";
 import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } from "./helpers.js";
 
@@ -24,18 +29,21 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
   const config = {
     ...syntheticConfig,
     target_score: 0.8,
-    max_iterations: 1
+    max_iterations: 1,
   };
   await writeFixture(root, config, syntheticEvals);
 
   const seedSkillDir = join(root, "seed-skill");
   await mkdir(seedSkillDir, { recursive: true });
-  await writeFile(join(seedSkillDir, "SKILL.md"), "# Release Summary\n\nSummarise changes briefly.\n");
+  await writeFile(
+    join(seedSkillDir, "SKILL.md"),
+    "# Release Summary\n\nSummarise changes briefly.\n",
+  );
 
   const evalCase = syntheticEvals.evals[0];
   const client = new QueueModelClient([
     JSON.stringify({
-      output_files: [{ path: "RESULT.md", contents: "Baseline summary was too thin.\n" }]
+      output_files: [{ path: "RESULT.md", contents: "Baseline summary was too thin.\n" }],
     }),
     JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.4)),
     JSON.stringify({
@@ -43,14 +51,17 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
       changes: [
         {
           path: "SKILL.md",
-          contents: "# Release Summary\n\nSummarise changes with concrete user-facing impact and risk notes.\n"
-        }
-      ]
+          contents:
+            "# Release Summary\n\nSummarise changes with concrete user-facing impact and risk notes.\n",
+        },
+      ],
     }),
     JSON.stringify({
-      output_files: [{ path: "RESULT.md", contents: "Improved summary with impact and risk notes.\n" }]
+      output_files: [
+        { path: "RESULT.md", contents: "Improved summary with impact and risk notes.\n" },
+      ],
     }),
-    JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.9))
+    JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.9)),
   ]);
 
   const result = await orchestrateBaseline({
@@ -58,7 +69,7 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
     agent: new ModelEvalAgent(client),
     researcher: new ModelSkillResearcher(client),
     runResearch: true,
-    seedSkillDir
+    seedSkillDir,
   });
 
   expect(result.completedIterations).toBe(1);
@@ -69,19 +80,25 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
     "judge",
     "skill-builder",
     "task-producer",
-    "judge"
+    "judge",
   ]);
 
-  await expect(readFile(join(root, "workspace", "baseline", evalCase.id, "RESULT.md"), "utf8")).resolves.toBe(
-    "Baseline summary was too thin.\n"
-  );
-  await expect(readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8")).resolves.toContain(
-    "concrete user-facing impact"
-  );
   await expect(
-    readFile(join(root, "workspace", "iterations", "1", "outputs", evalCase.id, "RESULT.md"), "utf8")
+    readFile(join(root, "workspace", "baseline", evalCase.id, "RESULT.md"), "utf8"),
+  ).resolves.toBe("Baseline summary was too thin.\n");
+  await expect(
+    readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8"),
+  ).resolves.toContain("concrete user-facing impact");
+  await expect(
+    readFile(
+      join(root, "workspace", "iterations", "1", "outputs", evalCase.id, "RESULT.md"),
+      "utf8",
+    ),
   ).resolves.toBe("Improved summary with impact and risk notes.\n");
   await expect(
-    readFile(join(root, "workspace", "iterations", "1", "skill", ".autoresearch-transcript.json"), "utf8")
+    readFile(
+      join(root, "workspace", "iterations", "1", "skill", ".autoresearch-transcript.json"),
+      "utf8",
+    ),
   ).resolves.toContain("Add concrete output guidance");
 });

--- a/tests/flue-harness.test.ts
+++ b/tests/flue-harness.test.ts
@@ -8,21 +8,17 @@ import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } fro
 
 class MockFlueSession {
   readonly id = "mock";
-  tasks: Array<{ text: string; result: unknown; agent?: string; model?: string; cwd?: string }> =
-    [];
+  tasks: Array<{ text: string; result: unknown; agent?: string; model?: string; cwd?: string }> = [];
 
   constructor(private readonly responses: unknown[]) {}
 
-  async task(
-    text: string,
-    options?: { result?: unknown; agent?: string; model?: string; cwd?: string },
-  ) {
+  async task(text: string, options?: { result?: unknown; agent?: string; model?: string; cwd?: string }) {
     this.tasks.push({
       text,
       result: options?.result,
       agent: options?.agent,
       model: options?.model,
-      cwd: options?.cwd,
+      cwd: options?.cwd
     });
     const response = this.responses.shift();
     if (!response) {
@@ -38,16 +34,16 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
   const evalCase = syntheticEvals.evals[0];
   const session = new MockFlueSession([
     {
-      output_files: [{ path: "RESULT.md", contents: "Flue output\n" }],
+      output_files: [{ path: "RESULT.md", contents: "Flue output\n" }]
     },
-    score(evalCase.id, evalCase.eval_type, "summarise", 1),
+    score(evalCase.id, evalCase.eval_type, "summarise", 1)
   ]) as unknown as FlueSession;
   const sandbox = createEvalSandbox({
     evalId: evalCase.id,
     inputDir: join(root, "input"),
     referenceDir: join(root, "reference"),
     evalsDir: join(root, "evals"),
-    outputDir: join(root, "out"),
+    outputDir: join(root, "out")
   });
 
   const result = await new FlueEvalAgent(session).run({
@@ -58,47 +54,37 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: {
       producer: { provider: "anthropic", name: "claude-haiku-4-5" },
-      judge: { provider: "anthropic", name: "claude-sonnet-4-6" },
+      judge: { provider: "anthropic", name: "claude-sonnet-4-6" }
     },
-    sandbox,
+    sandbox
   });
 
   expect(result.total_score).toBe(1);
   expect((session as any).tasks.map((task: any) => task.model)).toEqual([
     "anthropic/claude-haiku-4-5",
-    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-sonnet-4-6"
   ]);
   expect((session as any).tasks.map((task: any) => task.agent)).toEqual(["producer", "judge"]);
   expect((session as any).tasks[0].text).not.toContain("Role instructions:");
   expect((session as any).tasks[0].text).toContain("Producer role: task-producer");
   expect((session as any).tasks[1].text).not.toContain("Role instructions:");
   expect((session as any).tasks[1].text).toContain("Judge role: eval-judge");
-  expect((session as any).tasks[0].cwd).toContain(
-    join(sandbox.outputDir, ".phase-workspaces", "producer"),
-  );
-  expect((session as any).tasks[1].cwd).toContain(
-    join(sandbox.outputDir, ".phase-workspaces", "judge"),
-  );
-  expect((session as any).tasks[1].text).toContain(
-    "Available paths: ./evals, ./reference, ./output.",
-  );
+  expect((session as any).tasks[0].cwd).toContain(join(sandbox.outputDir, ".phase-workspaces", "producer"));
+  expect((session as any).tasks[1].cwd).toContain(join(sandbox.outputDir, ".phase-workspaces", "judge"));
+  expect((session as any).tasks[1].text).toContain("Available paths: ./evals, ./reference, ./output.");
   expect((session as any).tasks[1].text).not.toContain("release-notes-alpha");
   await expect(
-    readFile(join(sandbox.outputDir, ".phase-workspaces", "judge", "output", "RESULT.md"), "utf8"),
+    readFile(join(sandbox.outputDir, ".phase-workspaces", "judge", "output", "RESULT.md"), "utf8")
   ).resolves.toBe("Flue output\n");
-  await expect(
-    stat(join(sandbox.outputDir, ".phase-workspaces", "judge", "skill")),
-  ).rejects.toMatchObject({
-    code: "ENOENT",
+  await expect(stat(join(sandbox.outputDir, ".phase-workspaces", "judge", "skill"))).rejects.toMatchObject({
+    code: "ENOENT"
   });
-  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe(
-    "Flue output\n",
-  );
+  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Flue output\n");
 });
 
 test("runFlueAutoresearch executes the dry run through detached Flue tasks", async () => {
   const root = await tempProject();
-  const config = { ...syntheticConfig, target_score: 0.8, max_iterations: 1 };
+  const config = { ...syntheticConfig, target_score: 0.8, max_iterations: 2 };
   await writeFixture(root, config, syntheticEvals);
   const seedSkillDir = join(root, "seed-skill");
   await mkdir(seedSkillDir, { recursive: true });
@@ -106,37 +92,48 @@ test("runFlueAutoresearch executes the dry run through detached Flue tasks", asy
   const evalCase = syntheticEvals.evals[0];
   const session = new MockFlueSession([
     {
-      output_files: [{ path: "RESULT.md", contents: "Baseline\n" }],
+      output_files: [{ path: "RESULT.md", contents: "Baseline\n" }]
     },
     score(evalCase.id, evalCase.eval_type, "summarise", 0.4),
     {
       summary: "Improve skill",
-      changes: [{ path: "SKILL.md", contents: "# Improved\n" }],
+      changes: [{ path: "SKILL.md", contents: "# Improved 1\n" }]
     },
     {
-      output_files: [{ path: "RESULT.md", contents: "Iteration\n" }],
+      output_files: [{ path: "RESULT.md", contents: "Iteration\n" }]
     },
-    score(evalCase.id, evalCase.eval_type, "summarise", 0.9),
+    score(evalCase.id, evalCase.eval_type, "summarise", 0.5),
+    {
+      summary: "Improve skill again",
+      changes: [{ path: "SKILL.md", contents: "# Improved 2\n" }]
+    },
+    {
+      output_files: [{ path: "RESULT.md", contents: "Iteration 2\n" }]
+    },
+    score(evalCase.id, evalCase.eval_type, "summarise", 0.9)
   ]) as unknown as MockFlueSession;
 
   const result = await runFlueAutoresearch({
     session: session as unknown as FlueSession,
     projectRoot: root,
     runResearch: true,
-    seedSkillDir,
+    seedSkillDir
   });
 
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
-  expect(session.tasks).toHaveLength(5);
+  expect(session.tasks).toHaveLength(8);
   expect(session.tasks.map((task) => task.agent)).toEqual([
     "producer",
     "judge",
     "researcher",
     "producer",
     "judge",
+    "researcher",
+    "producer",
+    "judge"
   ]);
   expect(session.tasks.every((task) => task.result)).toBe(true);
-  await expect(
-    readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8"),
-  ).resolves.toBe("# Improved\n");
+  await expect(readFile(join(root, "workspace", "iterations", "2", "skill", "SKILL.md"), "utf8")).resolves.toBe(
+    "# Improved 2\n"
+  );
 });

--- a/tests/flue-harness.test.ts
+++ b/tests/flue-harness.test.ts
@@ -8,12 +8,22 @@ import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } fro
 
 class MockFlueSession {
   readonly id = "mock";
-  tasks: Array<{ text: string; schema: unknown; model?: string; role?: string; cwd?: string }> = [];
+  tasks: Array<{ text: string; result: unknown; agent?: string; model?: string; cwd?: string }> =
+    [];
 
   constructor(private readonly responses: unknown[]) {}
 
-  async task(text: string, options?: { schema?: unknown; model?: string; role?: string; cwd?: string }) {
-    this.tasks.push({ text, schema: options?.schema, model: options?.model, role: options?.role, cwd: options?.cwd });
+  async task(
+    text: string,
+    options?: { result?: unknown; agent?: string; model?: string; cwd?: string },
+  ) {
+    this.tasks.push({
+      text,
+      result: options?.result,
+      agent: options?.agent,
+      model: options?.model,
+      cwd: options?.cwd,
+    });
     const response = this.responses.shift();
     if (!response) {
       throw new Error("No queued Flue response");
@@ -28,16 +38,16 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
   const evalCase = syntheticEvals.evals[0];
   const session = new MockFlueSession([
     {
-      output_files: [{ path: "RESULT.md", contents: "Flue output\n" }]
+      output_files: [{ path: "RESULT.md", contents: "Flue output\n" }],
     },
-    score(evalCase.id, evalCase.eval_type, "summarise", 1)
+    score(evalCase.id, evalCase.eval_type, "summarise", 1),
   ]) as unknown as FlueSession;
   const sandbox = createEvalSandbox({
     evalId: evalCase.id,
     inputDir: join(root, "input"),
     referenceDir: join(root, "reference"),
     evalsDir: join(root, "evals"),
-    outputDir: join(root, "out")
+    outputDir: join(root, "out"),
   });
 
   const result = await new FlueEvalAgent(session).run({
@@ -48,29 +58,42 @@ test("FlueEvalAgent uses session structured output and writes eval artifacts", a
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: {
       producer: { provider: "anthropic", name: "claude-haiku-4-5" },
-      judge: { provider: "anthropic", name: "claude-sonnet-4-6" }
+      judge: { provider: "anthropic", name: "claude-sonnet-4-6" },
     },
-    sandbox
+    sandbox,
   });
 
   expect(result.total_score).toBe(1);
   expect((session as any).tasks.map((task: any) => task.model)).toEqual([
     "anthropic/claude-haiku-4-5",
-    "anthropic/claude-sonnet-4-6"
+    "anthropic/claude-sonnet-4-6",
   ]);
-  expect((session as any).tasks[0].role).toBe("task-producer");
-  expect((session as any).tasks[1].role).toBe("eval-judge");
-  expect((session as any).tasks[0].cwd).toContain(join(sandbox.outputDir, ".phase-workspaces", "producer"));
-  expect((session as any).tasks[1].cwd).toContain(join(sandbox.outputDir, ".phase-workspaces", "judge"));
-  expect((session as any).tasks[1].text).toContain("Available paths: ./evals, ./reference, ./output.");
+  expect((session as any).tasks.map((task: any) => task.agent)).toEqual(["producer", "judge"]);
+  expect((session as any).tasks[0].text).not.toContain("Role instructions:");
+  expect((session as any).tasks[0].text).toContain("Producer role: task-producer");
+  expect((session as any).tasks[1].text).not.toContain("Role instructions:");
+  expect((session as any).tasks[1].text).toContain("Judge role: eval-judge");
+  expect((session as any).tasks[0].cwd).toContain(
+    join(sandbox.outputDir, ".phase-workspaces", "producer"),
+  );
+  expect((session as any).tasks[1].cwd).toContain(
+    join(sandbox.outputDir, ".phase-workspaces", "judge"),
+  );
+  expect((session as any).tasks[1].text).toContain(
+    "Available paths: ./evals, ./reference, ./output.",
+  );
   expect((session as any).tasks[1].text).not.toContain("release-notes-alpha");
   await expect(
-    readFile(join(sandbox.outputDir, ".phase-workspaces", "judge", "output", "RESULT.md"), "utf8")
+    readFile(join(sandbox.outputDir, ".phase-workspaces", "judge", "output", "RESULT.md"), "utf8"),
   ).resolves.toBe("Flue output\n");
-  await expect(stat(join(sandbox.outputDir, ".phase-workspaces", "judge", "skill"))).rejects.toMatchObject({
-    code: "ENOENT"
+  await expect(
+    stat(join(sandbox.outputDir, ".phase-workspaces", "judge", "skill")),
+  ).rejects.toMatchObject({
+    code: "ENOENT",
   });
-  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Flue output\n");
+  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe(
+    "Flue output\n",
+  );
 });
 
 test("runFlueAutoresearch executes the dry run through detached Flue tasks", async () => {
@@ -83,30 +106,37 @@ test("runFlueAutoresearch executes the dry run through detached Flue tasks", asy
   const evalCase = syntheticEvals.evals[0];
   const session = new MockFlueSession([
     {
-      output_files: [{ path: "RESULT.md", contents: "Baseline\n" }]
+      output_files: [{ path: "RESULT.md", contents: "Baseline\n" }],
     },
     score(evalCase.id, evalCase.eval_type, "summarise", 0.4),
     {
       summary: "Improve skill",
-      changes: [{ path: "SKILL.md", contents: "# Improved\n" }]
+      changes: [{ path: "SKILL.md", contents: "# Improved\n" }],
     },
     {
-      output_files: [{ path: "RESULT.md", contents: "Iteration\n" }]
+      output_files: [{ path: "RESULT.md", contents: "Iteration\n" }],
     },
-    score(evalCase.id, evalCase.eval_type, "summarise", 0.9)
+    score(evalCase.id, evalCase.eval_type, "summarise", 0.9),
   ]) as unknown as MockFlueSession;
 
   const result = await runFlueAutoresearch({
     session: session as unknown as FlueSession,
     projectRoot: root,
     runResearch: true,
-    seedSkillDir
+    seedSkillDir,
   });
 
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
   expect(session.tasks).toHaveLength(5);
-  expect(session.tasks.every((task) => task.schema)).toBe(true);
-  await expect(readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8")).resolves.toBe(
-    "# Improved\n"
-  );
+  expect(session.tasks.map((task) => task.agent)).toEqual([
+    "producer",
+    "judge",
+    "researcher",
+    "producer",
+    "judge",
+  ]);
+  expect(session.tasks.every((task) => task.result)).toBe(true);
+  await expect(
+    readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8"),
+  ).resolves.toBe("# Improved\n");
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,7 +14,10 @@ export async function writeFixture(root: string, config: unknown, evals: unknown
   await mkdir(join(root, "input"), { recursive: true });
   await writeFile(join(root, "config.json"), `${JSON.stringify(config, null, 2)}\n`);
   await writeFile(join(root, "evals", "eval-cases.json"), `${JSON.stringify(evals, null, 2)}\n`);
-  await writeFile(join(root, "evals", "rubric.md"), "# Rubric\n\nScore the configured dimensions.\n");
+  await writeFile(
+    join(root, "evals", "rubric.md"),
+    "# Rubric\n\nScore the configured dimensions.\n",
+  );
   await writeFile(join(root, "reference", "context.md"), "Reference material\n");
 }
 
@@ -27,11 +30,11 @@ export const securityConfig = {
   max_concurrency: 2,
   model: {
     provider: "anthropic",
-    name: "claude-sonnet-4-6"
+    name: "claude-sonnet-4-6",
   },
   roles: {
     judge: "judge",
-    skill_builder: "skill-builder"
+    skill_builder: "skill-builder",
   },
   tracks: [
     {
@@ -39,16 +42,16 @@ export const securityConfig = {
       eval_type: "detect-and-fix",
       role: "security-auditor",
       target_skill: "security-audit",
-      requires_description: false
+      requires_description: false,
     },
     {
       id: "authoring",
       eval_type: "secure-author",
       role: "secure-author",
       target_skill: "secure-authoring",
-      requires_description: true
-    }
-  ]
+      requires_description: true,
+    },
+  ],
 } satisfies ProjectConfig;
 
 export const syntheticConfig = {
@@ -59,7 +62,7 @@ export const syntheticConfig = {
   max_concurrency: 1,
   roles: {
     judge: "judge",
-    skill_builder: "skill-builder"
+    skill_builder: "skill-builder",
   },
   tracks: [
     {
@@ -67,9 +70,9 @@ export const syntheticConfig = {
       eval_type: "summarise-changelog",
       role: "task-producer",
       target_skill: "release-summary",
-      requires_description: false
-    }
-  ]
+      requires_description: false,
+    },
+  ],
 } satisfies ProjectConfig;
 
 export const securityEvals = {
@@ -80,7 +83,7 @@ export const securityEvals = {
       title: "Detect reflected XSS",
       input: {},
       expectations: {},
-      scoring_dimensions: [{ id: "finding", label: "Finding", max_score: 2 }]
+      scoring_dimensions: [{ id: "finding", label: "Finding", max_score: 2 }],
     },
     {
       id: "author-001",
@@ -88,9 +91,9 @@ export const securityEvals = {
       title: "Author safe DOM code",
       input: {},
       expectations: {},
-      scoring_dimensions: [{ id: "safety", label: "Safety", max_score: 3 }]
-    }
-  ]
+      scoring_dimensions: [{ id: "safety", label: "Safety", max_score: 3 }],
+    },
+  ],
 };
 
 export const syntheticEvals = {
@@ -101,12 +104,18 @@ export const syntheticEvals = {
       title: "Summarise changes",
       input: {},
       expectations: {},
-      scoring_dimensions: [{ id: "clarity", label: "Clarity", max_score: 1 }]
-    }
-  ]
+      scoring_dimensions: [{ id: "clarity", label: "Clarity", max_score: 1 }],
+    },
+  ],
 };
 
-export function score(eval_id: string, eval_type: string, track_id: string, total_score = 1, max_score = 1): EvalScore {
+export function score(
+  eval_id: string,
+  eval_type: string,
+  track_id: string,
+  total_score = 1,
+  max_score = 1,
+): EvalScore {
   return {
     eval_id,
     eval_type,
@@ -114,6 +123,6 @@ export function score(eval_id: string, eval_type: string, track_id: string, tota
     total_score,
     max_score,
     dimensions: [{ id: "clarity", score: total_score, max_score, rationale: "Clear" }],
-    summary: "Good"
+    summary: "Good",
   };
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,10 +14,7 @@ export async function writeFixture(root: string, config: unknown, evals: unknown
   await mkdir(join(root, "input"), { recursive: true });
   await writeFile(join(root, "config.json"), `${JSON.stringify(config, null, 2)}\n`);
   await writeFile(join(root, "evals", "eval-cases.json"), `${JSON.stringify(evals, null, 2)}\n`);
-  await writeFile(
-    join(root, "evals", "rubric.md"),
-    "# Rubric\n\nScore the configured dimensions.\n",
-  );
+  await writeFile(join(root, "evals", "rubric.md"), "# Rubric\n\nScore the configured dimensions.\n");
   await writeFile(join(root, "reference", "context.md"), "Reference material\n");
 }
 
@@ -30,11 +27,11 @@ export const securityConfig = {
   max_concurrency: 2,
   model: {
     provider: "anthropic",
-    name: "claude-sonnet-4-6",
+    name: "claude-sonnet-4-6"
   },
   roles: {
     judge: "judge",
-    skill_builder: "skill-builder",
+    skill_builder: "skill-builder"
   },
   tracks: [
     {
@@ -42,16 +39,16 @@ export const securityConfig = {
       eval_type: "detect-and-fix",
       role: "security-auditor",
       target_skill: "security-audit",
-      requires_description: false,
+      requires_description: false
     },
     {
       id: "authoring",
       eval_type: "secure-author",
       role: "secure-author",
       target_skill: "secure-authoring",
-      requires_description: true,
-    },
-  ],
+      requires_description: true
+    }
+  ]
 } satisfies ProjectConfig;
 
 export const syntheticConfig = {
@@ -62,7 +59,7 @@ export const syntheticConfig = {
   max_concurrency: 1,
   roles: {
     judge: "judge",
-    skill_builder: "skill-builder",
+    skill_builder: "skill-builder"
   },
   tracks: [
     {
@@ -70,9 +67,9 @@ export const syntheticConfig = {
       eval_type: "summarise-changelog",
       role: "task-producer",
       target_skill: "release-summary",
-      requires_description: false,
-    },
-  ],
+      requires_description: false
+    }
+  ]
 } satisfies ProjectConfig;
 
 export const securityEvals = {
@@ -83,7 +80,7 @@ export const securityEvals = {
       title: "Detect reflected XSS",
       input: {},
       expectations: {},
-      scoring_dimensions: [{ id: "finding", label: "Finding", max_score: 2 }],
+      scoring_dimensions: [{ id: "finding", label: "Finding", max_score: 2 }]
     },
     {
       id: "author-001",
@@ -91,9 +88,9 @@ export const securityEvals = {
       title: "Author safe DOM code",
       input: {},
       expectations: {},
-      scoring_dimensions: [{ id: "safety", label: "Safety", max_score: 3 }],
-    },
-  ],
+      scoring_dimensions: [{ id: "safety", label: "Safety", max_score: 3 }]
+    }
+  ]
 };
 
 export const syntheticEvals = {
@@ -104,9 +101,9 @@ export const syntheticEvals = {
       title: "Summarise changes",
       input: {},
       expectations: {},
-      scoring_dimensions: [{ id: "clarity", label: "Clarity", max_score: 1 }],
-    },
-  ],
+      scoring_dimensions: [{ id: "clarity", label: "Clarity", max_score: 1 }]
+    }
+  ]
 };
 
 export function score(
@@ -115,6 +112,7 @@ export function score(
   track_id: string,
   total_score = 1,
   max_score = 1,
+  dimensionId = defaultDimensionId(eval_type)
 ): EvalScore {
   return {
     eval_id,
@@ -122,7 +120,17 @@ export function score(
     track_id,
     total_score,
     max_score,
-    dimensions: [{ id: "clarity", score: total_score, max_score, rationale: "Clear" }],
-    summary: "Good",
+    dimensions: [{ id: dimensionId, score: total_score, max_score, rationale: "Clear" }],
+    summary: "Good"
   };
+}
+
+function defaultDimensionId(evalType: string): string {
+  if (evalType === "detect-and-fix") {
+    return "finding";
+  }
+  if (evalType === "secure-author") {
+    return "safety";
+  }
+  return "clarity";
 }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -15,7 +15,7 @@ function sink() {
     },
     error(message) {
       calls.push({ level: "error", message });
-    }
+    },
   };
   return { calls, target };
 }
@@ -33,7 +33,7 @@ test("createLogger routes messages by constant log level", () => {
     { level: "log", message: "info" },
     { level: "warn", message: "careful" },
     { level: "debug", message: "trace" },
-    { level: "error", message: "broken" }
+    { level: "error", message: "broken" },
   ]);
 });
 
@@ -44,14 +44,14 @@ test("writeEvents uses the severity returned by formatEvent", () => {
   writeEvents(
     [
       { type: "project-loaded", root: "/tmp/project" },
-      { type: "max-iterations-reached", completedIterations: 3, maxIterations: 3 }
+      { type: "max-iterations-reached", completedIterations: 3, maxIterations: 3 },
     ],
-    logger
+    logger,
   );
 
   expect(calls).toEqual([
     { level: "debug", message: "Loaded project: /tmp/project" },
-    { level: "warn", message: "Max iterations reached: 3/3" }
+    { level: "warn", message: "Max iterations reached: 3/3" },
   ]);
 });
 
@@ -61,8 +61,8 @@ test("formatEvent classifies target completion as a regular log", () => {
       type: "target-score-reached",
       iteration: 2,
       normalizedScore: 0.9,
-      targetScore: 0.8
-    })
+      targetScore: 0.8,
+    }),
   ).toEqual({ level: "log", message: "Target reached at iteration 2: 0.900" });
 });
 
@@ -71,7 +71,7 @@ test("formatEvent explains baseline target completion", () => {
     formatEvent({
       type: "baseline-target-score-reached",
       normalizedScore: 0.95,
-      targetScore: 0.8
-    })
+      targetScore: 0.8,
+    }),
   ).toEqual({ level: "log", message: "Baseline reached target: 0.950 >= 0.800" });
 });

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -12,7 +12,7 @@ import {
   ModelRequest,
   parseModelProduceResponse,
   readGuidanceLedger,
-  parseSkillResearchPatch
+  parseSkillResearchPatch,
 } from "../src/model-agent.js";
 import { createEvalSandbox } from "../src/sandbox.js";
 import { trackForEval } from "../src/project.js";
@@ -60,8 +60,8 @@ test("buildProduceModelRequest includes eval, mounted files, and target skill co
       referenceDir: join(root, "reference"),
       evalsDir: join(root, "evals"),
       outputDir,
-      skillDir
-    })
+      skillDir,
+    }),
   });
 
   expect(request.system).toBe("task-producer");
@@ -80,9 +80,9 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
   const evalScore = score(evalCase.id, evalCase.eval_type, "summarise");
   const client = new MemoryModelClient(
     JSON.stringify({
-      output_files: [{ path: "RESULT.md", contents: "Summarised changes\n" }]
+      output_files: [{ path: "RESULT.md", contents: "Summarised changes\n" }],
     }),
-    JSON.stringify(evalScore)
+    JSON.stringify(evalScore),
   );
   const agent = new ModelEvalAgent(client);
   const sandbox = createEvalSandbox({
@@ -90,7 +90,7 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
     inputDir: join(root, "input"),
     referenceDir: join(root, "reference"),
     evalsDir: join(root, "evals"),
-    outputDir: join(root, "out")
+    outputDir: join(root, "out"),
   });
 
   const result = await agent.run({
@@ -101,27 +101,34 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: {
       producer: { provider: "anthropic", name: "claude-haiku-4-5" },
-      judge: { provider: "anthropic", name: "claude-sonnet-4-6" }
+      judge: { provider: "anthropic", name: "claude-sonnet-4-6" },
     },
-    sandbox
+    sandbox,
   });
 
   expect(result.eval_id).toBe(evalCase.id);
-  expect(client.requests.map((request) => request.model.name)).toEqual(["claude-haiku-4-5", "claude-sonnet-4-6"]);
-  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Summarised changes\n");
-  await expect(readFile(join(sandbox.outputDir, "producer-transcript.json"), "utf8")).resolves.toContain(
-    "task-producer"
+  expect(client.requests.map((request) => request.model.name)).toEqual([
+    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+  ]);
+  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe(
+    "Summarised changes\n",
   );
-  await expect(readFile(join(sandbox.outputDir, "judge-transcript.json"), "utf8")).resolves.toContain("eval-judge");
+  await expect(
+    readFile(join(sandbox.outputDir, "producer-transcript.json"), "utf8"),
+  ).resolves.toContain("task-producer");
+  await expect(
+    readFile(join(sandbox.outputDir, "judge-transcript.json"), "utf8"),
+  ).resolves.toContain("eval-judge");
 });
 
 test("parseModelProduceResponse requires output files and output writes reject unsafe paths", async () => {
   expect(() => parseModelProduceResponse(JSON.stringify({ output_files: [] }))).toThrow(
-    /Invalid model producer response/
+    /Invalid model producer response/,
   );
-  await expect(applyOutputFiles("/tmp/output", [{ path: "../escape.md", contents: "bad" }])).rejects.toThrow(
-    /escapes target directory/
-  );
+  await expect(
+    applyOutputFiles("/tmp/output", [{ path: "../escape.md", contents: "bad" }]),
+  ).rejects.toThrow(/escapes target directory/);
 });
 
 test("buildJudgeModelRequest scores only producer output with judge model", async () => {
@@ -141,10 +148,10 @@ test("buildJudgeModelRequest scores only producer output with judge model", asyn
         inputDir: join(root, "input"),
         referenceDir: join(root, "reference"),
         evalsDir: join(root, "evals"),
-        outputDir: join(root, "out")
-      })
+        outputDir: join(root, "out"),
+      }),
     },
-    [{ path: "RESULT.md", contents: "Output\n" }]
+    [{ path: "RESULT.md", contents: "Output\n" }],
   );
 
   expect(request.system).toBe("eval-judge");
@@ -167,10 +174,10 @@ test("buildJudgeModelRequest bounds large producer outputs before judging", asyn
         inputDir: join(root, "input"),
         referenceDir: join(root, "reference"),
         evalsDir: join(root, "evals"),
-        outputDir: join(root, "out")
-      })
+        outputDir: join(root, "out"),
+      }),
     },
-    [{ path: "RESULT.md", contents: "x".repeat(250_000) }]
+    [{ path: "RESULT.md", contents: "x".repeat(250_000) }],
   );
 
   expect(request.prompt.length).toBeLessThan(120_000);
@@ -184,13 +191,13 @@ test("buildProduceModelRequest fails before provider calls when prompt budget is
     evals: [
       {
         ...syntheticEvals.evals[0],
-        expectations: { huge: "x".repeat(800_000) }
-      }
-    ]
+        expectations: { huge: "x".repeat(800_000) },
+      },
+    ],
   });
   const evalCase = {
     ...syntheticEvals.evals[0],
-    expectations: { huge: "x".repeat(800_000) }
+    expectations: { huge: "x".repeat(800_000) },
   };
 
   await expect(
@@ -204,9 +211,9 @@ test("buildProduceModelRequest fails before provider calls when prompt budget is
         inputDir: join(root, "input"),
         referenceDir: join(root, "reference"),
         evalsDir: join(root, "evals"),
-        outputDir: join(root, "out")
-      })
-    })
+        outputDir: join(root, "out"),
+      }),
+    }),
   ).rejects.toThrow(/prompt budget exceeded before producer eval notes-001/);
 });
 
@@ -222,8 +229,8 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
     summary: "Improve the examples.",
     changes: [
       { path: "SKILL.md", contents: "# Updated\n" },
-      { path: "examples/basic.md", contents: "Use concise release notes.\n" }
-    ]
+      { path: "examples/basic.md", contents: "Use concise release notes.\n" },
+    ],
   };
   const client = new MemoryModelClient(JSON.stringify(patch));
   const researcher = new ModelSkillResearcher(client);
@@ -237,8 +244,8 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
-    }
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
+    },
   });
 
   expect(modelRequest.prompt).toContain("Current skill files");
@@ -253,21 +260,23 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
-    }
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
+    },
   });
 
   await expect(readFile(join(candidateSkillDir, "SKILL.md"), "utf8")).resolves.toBe("# Updated\n");
   await expect(readFile(join(candidateSkillDir, "examples", "basic.md"), "utf8")).resolves.toBe(
-    "Use concise release notes.\n"
+    "Use concise release notes.\n",
   );
-  await expect(readFile(join(candidateSkillDir, "RESEARCH.md"), "utf8")).resolves.toContain("Improve the examples.");
-  await expect(readFile(join(candidateSkillDir, ".autoresearch-transcript.json"), "utf8")).resolves.toContain(
-    "SKILL.md"
+  await expect(readFile(join(candidateSkillDir, "RESEARCH.md"), "utf8")).resolves.toContain(
+    "Improve the examples.",
   );
+  await expect(
+    readFile(join(candidateSkillDir, ".autoresearch-transcript.json"), "utf8"),
+  ).resolves.toContain("SKILL.md");
 });
 
-test("buildResearchModelRequest uses full seed guidance first, then ledger and index", async () => {
+test("buildResearchModelRequest uses progressive seed guidance and regression context", async () => {
   const root = await tempProject();
   await writeFixture(root, { ...syntheticConfig, research_start: "empty" }, syntheticEvals);
   const project = await loadProject(root);
@@ -279,7 +288,7 @@ test("buildResearchModelRequest uses full seed guidance first, then ledger and i
   await writeFile(join(previousSkillDir, "SKILL.md"), "# Candidate\n");
   await writeFile(
     join(guidanceSkillDir, "SKILL.md"),
-    "# Seed Skill\n\n## Breaking changes\n\nMention risky changes.\n\n## Tone\n\nBe concise.\n"
+    "# Seed Skill\n\n## Breaking changes\n\nMention risky changes.\n\n## Tone\n\nBe concise.\n",
   );
   await mkdir(join(root, "workspace"), { recursive: true });
   await writeFile(
@@ -293,13 +302,13 @@ test("buildResearchModelRequest uses full seed guidance first, then ledger and i
             section: "Breaking changes",
             action: "used",
             reason: "The first failure missed risk notes.",
-            appliedTo: "SKILL.md"
-          }
-        ]
+            appliedTo: "SKILL.md",
+          },
+        ],
       },
       null,
-      2
-    )}\n`
+      2,
+    )}\n`,
   );
 
   const first = await buildResearchModelRequest({
@@ -313,12 +322,15 @@ test("buildResearchModelRequest uses full seed guidance first, then ledger and i
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
-    }
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
+    },
   });
 
-  expect(first.prompt).toContain("Seed/reference skill files");
-  expect(first.prompt).toContain("Mention risky changes.");
+  expect(first.prompt).toContain("Guidance ledger");
+  expect(first.prompt).toContain("Seed/reference skill index");
+  expect(first.prompt).toContain("Breaking changes");
+  expect(first.prompt).not.toContain("Mention risky changes.");
+  expect(first.prompt).toContain("Prefer the smallest effective change");
 
   const second = await buildResearchModelRequest({
     project,
@@ -331,8 +343,8 @@ test("buildResearchModelRequest uses full seed guidance first, then ledger and i
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
-    }
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
+    },
   });
 
   expect(second.prompt).toContain("Guidance ledger");
@@ -359,11 +371,11 @@ test("ModelSkillResearcher appends guidance decisions to the ledger", async () =
           section: "Breaking changes",
           action: "used",
           reason: "Judge rationale called out missing breaking-change risk.",
-          appliedTo: "SKILL.md"
-        }
+          appliedTo: "SKILL.md",
+        },
       ],
-      changes: [{ path: "SKILL.md", contents: "# Updated\n" }]
-    })
+      changes: [{ path: "SKILL.md", contents: "# Updated\n" }],
+    }),
   );
   const researcher = new ModelSkillResearcher(client);
 
@@ -377,8 +389,8 @@ test("ModelSkillResearcher appends guidance decisions to the ledger", async () =
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
-    }
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
+    },
   });
 
   await expect(readGuidanceLedger(guidanceLedgerPath)).resolves.toMatchObject({
@@ -387,9 +399,9 @@ test("ModelSkillResearcher appends guidance decisions to the ledger", async () =
         iteration: 2,
         source: "seed-reference/SKILL.md",
         section: "Breaking changes",
-        action: "used"
-      }
-    ]
+        action: "used",
+      },
+    ],
   });
 });
 
@@ -399,7 +411,9 @@ test("readGuidanceLedger reports invalid ledger files with context", async () =>
   await mkdir(join(root, "workspace"), { recursive: true });
   await writeFile(guidanceLedgerPath, "{not json");
 
-  await expect(readGuidanceLedger(guidanceLedgerPath)).rejects.toThrow(/Could not read guidance ledger/);
+  await expect(readGuidanceLedger(guidanceLedgerPath)).rejects.toThrow(
+    /Could not read guidance ledger/,
+  );
 });
 
 test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail during research", async () => {
@@ -413,7 +427,7 @@ test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail d
   await mkdir(previousSkillDir, { recursive: true });
   await writeFile(join(previousSkillDir, "SKILL.md"), "# Previous\n");
   const client = new MemoryModelClient(
-    JSON.stringify({ summary: "bad", changes: [{ path: "../escape.md", contents: "bad" }] })
+    JSON.stringify({ summary: "bad", changes: [{ path: "../escape.md", contents: "bad" }] }),
   );
   const researcher = new ModelSkillResearcher(client);
 
@@ -427,9 +441,9 @@ test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail d
       previousScores: [],
       previousAggregate: {
         tracks: [],
-        overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
-      }
-    })
+        overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
+      },
+    }),
   ).rejects.toThrow(/escapes target directory/);
   await expect(stat(candidateSkillDir)).rejects.toMatchObject({ code: "ENOENT" });
 });
@@ -438,14 +452,16 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
   const calls: Array<{ url: string; init: RequestInit }> = [];
   const fetchStub: typeof fetch = async (url, init) => {
     calls.push({ url: String(url), init: init ?? {} });
-    return new Response(JSON.stringify({ content: [{ type: "text", text: "Done" }] }), { status: 200 });
+    return new Response(JSON.stringify({ content: [{ type: "text", text: "Done" }] }), {
+      status: 200,
+    });
   };
   const client = new AnthropicMessagesClient({ apiKey: "test-key", fetch: fetchStub });
 
   const result = await client.complete({
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     system: "system prompt",
-    prompt: "user prompt"
+    prompt: "user prompt",
   });
 
   expect(result).toBe("Done");
@@ -454,6 +470,6 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
   expect(JSON.parse(String(calls[0].init.body))).toMatchObject({
     model: "claude-sonnet-4-6",
     system: "system prompt",
-    messages: [{ role: "user", content: "user prompt" }]
+    messages: [{ role: "user", content: "user prompt" }],
   });
 });

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -12,7 +12,7 @@ import {
   ModelRequest,
   parseModelProduceResponse,
   readGuidanceLedger,
-  parseSkillResearchPatch,
+  parseSkillResearchPatch
 } from "../src/model-agent.js";
 import { createEvalSandbox } from "../src/sandbox.js";
 import { trackForEval } from "../src/project.js";
@@ -60,8 +60,8 @@ test("buildProduceModelRequest includes eval, mounted files, and target skill co
       referenceDir: join(root, "reference"),
       evalsDir: join(root, "evals"),
       outputDir,
-      skillDir,
-    }),
+      skillDir
+    })
   });
 
   expect(request.system).toBe("task-producer");
@@ -80,9 +80,9 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
   const evalScore = score(evalCase.id, evalCase.eval_type, "summarise");
   const client = new MemoryModelClient(
     JSON.stringify({
-      output_files: [{ path: "RESULT.md", contents: "Summarised changes\n" }],
+      output_files: [{ path: "RESULT.md", contents: "Summarised changes\n" }]
     }),
-    JSON.stringify(evalScore),
+    JSON.stringify(evalScore)
   );
   const agent = new ModelEvalAgent(client);
   const sandbox = createEvalSandbox({
@@ -90,7 +90,7 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
     inputDir: join(root, "input"),
     referenceDir: join(root, "reference"),
     evalsDir: join(root, "evals"),
-    outputDir: join(root, "out"),
+    outputDir: join(root, "out")
   });
 
   const result = await agent.run({
@@ -101,34 +101,27 @@ test("ModelEvalAgent runs producer then judge and persists separate transcripts"
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     models: {
       producer: { provider: "anthropic", name: "claude-haiku-4-5" },
-      judge: { provider: "anthropic", name: "claude-sonnet-4-6" },
+      judge: { provider: "anthropic", name: "claude-sonnet-4-6" }
     },
-    sandbox,
+    sandbox
   });
 
   expect(result.eval_id).toBe(evalCase.id);
-  expect(client.requests.map((request) => request.model.name)).toEqual([
-    "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-  ]);
-  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe(
-    "Summarised changes\n",
+  expect(client.requests.map((request) => request.model.name)).toEqual(["claude-haiku-4-5", "claude-sonnet-4-6"]);
+  await expect(readFile(join(sandbox.outputDir, "RESULT.md"), "utf8")).resolves.toBe("Summarised changes\n");
+  await expect(readFile(join(sandbox.outputDir, "producer-transcript.json"), "utf8")).resolves.toContain(
+    "task-producer"
   );
-  await expect(
-    readFile(join(sandbox.outputDir, "producer-transcript.json"), "utf8"),
-  ).resolves.toContain("task-producer");
-  await expect(
-    readFile(join(sandbox.outputDir, "judge-transcript.json"), "utf8"),
-  ).resolves.toContain("eval-judge");
+  await expect(readFile(join(sandbox.outputDir, "judge-transcript.json"), "utf8")).resolves.toContain("eval-judge");
 });
 
 test("parseModelProduceResponse requires output files and output writes reject unsafe paths", async () => {
   expect(() => parseModelProduceResponse(JSON.stringify({ output_files: [] }))).toThrow(
-    /Invalid model producer response/,
+    /Invalid model producer response/
   );
-  await expect(
-    applyOutputFiles("/tmp/output", [{ path: "../escape.md", contents: "bad" }]),
-  ).rejects.toThrow(/escapes target directory/);
+  await expect(applyOutputFiles("/tmp/output", [{ path: "../escape.md", contents: "bad" }])).rejects.toThrow(
+    /escapes target directory/
+  );
 });
 
 test("buildJudgeModelRequest scores only producer output with judge model", async () => {
@@ -148,10 +141,10 @@ test("buildJudgeModelRequest scores only producer output with judge model", asyn
         inputDir: join(root, "input"),
         referenceDir: join(root, "reference"),
         evalsDir: join(root, "evals"),
-        outputDir: join(root, "out"),
-      }),
+        outputDir: join(root, "out")
+      })
     },
-    [{ path: "RESULT.md", contents: "Output\n" }],
+    [{ path: "RESULT.md", contents: "Output\n" }]
   );
 
   expect(request.system).toBe("eval-judge");
@@ -174,10 +167,10 @@ test("buildJudgeModelRequest bounds large producer outputs before judging", asyn
         inputDir: join(root, "input"),
         referenceDir: join(root, "reference"),
         evalsDir: join(root, "evals"),
-        outputDir: join(root, "out"),
-      }),
+        outputDir: join(root, "out")
+      })
     },
-    [{ path: "RESULT.md", contents: "x".repeat(250_000) }],
+    [{ path: "RESULT.md", contents: "x".repeat(250_000) }]
   );
 
   expect(request.prompt.length).toBeLessThan(120_000);
@@ -191,13 +184,13 @@ test("buildProduceModelRequest fails before provider calls when prompt budget is
     evals: [
       {
         ...syntheticEvals.evals[0],
-        expectations: { huge: "x".repeat(800_000) },
-      },
-    ],
+        expectations: { huge: "x".repeat(800_000) }
+      }
+    ]
   });
   const evalCase = {
     ...syntheticEvals.evals[0],
-    expectations: { huge: "x".repeat(800_000) },
+    expectations: { huge: "x".repeat(800_000) }
   };
 
   await expect(
@@ -211,9 +204,9 @@ test("buildProduceModelRequest fails before provider calls when prompt budget is
         inputDir: join(root, "input"),
         referenceDir: join(root, "reference"),
         evalsDir: join(root, "evals"),
-        outputDir: join(root, "out"),
-      }),
-    }),
+        outputDir: join(root, "out")
+      })
+    })
   ).rejects.toThrow(/prompt budget exceeded before producer eval notes-001/);
 });
 
@@ -225,12 +218,14 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
   const candidateSkillDir = join(root, "candidate-skill");
   await mkdir(previousSkillDir, { recursive: true });
   await writeFile(join(previousSkillDir, "SKILL.md"), "# Previous\n");
+  await writeFile(join(previousSkillDir, "RESEARCH.md"), "# Old research\n");
+  await writeFile(join(previousSkillDir, ".autoresearch-transcript.json"), "{}\n");
   const patch = {
     summary: "Improve the examples.",
     changes: [
       { path: "SKILL.md", contents: "# Updated\n" },
-      { path: "examples/basic.md", contents: "Use concise release notes.\n" },
-    ],
+      { path: "examples/basic.md", contents: "Use concise release notes.\n" }
+    ]
   };
   const client = new MemoryModelClient(JSON.stringify(patch));
   const researcher = new ModelSkillResearcher(client);
@@ -244,8 +239,8 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
-    },
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
   });
 
   expect(modelRequest.prompt).toContain("Current skill files");
@@ -260,20 +255,19 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
-    },
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
   });
 
   await expect(readFile(join(candidateSkillDir, "SKILL.md"), "utf8")).resolves.toBe("# Updated\n");
   await expect(readFile(join(candidateSkillDir, "examples", "basic.md"), "utf8")).resolves.toBe(
-    "Use concise release notes.\n",
+    "Use concise release notes.\n"
   );
-  await expect(readFile(join(candidateSkillDir, "RESEARCH.md"), "utf8")).resolves.toContain(
-    "Improve the examples.",
+  await expect(readFile(join(candidateSkillDir, "RESEARCH.md"), "utf8")).resolves.toContain("Improve the examples.");
+  await expect(readFile(join(candidateSkillDir, ".autoresearch-transcript.json"), "utf8")).resolves.toContain(
+    "SKILL.md"
   );
-  await expect(
-    readFile(join(candidateSkillDir, ".autoresearch-transcript.json"), "utf8"),
-  ).resolves.toContain("SKILL.md");
+  await expect(readFile(join(candidateSkillDir, "RESEARCH.md"), "utf8")).resolves.not.toContain("Old research");
 });
 
 test("buildResearchModelRequest uses progressive seed guidance and regression context", async () => {
@@ -288,7 +282,7 @@ test("buildResearchModelRequest uses progressive seed guidance and regression co
   await writeFile(join(previousSkillDir, "SKILL.md"), "# Candidate\n");
   await writeFile(
     join(guidanceSkillDir, "SKILL.md"),
-    "# Seed Skill\n\n## Breaking changes\n\nMention risky changes.\n\n## Tone\n\nBe concise.\n",
+    "# Seed Skill\n\n## Breaking changes\n\nMention risky changes.\n\n## Tone\n\nBe concise.\n"
   );
   await mkdir(join(root, "workspace"), { recursive: true });
   await writeFile(
@@ -302,13 +296,13 @@ test("buildResearchModelRequest uses progressive seed guidance and regression co
             section: "Breaking changes",
             action: "used",
             reason: "The first failure missed risk notes.",
-            appliedTo: "SKILL.md",
-          },
-        ],
+            appliedTo: "SKILL.md"
+          }
+        ]
       },
       null,
-      2,
-    )}\n`,
+      2
+    )}\n`
   );
 
   const first = await buildResearchModelRequest({
@@ -318,12 +312,12 @@ test("buildResearchModelRequest uses progressive seed guidance and regression co
     candidateSkillDir: join(root, "candidate-1"),
     guidanceSkillDir,
     guidanceLedgerPath,
-    baselineScores: [],
+    baselineScores: [score("missing-case", "summarise-changelog", "summarise", 1)],
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
-    },
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
   });
 
   expect(first.prompt).toContain("Guidance ledger");
@@ -331,6 +325,7 @@ test("buildResearchModelRequest uses progressive seed guidance and regression co
   expect(first.prompt).toContain("Breaking changes");
   expect(first.prompt).not.toContain("Mention risky changes.");
   expect(first.prompt).toContain("Prefer the smallest effective change");
+  expect(first.prompt).toContain("missing-case: baseline 1/1, previous 0/0");
 
   const second = await buildResearchModelRequest({
     project,
@@ -343,8 +338,8 @@ test("buildResearchModelRequest uses progressive seed guidance and regression co
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
-    },
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
   });
 
   expect(second.prompt).toContain("Guidance ledger");
@@ -371,11 +366,11 @@ test("ModelSkillResearcher appends guidance decisions to the ledger", async () =
           section: "Breaking changes",
           action: "used",
           reason: "Judge rationale called out missing breaking-change risk.",
-          appliedTo: "SKILL.md",
-        },
+          appliedTo: "SKILL.md"
+        }
       ],
-      changes: [{ path: "SKILL.md", contents: "# Updated\n" }],
-    }),
+      changes: [{ path: "SKILL.md", contents: "# Updated\n" }]
+    })
   );
   const researcher = new ModelSkillResearcher(client);
 
@@ -389,8 +384,8 @@ test("ModelSkillResearcher appends guidance decisions to the ledger", async () =
     previousScores: [],
     previousAggregate: {
       tracks: [],
-      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
-    },
+      overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+    }
   });
 
   await expect(readGuidanceLedger(guidanceLedgerPath)).resolves.toMatchObject({
@@ -399,9 +394,9 @@ test("ModelSkillResearcher appends guidance decisions to the ledger", async () =
         iteration: 2,
         source: "seed-reference/SKILL.md",
         section: "Breaking changes",
-        action: "used",
-      },
-    ],
+        action: "used"
+      }
+    ]
   });
 });
 
@@ -411,9 +406,7 @@ test("readGuidanceLedger reports invalid ledger files with context", async () =>
   await mkdir(join(root, "workspace"), { recursive: true });
   await writeFile(guidanceLedgerPath, "{not json");
 
-  await expect(readGuidanceLedger(guidanceLedgerPath)).rejects.toThrow(
-    /Could not read guidance ledger/,
-  );
+  await expect(readGuidanceLedger(guidanceLedgerPath)).rejects.toThrow(/Could not read guidance ledger/);
 });
 
 test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail during research", async () => {
@@ -427,7 +420,7 @@ test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail d
   await mkdir(previousSkillDir, { recursive: true });
   await writeFile(join(previousSkillDir, "SKILL.md"), "# Previous\n");
   const client = new MemoryModelClient(
-    JSON.stringify({ summary: "bad", changes: [{ path: "../escape.md", contents: "bad" }] }),
+    JSON.stringify({ summary: "bad", changes: [{ path: "../escape.md", contents: "bad" }] })
   );
   const researcher = new ModelSkillResearcher(client);
 
@@ -441,9 +434,9 @@ test("parseSkillResearchPatch rejects non-JSON responses and unsafe paths fail d
       previousScores: [],
       previousAggregate: {
         tracks: [],
-        overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 },
-      },
-    }),
+        overall: { score: 0, maxScore: 1, normalizedScore: 0, evalCount: 0 }
+      }
+    })
   ).rejects.toThrow(/escapes target directory/);
   await expect(stat(candidateSkillDir)).rejects.toMatchObject({ code: "ENOENT" });
 });
@@ -453,7 +446,7 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
   const fetchStub: typeof fetch = async (url, init) => {
     calls.push({ url: String(url), init: init ?? {} });
     return new Response(JSON.stringify({ content: [{ type: "text", text: "Done" }] }), {
-      status: 200,
+      status: 200
     });
   };
   const client = new AnthropicMessagesClient({ apiKey: "test-key", fetch: fetchStub });
@@ -461,7 +454,7 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
   const result = await client.complete({
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
     system: "system prompt",
-    prompt: "user prompt",
+    prompt: "user prompt"
   });
 
   expect(result).toBe("Done");
@@ -470,6 +463,6 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
   expect(JSON.parse(String(calls[0].init.body))).toMatchObject({
     model: "claude-sonnet-4-6",
     system: "system prompt",
-    messages: [{ role: "user", content: "user prompt" }],
+    messages: [{ role: "user", content: "user prompt" }]
   });
 });

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -6,7 +6,7 @@ import {
   syntheticConfig,
   syntheticEvals,
   tempProject,
-  writeFixture
+  writeFixture,
 } from "./helpers.js";
 
 test("loads security and synthetic project fixtures without domain branches", async () => {
@@ -27,7 +27,12 @@ test("resolves default model and rejects unsupported providers", async () => {
   await writeFixture(root, syntheticConfig, syntheticEvals);
   const project = await loadProject(root);
 
-  expect(resolveModel(project.config)).toEqual({ provider: "anthropic", name: "claude-sonnet-4-6" });
+  expect(resolveModel(project.config)).toEqual({
+    provider: "anthropic",
+    name: "claude-sonnet-4-6",
+  });
   expect(resolveModel(project.config, { name: "claude-opus-4-6" }).name).toBe("claude-opus-4-6");
-  expect(() => resolveModel(project.config, { provider: "openai" })).toThrow(/Unsupported model provider/);
+  expect(() => resolveModel(project.config, { provider: "openai" })).toThrow(
+    /Unsupported model provider/,
+  );
 });

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -10,7 +10,7 @@ import {
   syntheticConfig,
   syntheticEvals,
   tempProject,
-  writeFixture
+  writeFixture,
 } from "./helpers.js";
 
 test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
@@ -27,7 +27,7 @@ test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
     referenceDir: join(root, "reference"),
     evalsDir: join(root, "evals"),
     skillDir: join(root, "skill"),
-    outputDir: join(root, "out")
+    outputDir: join(root, "out"),
   });
 
   const readonlyPaths = [
@@ -36,7 +36,7 @@ test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
     () => sandbox.mkdir(join(root, "evals", "new")),
     () => sandbox.rm(join(root, "skill", "SKILL.md")),
     () => sandbox.cp(join(root, "reference", "ref.txt"), join(root, "input", "copy.txt")),
-    () => sandbox.chmod(join(root, "reference", "ref.txt"), 0o600)
+    () => sandbox.chmod(join(root, "reference", "ref.txt"), 0o600),
   ];
 
   for (const action of readonlyPaths) {
@@ -55,7 +55,7 @@ test("runEval maps eval type to role and target skill through config", async () 
     async run(request) {
       calls.push(request);
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 1, 2);
-    }
+    },
   };
 
   await runEval(
@@ -64,9 +64,9 @@ test("runEval maps eval type to role and target skill through config", async () 
       projectRoot: root,
       evalCase: securityEvals.evals[0],
       baseline: true,
-      outputRoot: join(root, "workspace", "baseline", "outputs")
+      outputRoot: join(root, "workspace", "baseline", "outputs"),
     },
-    agent
+    agent,
   );
   await runEval(
     {
@@ -75,18 +75,22 @@ test("runEval maps eval type to role and target skill through config", async () 
       evalCase: securityEvals.evals[1],
       baseline: false,
       targetSkillDir: join(root, "skills", "secure-authoring"),
-      outputRoot: join(root, "workspace", "iterations", "1")
+      outputRoot: join(root, "workspace", "iterations", "1"),
     },
-    agent
+    agent,
   );
 
   expect(calls).toHaveLength(2);
   expect((calls[0] as any).role).toBe("security-auditor");
   expect((calls[0] as any).targetSkill).toBeUndefined();
-  expect((calls[0] as any).sandbox.mounts.some((mount: any) => mount.target === "/skill")).toBe(false);
+  expect((calls[0] as any).sandbox.mounts.some((mount: any) => mount.target === "/skill")).toBe(
+    false,
+  );
   expect((calls[1] as any).role).toBe("secure-author");
   expect((calls[1] as any).targetSkill).toBe("secure-authoring");
-  expect((calls[1] as any).sandbox.mounts.find((mount: any) => mount.target === "/skill").readOnly).toBe(true);
+  expect(
+    (calls[1] as any).sandbox.mounts.find((mount: any) => mount.target === "/skill").readOnly,
+  ).toBe(true);
 });
 
 test("runWithConcurrency respects the configured limit", async () => {
@@ -110,13 +114,25 @@ test("orchestrator requires complete artefacts when started with withBaseline", 
   await mkdir(join(reuseRoot, "workspace", "baseline", "notes-001", "output"), { recursive: true });
   await writeFile(
     join(reuseRoot, "workspace", "baseline", "scores-0.json"),
-    JSON.stringify(score("notes-001", "summarise-changelog", "summarise"))
+    JSON.stringify(score("notes-001", "summarise-changelog", "summarise")),
   );
   await writeFile(join(reuseRoot, "workspace", "baseline", "notes-001", "task.md"), "Task");
-  await writeFile(join(reuseRoot, "workspace", "baseline", "notes-001", "input", "SPEC.md"), "Input");
-  await writeFile(join(reuseRoot, "workspace", "baseline", "notes-001", "output", "SPEC.md"), "Output");
-  await writeFile(join(reuseRoot, "workspace", "baseline", "summary.json"), JSON.stringify({ average: 1 }));
-  await writeFile(join(reuseRoot, "workspace", "baseline", "summary-summarise.json"), JSON.stringify({ average: 1 }));
+  await writeFile(
+    join(reuseRoot, "workspace", "baseline", "notes-001", "input", "SPEC.md"),
+    "Input",
+  );
+  await writeFile(
+    join(reuseRoot, "workspace", "baseline", "notes-001", "output", "SPEC.md"),
+    "Output",
+  );
+  await writeFile(
+    join(reuseRoot, "workspace", "baseline", "summary.json"),
+    JSON.stringify({ average: 1 }),
+  );
+  await writeFile(
+    join(reuseRoot, "workspace", "baseline", "summary-summarise.json"),
+    JSON.stringify({ average: 1 }),
+  );
   await writeFile(join(reuseRoot, "workspace", "baseline", "analysis-summarise.md"), "Analysis");
 
   const reused = await orchestrateBaseline({ projectRoot: reuseRoot, withBaseline: true });
@@ -125,9 +141,9 @@ test("orchestrator requires complete artefacts when started with withBaseline", 
 
   const missingRoot = await tempProject();
   await writeFixture(missingRoot, syntheticConfig, syntheticEvals);
-  await expect(orchestrateBaseline({ projectRoot: missingRoot, withBaseline: true })).rejects.toThrow(
-    /--with-baseline/
-  );
+  await expect(
+    orchestrateBaseline({ projectRoot: missingRoot, withBaseline: true }),
+  ).rejects.toThrow(/--with-baseline/);
 });
 
 test("orchestrator generates initial baseline by default without counting it as an iteration", async () => {
@@ -136,16 +152,22 @@ test("orchestrator generates initial baseline by default without counting it as 
   const agent: EvalAgent = {
     async run(request) {
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
-    }
+    },
   };
   const generated = await orchestrateBaseline({ projectRoot: generateRoot, agent });
-  expect(generated.events[1]).toMatchObject({ type: "baseline-started", countsTowardIterations: false });
+  expect(generated.events[1]).toMatchObject({
+    type: "baseline-started",
+    countsTowardIterations: false,
+  });
   expect(generated.events[2]).toMatchObject({ type: "baseline-generated", scores: 1 });
   expect(generated.completedIterations).toBe(0);
-  expect(generated.events.at(-1)).toMatchObject({ type: "research-loop-ready", completedIterations: 0 });
-  await expect(readFile(join(generateRoot, "workspace", "baseline", "scores-0.json"), "utf8")).resolves.toContain(
-    "notes-001"
-  );
+  expect(generated.events.at(-1)).toMatchObject({
+    type: "research-loop-ready",
+    completedIterations: 0,
+  });
+  await expect(
+    readFile(join(generateRoot, "workspace", "baseline", "scores-0.json"), "utf8"),
+  ).resolves.toContain("notes-001");
 });
 
 test("orchestrator skips research when the baseline already reaches target score", async () => {
@@ -154,19 +176,19 @@ test("orchestrator skips research when the baseline already reaches target score
   const agent: EvalAgent = {
     async run(request) {
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.95);
-    }
+    },
   };
   const researcher: SkillResearcher = {
     async improve() {
       throw new Error("researcher should not run when baseline reaches target");
-    }
+    },
   };
 
   const result = await orchestrateBaseline({
     projectRoot: root,
     agent,
     researcher,
-    runResearch: true
+    runResearch: true,
   });
 
   expect(result.completedIterations).toBe(0);
@@ -175,9 +197,11 @@ test("orchestrator skips research when the baseline already reaches target score
   expect(result.events.at(-1)).toMatchObject({
     type: "baseline-target-score-reached",
     normalizedScore: 0.95,
-    targetScore: syntheticConfig.target_score
+    targetScore: syntheticConfig.target_score,
   });
-  await expect(stat(join(root, "workspace", "iterations", "1"))).rejects.toMatchObject({ code: "ENOENT" });
+  await expect(stat(join(root, "workspace", "iterations", "1"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
 });
 
 test("orchestrator can force research when the baseline already reaches target score", async () => {
@@ -191,14 +215,14 @@ test("orchestrator can force research when the baseline already reaches target s
   const agent: EvalAgent = {
     async run(request) {
       return request.targetSkill
-        ? score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9)
+        ? score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.96)
         : score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.95);
-    }
+    },
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-    }
+    },
   };
 
   const result = await orchestrateBaseline({
@@ -207,7 +231,7 @@ test("orchestrator can force research when the baseline already reaches target s
     researcher,
     runResearch: true,
     forceResearch: true,
-    seedSkillDir: seedSkill
+    seedSkillDir: seedSkill,
   });
 
   expect(result.completedIterations).toBe(1);
@@ -232,13 +256,16 @@ test("orchestrator runs research iterations until target score is reached", asyn
       evalRuns++;
       const total = evalRuns === 1 ? 0.5 : 0.9;
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, total);
-    }
+    },
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-      await writeFile(join(request.candidateSkillDir, `iteration-${request.iteration}.txt`), "candidate\n");
-    }
+      await writeFile(
+        join(request.candidateSkillDir, `iteration-${request.iteration}.txt`),
+        "candidate\n",
+      );
+    },
   };
 
   const result = await orchestrateBaseline({
@@ -246,19 +273,93 @@ test("orchestrator runs research iterations until target score is reached", asyn
     agent,
     researcher,
     runResearch: true,
-    seedSkillDir: seedSkill
+    seedSkillDir: seedSkill,
   });
 
   expect(result.completedIterations).toBe(2);
   expect(result.bestIteration?.iteration).toBe(2);
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
   expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 2 });
-  await expect(readFile(join(root, "workspace", "iterations", "2", "scores-0.json"), "utf8")).resolves.toContain(
-    "notes-001"
-  );
-  await expect(readFile(join(root, "workspace", "iterations", "2", "skill", "iteration-2.txt"), "utf8")).resolves.toBe(
-    "candidate\n"
-  );
+  await expect(
+    readFile(join(root, "workspace", "iterations", "2", "scores-0.json"), "utf8"),
+  ).resolves.toContain("notes-001");
+  await expect(
+    readFile(join(root, "workspace", "iterations", "2", "skill", "iteration-2.txt"), "utf8"),
+  ).resolves.toBe("candidate\n");
+});
+
+test("orchestrator keeps iterating when aggregate target has a baseline regression", async () => {
+  const root = await tempProject();
+  const config = {
+    ...syntheticConfig,
+    target_score: 0.85,
+    max_iterations: 2,
+    tracks: [
+      {
+        ...syntheticConfig.tracks[0],
+        eval_type: "two-case-eval",
+      },
+    ],
+  };
+  const evals = {
+    evals: [
+      {
+        ...syntheticEvals.evals[0],
+        id: "case-a",
+        eval_type: "two-case-eval",
+      },
+      {
+        ...syntheticEvals.evals[0],
+        id: "case-b",
+        eval_type: "two-case-eval",
+      },
+    ],
+  };
+  await writeFixture(root, config, evals);
+  const seedSkill = join(root, "seed-skill");
+  await mkdir(seedSkill, { recursive: true });
+  await writeFile(join(seedSkill, "SKILL.md"), "# Release Summary\n");
+
+  const agent: EvalAgent = {
+    async run(request) {
+      if (!request.targetSkill) {
+        return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.8);
+      }
+      const iteration = request.sandbox.outputDir.includes(join("iterations", "1")) ? 1 : 2;
+      if (iteration === 1) {
+        return score(
+          request.evalCase.id,
+          request.evalCase.eval_type,
+          request.track.id,
+          request.evalCase.id === "case-a" ? 1 : 0.7,
+        );
+      }
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9);
+    },
+  };
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+    },
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    agent,
+    researcher,
+    runResearch: true,
+    seedSkillDir: seedSkill,
+  });
+
+  expect(result.completedIterations).toBe(2);
+  expect(result.events).toContainEqual({
+    type: "target-score-blocked-by-regression",
+    iteration: 1,
+    normalizedScore: 0.85,
+    targetScore: 0.85,
+    regressions: [{ evalId: "case-b", baselineScore: 0.8, candidateScore: 0.7 }],
+  });
+  expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 2 });
 });
 
 test("orchestrator can start research from an empty skill while using the seed as guidance", async () => {
@@ -278,23 +379,31 @@ test("orchestrator can start research from an empty skill while using the seed a
         return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
       }
       evalRuns++;
-      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, evalRuns === 1 ? 0.5 : 0.9);
-    }
+      return score(
+        request.evalCase.id,
+        request.evalCase.eval_type,
+        request.track.id,
+        evalRuns === 1 ? 0.5 : 0.9,
+      );
+    },
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       previousSkillDirs.push(request.previousSkillDir);
       guidanceSkillDirs.push(request.guidanceSkillDir);
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-      await writeFile(join(request.candidateSkillDir, `iteration-${request.iteration}.txt`), "candidate\n");
-    }
+      await writeFile(
+        join(request.candidateSkillDir, `iteration-${request.iteration}.txt`),
+        "candidate\n",
+      );
+    },
   };
 
   const result = await orchestrateBaseline({
     projectRoot: root,
     agent,
     researcher,
-    runResearch: true
+    runResearch: true,
   });
 
   expect(result.completedIterations).toBe(2);
@@ -302,9 +411,100 @@ test("orchestrator can start research from an empty skill while using the seed a
   expect(await readdir(previousSkillDirs[0])).toEqual([]);
   expect(previousSkillDirs[1]).toBe(join(root, "workspace", "iterations", "1", "skill"));
   expect(guidanceSkillDirs).toEqual([seedSkill, seedSkill]);
-  await expect(stat(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"))).rejects.toMatchObject({
-    code: "ENOENT"
+  await expect(
+    stat(join(root, "workspace", "iterations", "1", "skill", "SKILL.md")),
+  ).rejects.toMatchObject({
+    code: "ENOENT",
   });
+});
+
+test("orchestrator resolves config skill paths relative to the project root", async () => {
+  const root = await tempProject();
+  const seedSkill = join(root, "skills", "security-audit");
+  const guidanceSkill = join(root, "skills", "guidance-reference");
+  const config = {
+    ...syntheticConfig,
+    origin_skill: "skills/security-audit",
+    guidance_skill: "skills/guidance-reference",
+    research_start: "empty" as const,
+    max_iterations: 1,
+  };
+  await writeFixture(root, config, syntheticEvals);
+  await mkdir(seedSkill, { recursive: true });
+  await mkdir(guidanceSkill, { recursive: true });
+  await writeFile(join(seedSkill, "SKILL.md"), "# Seed\n");
+  await writeFile(join(guidanceSkill, "SKILL.md"), "# Guidance\n");
+
+  let previousSkillDir = "";
+  let guidanceSkillDir = "";
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(
+        request.evalCase.id,
+        request.evalCase.eval_type,
+        request.track.id,
+        request.targetSkill ? 0.9 : 0.2,
+      );
+    },
+  };
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      previousSkillDir = request.previousSkillDir;
+      guidanceSkillDir = request.guidanceSkillDir ?? "";
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+      await writeFile(join(request.candidateSkillDir, "SKILL.md"), "# Candidate\n");
+    },
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    agent,
+    researcher,
+    runResearch: true,
+  });
+
+  expect(result.completedIterations).toBe(1);
+  expect(previousSkillDir).toBe(join(root, "workspace", "empty-skill"));
+  expect(guidanceSkillDir).toBe(guidanceSkill);
+});
+
+test("orchestrator preserves absolute origin_skill paths", async () => {
+  const root = await tempProject();
+  const seedSkill = join(root, "absolute-seed");
+  await writeFixture(
+    root,
+    { ...syntheticConfig, origin_skill: seedSkill, max_iterations: 1 },
+    syntheticEvals,
+  );
+  await mkdir(seedSkill, { recursive: true });
+  await writeFile(join(seedSkill, "SKILL.md"), "# Seed\n");
+
+  let previousSkillDir = "";
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(
+        request.evalCase.id,
+        request.evalCase.eval_type,
+        request.track.id,
+        request.targetSkill ? 0.9 : 0.2,
+      );
+    },
+  };
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      previousSkillDir = request.previousSkillDir;
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+    },
+  };
+
+  await orchestrateBaseline({
+    projectRoot: root,
+    agent,
+    researcher,
+    runResearch: true,
+  });
+
+  expect(previousSkillDir).toBe(seedSkill);
 });
 
 test("orchestrator stops research at max iterations and keeps the best candidate", async () => {
@@ -321,13 +521,18 @@ test("orchestrator stops research at max iterations and keeps the best candidate
         return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
       }
       candidateRuns++;
-      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, candidateRuns === 2 ? 0.6 : 0.4);
-    }
+      return score(
+        request.evalCase.id,
+        request.evalCase.eval_type,
+        request.track.id,
+        candidateRuns === 2 ? 0.6 : 0.4,
+      );
+    },
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-    }
+    },
   };
 
   const result = await orchestrateBaseline({
@@ -335,7 +540,7 @@ test("orchestrator stops research at max iterations and keeps the best candidate
     agent,
     researcher,
     runResearch: true,
-    seedSkillDir: seedSkill
+    seedSkillDir: seedSkill,
   });
 
   expect(result.completedIterations).toBe(syntheticConfig.max_iterations);
@@ -343,6 +548,6 @@ test("orchestrator stops research at max iterations and keeps the best candidate
   expect(result.aggregate.overall.normalizedScore).toBe(0.6);
   expect(result.events.at(-1)).toMatchObject({
     type: "max-iterations-reached",
-    completedIterations: syntheticConfig.max_iterations
+    completedIterations: syntheticConfig.max_iterations,
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    environment: "node"
-  }
+    environment: "node",
+  },
 });


### PR DESCRIPTION
## Summary
- Move Flue role behavior into named subagent profiles and split prompt construction into focused prompt modules.
- Resolve `origin_skill` and `guidance_skill` relative to `projectRoot`, and keep payload overrides explicit.
- Make research stop only when the target score is reached without regressing any eval case below baseline.
- Tighten the alpha fixture/docs and clean up recorded fixture warnings.

## Testing
- Added and updated unit tests around prompt generation, Flue task wiring, path resolution, and regression-aware iteration stopping.
- Verified the affected orchestrator and Flue harness tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Autoresearch now prevents completion when reaching target score if any evaluation case regresses below baseline—iterations continue until a non-regressing candidate meets the target or max iterations complete.

* **Improvements**
  * Refined guidance-ledger tracking for skill research iterations.
  * Streamlined command-line invocations by removing explicit ID arguments in favor of payload-based session management.

* **Documentation**
  * Updated workflow guides and examples to reflect current CLI and integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix #15 
Fix #53 