### PR TITLE
Validate configured Flue roles before orchestration

### DIFF
--- a/src/flue-roles.ts
+++ b/src/flue-roles.ts
@@ -1,0 +1,75 @@
+import { readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { ProjectConfig } from "./schemas.js";
+
+export interface RoleReference {
+  field: string;
+  role: string;
+}
+
+async function readRoleDirectory(path: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+      .map((entry) => entry.name.slice(0, -".md".length));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function loadAvailableFlueRoles(rootPath = process.cwd()): Promise<string[]> {
+  const root = resolve(rootPath);
+  const roles = await Promise.all([
+    readRoleDirectory(join(root, "roles")),
+    readRoleDirectory(join(root, ".flue", "roles")),
+  ]);
+  return [...new Set(roles.flat())].sort();
+}
+
+export function configuredFlueRoleReferences(config: ProjectConfig): RoleReference[] {
+  return [
+    { field: "roles.judge", role: config.roles.judge },
+    { field: "roles.skill_builder", role: config.roles.skill_builder },
+    ...config.tracks.map((track, index) => ({
+      field: `tracks[${index}].role`,
+      role: track.role,
+    })),
+  ];
+}
+
+export function validateConfiguredFlueRoles(
+  config: ProjectConfig,
+  availableRoles: string[],
+): void {
+  const available = new Set(availableRoles);
+  const missing = configuredFlueRoleReferences(config).filter(
+    (reference) => !available.has(reference.role),
+  );
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  const byRole = new Map<string, string[]>();
+  for (const reference of missing) {
+    byRole.set(reference.role, [...(byRole.get(reference.role) ?? []), reference.field]);
+  }
+
+  const missingLines = [...byRole.entries()].map(
+    ([role, fields]) => `- ${role}: ${fields.join(", ")}`,
+  );
+  const availableLine = availableRoles.length > 0 ? availableRoles.join(", ") : "(none)";
+  throw new Error(
+    [
+      "Configured Flue roles are not registered.",
+      "Missing roles:",
+      ...missingLines,
+      `Available roles: ${availableLine}`,
+      "Define roles as markdown files in roles/ or .flue/roles/.",
+    ].join("\n"),
+  );
+}

--- a/src/flue-roles.ts
+++ b/src/flue-roles.ts
@@ -30,6 +30,16 @@ export async function loadAvailableFlueRoles(rootPath = process.cwd()): Promise<
   return [...new Set(roles.flat())].sort();
 }
 
+function missingRequiredProjectRoleFields(config: ProjectConfig): string[] {
+  const roles = config.roles as Partial<Record<"judge" | "skill_builder", unknown>>;
+  return [
+    ["roles.judge", roles.judge],
+    ["roles.skill_builder", roles.skill_builder],
+  ]
+    .filter(([, role]) => typeof role !== "string" || role.length === 0)
+    .map(([field]) => field as string);
+}
+
 export function configuredFlueRoleReferences(config: ProjectConfig): RoleReference[] {
   return [
     { field: "roles.judge", role: config.roles.judge },
@@ -45,6 +55,13 @@ export function validateConfiguredFlueRoles(
   config: ProjectConfig,
   availableRoles: string[],
 ): void {
+  const missingRequiredFields = missingRequiredProjectRoleFields(config);
+  if (missingRequiredFields.length > 0) {
+    throw new Error(
+      `Configured Flue roles are missing required fields: ${missingRequiredFields.join(", ")}`,
+    );
+  }
+
   const available = new Set(availableRoles);
   const missing = configuredFlueRoleReferences(config).filter(
     (reference) => !available.has(reference.role),

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,6 +2,7 @@ import { cp, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
+import { loadAvailableFlueRoles, validateConfiguredFlueRoles } from "./flue-roles.js";
 import { loadProject, ProjectInputs } from "./project.js";
 import { runEval, runWithConcurrency, EvalAgent } from "./runner.js";
 import { EvalScore } from "./schemas.js";
@@ -93,6 +94,7 @@ export async function orchestrateBaseline(
   const events: RunEvent[] = [];
   const project = await loadProject(options.projectRoot);
   events.push({ type: "project-loaded", root: project.root });
+  validateConfiguredFlueRoles(project.config, await loadAvailableFlueRoles());
 
   const expectedEvalIds = project.evals.evals.map((evalCase) => evalCase.id);
   const baselineScores = options.withBaseline

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -13,10 +13,10 @@ export const RoleModelsSchema = v.object({
   researcher: v.optional(ModelConfigSchema),
 });
 
-export const RolesConfigSchema = v.record(
-  v.pipe(v.string(), v.minLength(1)),
-  v.pipe(v.string(), v.minLength(1)),
-);
+export const RolesConfigSchema = v.object({
+  judge: v.pipe(v.string(), v.minLength(1)),
+  skill_builder: v.pipe(v.string(), v.minLength(1)),
+});
 
 export const TrackSchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),

--- a/tests/e2e-dry-run.test.ts
+++ b/tests/e2e-dry-run.test.ts
@@ -75,13 +75,15 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
   expect(result.completedIterations).toBe(1);
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
   expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 1 });
-  expect(client.requests.map((request) => request.system)).toEqual([
-    "task-producer",
-    "judge",
-    "skill-builder",
-    "task-producer",
-    "judge",
-  ]);
+  expect(client.requests.map((request) => request.system)).toEqual(
+    [
+      ["baseline producer", "task-producer"],
+      ["baseline judge", "eval-judge"],
+      ["researcher", "skill-builder"],
+      ["candidate producer", "task-producer"],
+      ["candidate judge", "eval-judge"],
+    ].map(([, system]) => system),
+  );
 
   await expect(
     readFile(join(root, "workspace", "baseline", evalCase.id, "RESULT.md"), "utf8"),

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -30,7 +30,7 @@ export const securityConfig = {
     name: "claude-sonnet-4-6"
   },
   roles: {
-    judge: "judge",
+    judge: "eval-judge",
     skill_builder: "skill-builder"
   },
   tracks: [
@@ -58,7 +58,7 @@ export const syntheticConfig = {
   max_iterations: 3,
   max_concurrency: 1,
   roles: {
-    judge: "judge",
+    judge: "eval-judge",
     skill_builder: "skill-builder"
   },
   tracks: [

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -1,3 +1,4 @@
+import { validateConfiguredFlueRoles } from "../src/flue-roles.js";
 import { loadProject, trackForEval } from "../src/project.js";
 import { resolveModel } from "../src/model.js";
 import {
@@ -35,4 +36,28 @@ test("resolves default model and rejects unsupported providers", async () => {
   expect(() => resolveModel(project.config, { provider: "openai" })).toThrow(
     /Unsupported model provider/,
   );
+});
+
+test("requires judge and skill builder role keys", async () => {
+  const root = await tempProject();
+  await writeFixture(
+    root,
+    {
+      ...syntheticConfig,
+      roles: {},
+    },
+    syntheticEvals,
+  );
+
+  await expect(loadProject(root)).rejects.toThrow(/roles\.judge/);
+
+  expect(() =>
+    validateConfiguredFlueRoles(
+      {
+        ...syntheticConfig,
+        roles: {} as typeof syntheticConfig.roles,
+      },
+      ["eval-judge", "skill-builder", "task-producer"],
+    ),
+  ).toThrow(/missing required fields: roles\.judge, roles\.skill_builder/);
 });

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -146,6 +146,84 @@ test("orchestrator requires complete artefacts when started with withBaseline", 
   ).rejects.toThrow(/--with-baseline/);
 });
 
+test("orchestrator rejects missing configured judge role before baseline work", async () => {
+  const root = await tempProject();
+  await writeFixture(
+    root,
+    {
+      ...syntheticConfig,
+      roles: {
+        ...syntheticConfig.roles,
+        judge: "release-notes-judge",
+      },
+    },
+    syntheticEvals,
+  );
+
+  await expect(orchestrateBaseline({ projectRoot: root, withBaseline: true })).rejects.toThrow(
+    new RegExp(
+      [
+        "Configured Flue roles are not registered.",
+        "release-notes-judge: roles.judge",
+        "Available roles: eval-judge, skill-builder, task-producer",
+        "Define roles as markdown files in roles/ or .flue/roles/.",
+      ].join("(.|\n)*"),
+    ),
+  );
+  await expect(stat(join(root, "workspace", "baseline"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+test("orchestrator rejects missing producer track role before running evals", async () => {
+  const root = await tempProject();
+  await writeFixture(
+    root,
+    {
+      ...syntheticConfig,
+      tracks: [
+        {
+          ...syntheticConfig.tracks[0],
+          role: "release-editor",
+        },
+      ],
+    },
+    syntheticEvals,
+  );
+  let agentRuns = 0;
+  const agent: EvalAgent = {
+    async run(request) {
+      agentRuns++;
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
+    },
+  };
+
+  await expect(orchestrateBaseline({ projectRoot: root, agent })).rejects.toThrow(
+    /release-editor: tracks\[0\]\.role/,
+  );
+  expect(agentRuns).toBe(0);
+  await expect(stat(join(root, "workspace", "baseline"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+test("orchestrator accepts valid configured Flue roles", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  let agentRuns = 0;
+  const agent: EvalAgent = {
+    async run(request) {
+      agentRuns++;
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
+    },
+  };
+
+  const result = await orchestrateBaseline({ projectRoot: root, agent });
+
+  expect(agentRuns).toBe(1);
+  expect(result.events[1]).toMatchObject({ type: "baseline-started" });
+});
+
 test("orchestrator generates initial baseline by default without counting it as an iteration", async () => {
   const generateRoot = await tempProject();
   await writeFixture(generateRoot, syntheticConfig, syntheticEvals);


### PR DESCRIPTION
## Summary
- Add a dedicated Flue role registry helper and validate configured roles before any baseline or eval work starts.
- Fail fast with an error that identifies the missing config fields and lists available Flue roles.
- Update fixtures and coverage to use the registered `eval-judge` role name.

## Testing
- Added unit and integration coverage for missing judge roles, missing track roles, and valid role configs.
- Verified the dry-run path still scores baseline and candidate runs correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The system now discovers and validates configured Flue roles from project role sources before orchestration, and reports any missing roles with grouped references and an "Available roles" summary.

* **Tests**
  * Added tests to ensure invalid role configurations are rejected before baseline work and that valid configurations proceed.
  * Updated end-to-end assertions to expect a specific role-labeled ordering and adjusted test fixtures accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix #16 