### PR TITLE
Add skill-creator and autoresearch acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ If you want to point the harness at your own skill, start with [docs/using-the-h
 
 If you want to work on the harness itself, read [CONTRIBUTING.md](CONTRIBUTING.md). It explains the project structure, Flue integration, data contracts, fixtures, test expectations, and alpha limitations.
 
+## Acknowledgements
+
+This project was originally inspired by Andrej Karpathy's
+[`autoresearch`](https://github.com/karpathy/autoresearch) and its compact loop
+for autonomous, auditable research iterations. The skill-specific harness design
+is also influenced by skill-creation guidance from OpenAI Codex's
+[`skill-creator`](https://github.com/openai/skills/blob/main/skills/.system/skill-creator/SKILL.md)
+and Anthropic's open-source
+[`skill-creator`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md).
+The ideas adopted here are conceptual: progressive disclosure for skill context,
+trigger-focused metadata, candidate skill review, baseline comparison, repeatable
+eval fixtures, and iterative review loops.
+
+No source text or implementation from those projects is intentionally copied into
+this repository. If future work closely adapts code, templates, prompts, or other
+copyrightable material from the Anthropic skill-creator, preserve its
+[`Apache-2.0` license notice](https://github.com/anthropics/skills/blob/main/skills/skill-creator/LICENSE.txt)
+and document the adapted files here or in a project notice file.
+
 ## Alpha Fixture
 
 The release-notes fixture lives at:


### PR DESCRIPTION
## Summary
- Add an acknowledgements section to the README
- Credit Andrej Karpathy's `autoresearch` as the original inspiration
- Link the OpenAI Codex and Anthropic `skill-creator` sources and note the license boundary for any closely adapted material

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added acknowledgements section to the README, crediting inspiration sources and providing licensing attribution guidance for adapted materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->