### PR TITLE
Add cost preview guardrails to the autoresearch harness

### DIFF
--- a/.flue/workflows/autoresearch.ts
+++ b/.flue/workflows/autoresearch.ts
@@ -11,6 +11,7 @@ interface AutoresearchPayload {
   forceResearch?: boolean;
   seedSkillDir?: string;
   guidanceSkillDir?: string;
+  budgetUsd?: number;
   sessionId?: string;
   model?: string;
 }
@@ -20,7 +21,7 @@ export async function run({ init, payload, env }: FlueContext<AutoresearchPayloa
   const autoresearch = createAgent(() => ({
     sandbox: local(),
     model,
-    subagents: autoresearchProfiles,
+    subagents: autoresearchProfiles
   }));
   const harness = await init(autoresearch);
   const session = await harness.session(payload.sessionId ?? "autoresearch");
@@ -32,12 +33,14 @@ export async function run({ init, payload, env }: FlueContext<AutoresearchPayloa
     forceResearch: payload.forceResearch,
     seedSkillDir: payload.seedSkillDir,
     guidanceSkillDir: payload.guidanceSkillDir,
+    budgetUsd: payload.budgetUsd
   });
 
   return {
     completedIterations: result.completedIterations,
     normalizedScore: result.aggregate.overall.normalizedScore,
     bestSkillDir: result.bestIteration?.skillDir,
-    events: result.events.map((event) => event.type),
+    cost: result.cost,
+    events: result.events.map((event) => event.type)
   };
 }

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -100,6 +100,7 @@ The important parts are not the exact directory names for every project, but tha
   "target_score": 0.8,
   "max_iterations": 1,
   "max_concurrency": 1,
+  "budget_usd": 0.5,
   "model": {
     "provider": "anthropic",
     "name": "claude-sonnet-4-6"
@@ -140,6 +141,8 @@ Important fields:
 - `guidance_skill`: optional path to a skill used only as seed/reference guidance, relative to the project root unless absolute. Use this when the candidate should start from `origin_skill`, but the researcher should consult a different reference skill; or when `research_start` is `"empty"` and the guidance source should be different from `origin_skill`. When `research_start` is `"empty"` and `guidance_skill` is omitted, the harness uses `origin_skill` as the guidance skill.
 - `target_score`: normalized score required to stop early.
 - `max_iterations`: maximum candidate-improvement attempts.
+- `max_concurrency`: maximum eval cases to run at the same time. This changes parallelism, not the total number of planned calls.
+- `budget_usd`: optional observed-cost cap. When provider usage and known pricing are available, the harness stops before starting more model calls once observed cost reaches this amount.
 - `models.producer`: model that produces eval outputs. The default config uses a cheaper/smaller model here.
 - `models.judge`: model that scores producer outputs. The default config uses a stronger model here.
 - `models.researcher`: model that patches the skill.
@@ -151,6 +154,36 @@ These role/model choices are starting suggestions, not requirements. Try differe
 Flue subagent profiles live in `.flue/profiles.ts`. The configured role labels are still passed through prompts as project context, while Flue behavior comes from the named `producer`, `judge`, and `researcher` profiles.
 
 For a multi-skill project, use one track per skill or skill responsibility. For example, a security project might have an `audit` track that targets `skills/security-audit` and an `authoring` track that targets `skills/secure-authoring`.
+
+## Cost Preview And Budget
+
+Before model-backed work starts, the harness emits a cost preview with the maximum planned model-call count by role:
+
+```text
+baseline producer calls = eval count when generating a fresh baseline
+baseline judge calls = eval count when generating a fresh baseline
+researcher calls = max_iterations when runResearch is true
+iteration producer calls = eval count * max_iterations when runResearch is true
+iteration judge calls = eval count * max_iterations when runResearch is true
+```
+
+Imported baseline smoke runs with `withBaseline:true` plan no baseline producer or judge calls. `max_concurrency` controls how many evals can run at once; it does not reduce the number of producer or judge calls.
+
+Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pass `--budget-usd <amount>` to the CLI for a one-off override. Flue payloads accept `budgetUsd`:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"budgetUsd":0.5,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+```
+
+The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue runs currently record call counts, but they do not expose token usage to this harness, so dollar-cost caps only take effect when usage and known pricing are available. Treat the dollar estimate as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
+
+Each successful run writes:
+
+```text
+workspace/cost-summary.json
+```
+
+That file includes planned calls, observed calls by role, token usage when available, and observed estimated cost when known.
 
 ## Seed Skill Selection
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
 import { FileScoreAgent, SnapshotResearcher } from "./adapters.js";
+import { formatCallCounts } from "./cost.js";
 import { createLogger, Logger, LogLevel } from "./logger.js";
 import { AnthropicMessagesClient, ModelEvalAgent, ModelSkillResearcher } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, RunEvent } from "./orchestrator.js";
@@ -13,6 +14,7 @@ interface CliOptions {
   seedSkillDir?: string;
   scoreDir?: string;
   modelClient?: "anthropic";
+  budgetUsd?: number;
   json: boolean;
 }
 
@@ -28,8 +30,9 @@ function usage(): string {
     "  --seed-skill <dir>    Seed skill directory for research iterations.",
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
+    "  --budget-usd <amount> Stop before additional model calls once observed cost reaches this cap.",
     "  --json                Print the full orchestrator result as JSON.",
-    "  -h, --help            Show this help.",
+    "  -h, --help            Show this help."
   ].join("\n");
 }
 
@@ -44,11 +47,12 @@ export function parseCliArgs(argv: string[]): CliOptions {
       "seed-skill": { type: "string" },
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
+      "budget-usd": { type: "string" },
       json: { type: "boolean" },
-      help: { type: "boolean", short: "h" },
+      help: { type: "boolean", short: "h" }
     },
     strict: true,
-    allowPositionals: false,
+    allowPositionals: false
   });
 
   if (parsed.values.help) {
@@ -64,7 +68,8 @@ export function parseCliArgs(argv: string[]): CliOptions {
     seedSkillDir: parsed.values["seed-skill"],
     scoreDir: parsed.values["score-dir"],
     modelClient: parseModelClient(parsed.values["model-client"]),
-    json: parsed.values.json ?? false,
+    budgetUsd: parseBudgetUsd(parsed.values["budget-usd"]),
+    json: parsed.values.json ?? false
   };
 
   if (options.scoreDir && options.modelClient) {
@@ -78,6 +83,20 @@ export function parseCliArgs(argv: string[]): CliOptions {
   }
 
   return options;
+}
+
+function parseBudgetUsd(value: string | boolean | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error("--budget-usd must be a non-negative number.");
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error("--budget-usd must be a non-negative number.");
+  }
+  return parsed;
 }
 
 function parseModelClient(value: string | boolean | undefined): "anthropic" | undefined {
@@ -100,6 +119,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     runResearch: cli.runResearch,
     forceResearch: cli.forceResearch,
     seedSkillDir: cli.seedSkillDir,
+    budgetUsd: cli.budgetUsd,
+    modelBacked: Boolean(modelClient),
+    onEvent: cli.json
+      ? undefined
+      : (event) => {
+          const formatted = formatEvent(event);
+          logger.write(formatted.level, formatted.message);
+        },
     agent: modelClient
       ? new ModelEvalAgent(modelClient)
       : cli.scoreDir
@@ -109,7 +136,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       ? new ModelSkillResearcher(modelClient)
       : cli.runResearch
         ? new SnapshotResearcher()
-        : undefined,
+        : undefined
   };
 
   const result = await orchestrateBaseline(options);
@@ -118,12 +145,15 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
 
-  writeEvents(result.events, logger);
   logger.write(
     "log",
     `Final score: ${result.aggregate.overall.normalizedScore.toFixed(3)} ` +
-      `(${result.aggregate.overall.score}/${result.aggregate.overall.maxScore})`,
+      `(${result.aggregate.overall.score}/${result.aggregate.overall.maxScore})`
   );
+  logger.write("log", `Model calls: ${formatCallCounts(result.cost.actual.calls)}`);
+  if (result.cost.actual.costUsd !== undefined) {
+    logger.write("log", `Observed model cost: $${result.cost.actual.costUsd.toFixed(4)}`);
+  }
   if (result.bestIteration) {
     logger.write("log", `Best skill: ${result.bestIteration.skillDir}`);
   }
@@ -140,6 +170,17 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
   switch (event.type) {
     case "project-loaded":
       return { level: "debug", message: `Loaded project: ${event.root}` };
+    case "cost-preview":
+      return {
+        level: event.summary.planned.totalCalls > 20 ? "warn" : "log",
+        message:
+          `Model call preview: ${event.summary.planned.totalCalls} maximum planned call(s) ` +
+          `across ${event.summary.planned.evalCount} eval(s), ` +
+          `${event.summary.planned.maxIterations} max iteration(s), ` +
+          `concurrency ${event.summary.planned.maxConcurrency}. ` +
+          `By role: ${formatCallCounts(event.summary.planned.calls)}` +
+          (event.summary.budgetUsd === undefined ? "" : `. Budget: $${event.summary.budgetUsd.toFixed(2)}`)
+      };
     case "baseline-imported":
       return { level: "log", message: `Imported baseline: ${event.scores} scores` };
     case "baseline-started":
@@ -149,44 +190,49 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
     case "aggregated":
       return {
         level: "log",
-        message: `Aggregated score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`,
+        message: `Aggregated score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`
       };
     case "research-loop-ready":
       return {
         level: "debug",
-        message: `Research loop ready: ${event.completedIterations}/${event.maxIterations} iterations complete`,
+        message: `Research loop ready: ${event.completedIterations}/${event.maxIterations} iterations complete`
       };
     case "iteration-started":
       return { level: "log", message: `Iteration ${event.iteration} started` };
     case "iteration-generated":
       return {
         level: "debug",
-        message: `Iteration ${event.iteration} skill: ${event.candidateSkillDir}`,
+        message: `Iteration ${event.iteration} skill: ${event.candidateSkillDir}`
       };
     case "iteration-scored":
       return {
         level: "log",
-        message: `Iteration ${event.iteration} score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`,
+        message: `Iteration ${event.iteration} score: ${event.aggregate.overall.normalizedScore.toFixed(3)}`
       };
     case "baseline-target-score-reached":
       return {
         level: "log",
-        message: `Baseline reached target: ${event.normalizedScore.toFixed(3)} >= ${event.targetScore.toFixed(3)}`,
+        message: `Baseline reached target: ${event.normalizedScore.toFixed(3)} >= ${event.targetScore.toFixed(3)}`
       };
     case "target-score-reached":
       return {
         level: "log",
-        message: `Target reached at iteration ${event.iteration}: ${event.normalizedScore.toFixed(3)}`,
+        message: `Target reached at iteration ${event.iteration}: ${event.normalizedScore.toFixed(3)}`
       };
     case "target-score-blocked-by-regression":
       return {
         level: "warn",
-        message: `Target score met at iteration ${event.iteration}, but ${event.regressions.length} eval(s) regressed from baseline`,
+        message: `Target score met at iteration ${event.iteration}, but ${event.regressions.length} eval(s) regressed from baseline`
       };
     case "max-iterations-reached":
       return {
         level: "warn",
-        message: `Max iterations reached: ${event.completedIterations}/${event.maxIterations}`,
+        message: `Max iterations reached: ${event.completedIterations}/${event.maxIterations}`
+      };
+    case "budget-reached":
+      return {
+        level: "warn",
+        message: `Budget reached after ${event.completedIterations} iteration(s): $${event.actualCostUsd.toFixed(4)} >= $${event.budgetUsd.toFixed(4)}`
       };
   }
 }

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,0 +1,266 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pricingForModel } from "./pricing.js";
+import { ProjectInputs } from "./project.js";
+import { ModelConfig } from "./schemas.js";
+
+export type ModelCallRole =
+  | "baseline_producer"
+  | "baseline_judge"
+  | "researcher"
+  | "iteration_producer"
+  | "iteration_judge";
+
+export type ModelCallCounts = Record<ModelCallRole, number>;
+
+export interface ModelCallPreview {
+  evalCount: number;
+  maxIterations: number;
+  maxConcurrency: number;
+  withBaseline: boolean;
+  runResearch: boolean;
+  modelBacked: boolean;
+  calls: ModelCallCounts;
+  totalCalls: number;
+}
+
+export interface ModelUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
+export interface ModelUsageSummary {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+}
+
+export type ModelUsageByRole = Record<ModelCallRole, ModelUsageSummary>;
+
+export interface ModelCallRecord {
+  role: ModelCallRole;
+  phase?: string;
+  model: ModelConfig;
+  usage?: ModelUsage;
+  costUsd?: number;
+}
+
+export interface ModelRunCostSummary {
+  budgetUsd?: number;
+  planned: ModelCallPreview;
+  actual: {
+    calls: ModelCallCounts;
+    totalCalls: number;
+    usageByRole: ModelUsageByRole;
+    totalUsage: ModelUsageSummary;
+    costUsd?: number;
+    records: ModelCallRecord[];
+  };
+}
+
+export class BudgetExceededError extends Error {
+  constructor(
+    readonly budgetUsd: number,
+    readonly actualCostUsd: number
+  ) {
+    super(`Model budget reached: observed $${actualCostUsd.toFixed(4)} >= configured budget $${budgetUsd.toFixed(4)}`);
+  }
+}
+
+export const MODEL_CALL_ROLES: readonly ModelCallRole[] = [
+  "baseline_producer",
+  "baseline_judge",
+  "researcher",
+  "iteration_producer",
+  "iteration_judge"
+];
+
+const EMPTY_USAGE: ModelUsageSummary = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 0
+};
+
+export function createModelCallPreview(
+  project: ProjectInputs,
+  options: { withBaseline?: boolean; runResearch?: boolean; modelBacked?: boolean }
+): ModelCallPreview {
+  const evalCount = project.evals.evals.length;
+  const maxIterations = project.config.max_iterations;
+  const modelBacked = options.modelBacked ?? true;
+  const calls = emptyCallCounts();
+
+  if (modelBacked) {
+    if (!options.withBaseline) {
+      calls.baseline_producer = evalCount;
+      calls.baseline_judge = evalCount;
+    }
+    if (options.runResearch) {
+      calls.researcher = maxIterations;
+      calls.iteration_producer = evalCount * maxIterations;
+      calls.iteration_judge = evalCount * maxIterations;
+    }
+  }
+
+  return {
+    evalCount,
+    maxIterations,
+    maxConcurrency: project.config.max_concurrency,
+    withBaseline: options.withBaseline ?? false,
+    runResearch: options.runResearch ?? false,
+    modelBacked,
+    calls,
+    totalCalls: sumCalls(calls)
+  };
+}
+
+export class ModelRunCostTracker {
+  readonly #budgetUsd: number | undefined;
+  readonly #planned: ModelCallPreview;
+  readonly #calls = emptyCallCounts();
+  readonly #usageByRole = emptyUsageByRole();
+  readonly #records: ModelCallRecord[] = [];
+  #costUsd: number | undefined;
+
+  constructor(planned: ModelCallPreview, budgetUsd?: number) {
+    this.#planned = planned;
+    this.#budgetUsd = budgetUsd;
+  }
+
+  get budgetUsd(): number | undefined {
+    return this.#budgetUsd;
+  }
+
+  get planned(): ModelCallPreview {
+    return this.#planned;
+  }
+
+  get actualCostUsd(): number | undefined {
+    return this.#costUsd;
+  }
+
+  assertCanStartModelCall(): void {
+    if (this.#budgetUsd === undefined || this.#costUsd === undefined) {
+      return;
+    }
+    if (this.#costUsd >= this.#budgetUsd) {
+      throw new BudgetExceededError(this.#budgetUsd, this.#costUsd);
+    }
+  }
+
+  isBudgetReached(): boolean {
+    return this.#budgetUsd !== undefined && this.#costUsd !== undefined && this.#costUsd >= this.#budgetUsd;
+  }
+
+  recordModelCall(record: ModelCallRecord): void {
+    this.#calls[record.role]++;
+    addUsage(this.#usageByRole[record.role], record.usage);
+    const costUsd = record.costUsd ?? estimateUsageCostUsd(record.model, record.usage);
+    if (costUsd !== undefined) {
+      this.#costUsd = (this.#costUsd ?? 0) + costUsd;
+    }
+    this.#records.push({ ...record, costUsd });
+  }
+
+  summary(): ModelRunCostSummary {
+    const usageByRole = cloneUsageByRole(this.#usageByRole);
+    return {
+      ...(this.#budgetUsd === undefined ? {} : { budgetUsd: this.#budgetUsd }),
+      planned: this.#planned,
+      actual: {
+        calls: { ...this.#calls },
+        totalCalls: sumCalls(this.#calls),
+        usageByRole,
+        totalUsage: totalUsage(usageByRole),
+        ...(this.#costUsd === undefined ? {} : { costUsd: this.#costUsd }),
+        records: this.#records.map((record) => ({
+          ...record,
+          usage: record.usage ? { ...record.usage } : undefined
+        }))
+      }
+    };
+  }
+}
+
+export async function persistCostSummary(projectRoot: string, summary: ModelRunCostSummary): Promise<void> {
+  const workspaceDir = join(projectRoot, "workspace");
+  await mkdir(workspaceDir, { recursive: true });
+  await writeFile(join(workspaceDir, "cost-summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+export function formatCallCounts(counts: ModelCallCounts): string {
+  return MODEL_CALL_ROLES.map((role) => `${role}: ${counts[role]}`).join(", ");
+}
+
+export function estimateUsageCostUsd(model: ModelConfig, usage: ModelUsage | undefined): number | undefined {
+  if (!usage || model.provider !== "anthropic") {
+    return undefined;
+  }
+  const pricing = pricingForModel(model);
+  if (!pricing) {
+    return undefined;
+  }
+  return (
+    ((usage.inputTokens ?? 0) * pricing.inputUsdPerMillion +
+      (usage.outputTokens ?? 0) * pricing.outputUsdPerMillion +
+      (usage.cacheCreationInputTokens ?? 0) * pricing.cacheCreationUsdPerMillion +
+      (usage.cacheReadInputTokens ?? 0) * pricing.cacheReadUsdPerMillion) /
+    1_000_000
+  );
+}
+
+function emptyCallCounts(): ModelCallCounts {
+  return {
+    baseline_producer: 0,
+    baseline_judge: 0,
+    researcher: 0,
+    iteration_producer: 0,
+    iteration_judge: 0
+  };
+}
+
+function emptyUsageByRole(): ModelUsageByRole {
+  return {
+    baseline_producer: { ...EMPTY_USAGE },
+    baseline_judge: { ...EMPTY_USAGE },
+    researcher: { ...EMPTY_USAGE },
+    iteration_producer: { ...EMPTY_USAGE },
+    iteration_judge: { ...EMPTY_USAGE }
+  };
+}
+
+function addUsage(target: ModelUsageSummary, usage: ModelUsage | undefined): void {
+  if (!usage) {
+    return;
+  }
+  target.inputTokens += usage.inputTokens ?? 0;
+  target.outputTokens += usage.outputTokens ?? 0;
+  target.cacheCreationInputTokens += usage.cacheCreationInputTokens ?? 0;
+  target.cacheReadInputTokens += usage.cacheReadInputTokens ?? 0;
+}
+
+function cloneUsageByRole(usageByRole: ModelUsageByRole): ModelUsageByRole {
+  return {
+    baseline_producer: { ...usageByRole.baseline_producer },
+    baseline_judge: { ...usageByRole.baseline_judge },
+    researcher: { ...usageByRole.researcher },
+    iteration_producer: { ...usageByRole.iteration_producer },
+    iteration_judge: { ...usageByRole.iteration_judge }
+  };
+}
+
+function totalUsage(usageByRole: ModelUsageByRole): ModelUsageSummary {
+  const summary = { ...EMPTY_USAGE };
+  for (const role of MODEL_CALL_ROLES) {
+    addUsage(summary, usageByRole[role]);
+  }
+  return summary;
+}
+
+function sumCalls(counts: ModelCallCounts): number {
+  return MODEL_CALL_ROLES.reduce((sum, role) => sum + counts[role], 0);
+}

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -1,4 +1,5 @@
 import type { FlueSession } from "@flue/runtime/client";
+import { ModelCallRole } from "./cost.js";
 import {
   applyOutputFiles,
   appendGuidanceLedger,
@@ -12,7 +13,13 @@ import {
 } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, SkillResearcher } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
-import { EvalScore, EvalScoreSchema, ModelProduceResponseSchema, SkillResearchPatchSchema } from "./schemas.js";
+import {
+  EvalScore,
+  EvalScoreSchema,
+  ModelConfig,
+  ModelProduceResponseSchema,
+  SkillResearchPatchSchema
+} from "./schemas.js";
 import { cp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -33,12 +40,14 @@ export class FlueEvalAgent implements EvalAgent {
 
   async run(request: EvalAgentRequest): Promise<EvalScore> {
     const produceRequest = await buildProduceModelRequest(request);
+    request.costTracker?.assertCanStartModelCall();
     const { data: produced } = await this.#session.task(produceRequest.prompt, {
       result: ModelProduceResponseSchema,
       agent: PRODUCER_AGENT,
       model: toFlueModel(produceRequest.model),
       cwd: produceRequest.workspaceDir
     });
+    recordFlueCall(request.costTracker, request.baseline ? "baseline_producer" : "iteration_producer", produceRequest);
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
     await writeTranscript(request.sandbox.outputDir, "producer-flue-transcript.json", {
       request: produceRequest,
@@ -46,12 +55,14 @@ export class FlueEvalAgent implements EvalAgent {
     });
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
+    request.costTracker?.assertCanStartModelCall();
     const { data: score } = await this.#session.task(judgeRequest.prompt, {
       result: EvalScoreSchema,
       agent: JUDGE_AGENT,
       model: toFlueModel(judgeRequest.model),
       cwd: judgeRequest.workspaceDir
     });
+    recordFlueCall(request.costTracker, request.baseline ? "baseline_judge" : "iteration_judge", judgeRequest);
     const validated = parseModelJudgeResponse(JSON.stringify(score), request.evalCase, request.track);
     await writeTranscript(request.sandbox.outputDir, "judge-flue-transcript.json", {
       request: judgeRequest,
@@ -70,12 +81,14 @@ export class FlueSkillResearcher implements SkillResearcher {
 
   async improve(request: Parameters<SkillResearcher["improve"]>[0]): Promise<void> {
     const modelRequest = await buildResearchModelRequest(request);
+    request.costTracker?.assertCanStartModelCall();
     const { data: patch } = await this.#session.task(modelRequest.prompt, {
       result: SkillResearchPatchSchema,
       agent: RESEARCHER_AGENT,
       model: toFlueModel(modelRequest.model),
       cwd: modelRequest.workspaceDir
     });
+    recordFlueCall(request.costTracker, "researcher", modelRequest);
     validateSkillResearchPatch(request.candidateSkillDir, patch);
     await cp(request.previousSkillDir, request.candidateSkillDir, {
       recursive: true,
@@ -96,6 +109,18 @@ export class FlueSkillResearcher implements SkillResearcher {
   }
 }
 
+function recordFlueCall(
+  tracker: Parameters<SkillResearcher["improve"]>[0]["costTracker"],
+  role: ModelCallRole,
+  request: { phase?: string; model: ModelConfig }
+): void {
+  tracker?.recordModelCall({
+    role,
+    phase: request.phase,
+    model: request.model
+  });
+}
+
 function toFlueModel(model: { provider: string; name: string }): string {
   return `${model.provider}/${model.name}`;
 }
@@ -103,6 +128,7 @@ function toFlueModel(model: { provider: string; name: string }): string {
 export async function runFlueAutoresearch(options: FlueAutoresearchOptions) {
   return orchestrateBaseline({
     ...options,
+    modelBacked: true,
     agent: new FlueEvalAgent(options.session),
     researcher: options.runResearch ? new FlueSkillResearcher(options.session) : undefined
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export * from "./adapters.js";
 export * from "./logger.js";
 export * from "./model-agent.js";
 export * from "./flue-harness.js";
+export * from "./cost.js";
+export * from "./pricing.js";

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -1,5 +1,6 @@
 import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
+import { ModelCallRole, ModelUsage } from "./cost.js";
 import { SkillResearcher, SkillResearchRequest } from "./orchestrator.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
 import { buildJudgePrompt } from "./prompts/judge-prompt.js";
@@ -24,16 +25,20 @@ import {
 export interface ModelRequest {
   system: string;
   prompt: string;
-  model: {
-    provider: string;
-    name: string;
-  };
+  model: ModelConfig;
   phase?: string;
   workspaceDir?: string;
 }
 
+export interface ModelCompletionResponse {
+  text: string;
+  usage?: ModelUsage;
+}
+
+export type ModelCompletion = string | ModelCompletionResponse;
+
 export interface ModelClient {
-  complete(request: ModelRequest): Promise<string>;
+  complete(request: ModelRequest): Promise<ModelCompletion>;
 }
 
 export interface AnthropicMessagesClientOptions {
@@ -60,7 +65,7 @@ export class AnthropicMessagesClient implements ModelClient {
     this.#fetch = options.fetch ?? fetch;
   }
 
-  async complete(request: ModelRequest): Promise<string> {
+  async complete(request: ModelRequest): Promise<ModelCompletion> {
     if (request.model.provider !== "anthropic") {
       throw new Error(`AnthropicMessagesClient cannot run provider "${request.model.provider}"`);
     }
@@ -84,7 +89,15 @@ export class AnthropicMessagesClient implements ModelClient {
       throw new Error(`Anthropic request failed with ${response.status}: ${await response.text()}`);
     }
 
-    const body = (await response.json()) as { content?: Array<{ type?: string; text?: string }> };
+    const body = (await response.json()) as {
+      content?: Array<{ type?: string; text?: string }>;
+      usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        cache_creation_input_tokens?: number;
+        cache_read_input_tokens?: number;
+      };
+    };
     const text = body.content
       ?.filter((item) => item.type === "text" && typeof item.text === "string")
       .map((item) => item.text)
@@ -92,7 +105,15 @@ export class AnthropicMessagesClient implements ModelClient {
     if (!text) {
       throw new Error("Anthropic response did not include text content");
     }
-    return text;
+    return {
+      text,
+      usage: {
+        inputTokens: body.usage?.input_tokens,
+        outputTokens: body.usage?.output_tokens,
+        cacheCreationInputTokens: body.usage?.cache_creation_input_tokens,
+        cacheReadInputTokens: body.usage?.cache_read_input_tokens
+      }
+    };
   }
 }
 
@@ -105,7 +126,12 @@ export class ModelEvalAgent implements EvalAgent {
 
   async run(request: EvalAgentRequest): Promise<EvalScore> {
     const produceRequest = await buildProduceModelRequest(request);
-    const produceResponse = await this.#client.complete(produceRequest);
+    const produceResponse = await completeTrackedModelRequest(
+      this.#client,
+      produceRequest,
+      request.baseline ? "baseline_producer" : "iteration_producer",
+      request.costTracker
+    );
     await persistTranscript(
       join(request.sandbox.outputDir, "producer-transcript.json"),
       produceRequest,
@@ -115,7 +141,12 @@ export class ModelEvalAgent implements EvalAgent {
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
 
     const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
-    const judgeResponse = await this.#client.complete(judgeRequest);
+    const judgeResponse = await completeTrackedModelRequest(
+      this.#client,
+      judgeRequest,
+      request.baseline ? "baseline_judge" : "iteration_judge",
+      request.costTracker
+    );
     await persistTranscript(join(request.sandbox.outputDir, "judge-transcript.json"), judgeRequest, judgeResponse);
     return parseModelJudgeResponse(judgeResponse, request.evalCase, request.track);
   }
@@ -130,7 +161,7 @@ export class ModelSkillResearcher implements SkillResearcher {
 
   async improve(request: SkillResearchRequest): Promise<void> {
     const modelRequest = await buildResearchModelRequest(request);
-    const response = await this.#client.complete(modelRequest);
+    const response = await completeTrackedModelRequest(this.#client, modelRequest, "researcher", request.costTracker);
     const patch = parseSkillResearchPatch(response);
     validateSkillResearchPatch(request.candidateSkillDir, patch);
     await cp(request.previousSkillDir, request.candidateSkillDir, {
@@ -147,6 +178,31 @@ export class ModelSkillResearcher implements SkillResearcher {
     });
     await persistTranscript(join(request.candidateSkillDir, ".autoresearch-transcript.json"), modelRequest, response);
   }
+}
+
+async function completeTrackedModelRequest(
+  client: ModelClient,
+  request: ModelRequest,
+  role: ModelCallRole,
+  tracker: SkillResearchRequest["costTracker"] | EvalAgentRequest["costTracker"]
+): Promise<string> {
+  tracker?.assertCanStartModelCall();
+  const completion = await client.complete(request);
+  tracker?.recordModelCall({
+    role,
+    phase: request.phase,
+    model: request.model,
+    usage: modelCompletionUsage(completion)
+  });
+  return modelCompletionText(completion);
+}
+
+export function modelCompletionText(completion: ModelCompletion): string {
+  return typeof completion === "string" ? completion : completion.text;
+}
+
+export function modelCompletionUsage(completion: ModelCompletion): ModelUsage | undefined {
+  return typeof completion === "string" ? undefined : completion.usage;
 }
 
 export async function buildProduceModelRequest(request: EvalAgentRequest): Promise<ModelRequest> {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,6 +2,7 @@ import { cp, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
+import { createModelCallPreview, ModelRunCostSummary, ModelRunCostTracker, persistCostSummary } from "./cost.js";
 import { loadAvailableFlueRoles, validateConfiguredFlueRoles } from "./flue-roles.js";
 import { loadProject, ProjectInputs } from "./project.js";
 import { runEval, runWithConcurrency, EvalAgent } from "./runner.js";
@@ -9,6 +10,7 @@ import { EvalScore } from "./schemas.js";
 
 export type RunEvent =
   | { type: "project-loaded"; root: string }
+  | { type: "cost-preview"; summary: ModelRunCostSummary }
   | { type: "baseline-imported"; scores: number; missing: string[] }
   | { type: "baseline-started"; evals: number; countsTowardIterations: false }
   | { type: "baseline-generated"; scores: number }
@@ -36,6 +38,7 @@ export type RunEvent =
     }
   | { type: "max-iterations-reached"; completedIterations: number; maxIterations: number }
   | { type: "research-loop-ready"; completedIterations: number; maxIterations: number }
+  | { type: "budget-reached"; budgetUsd: number; actualCostUsd: number; completedIterations: number }
   | { type: "aggregated"; aggregate: AggregateReport };
 
 export interface ScoreRegression {
@@ -58,6 +61,7 @@ export interface OrchestratorResult {
   completedIterations: number;
   iterations: IterationResult[];
   bestIteration?: IterationResult;
+  cost: ModelRunCostSummary;
   events: RunEvent[];
 }
 
@@ -71,6 +75,7 @@ export interface SkillResearchRequest {
   baselineScores: EvalScore[];
   previousScores: EvalScore[];
   previousAggregate: AggregateReport;
+  costTracker?: ModelRunCostTracker;
 }
 
 export interface SkillResearcher {
@@ -86,87 +91,107 @@ export interface OrchestrateOptions {
   forceResearch?: boolean;
   seedSkillDir?: string;
   guidanceSkillDir?: string;
+  budgetUsd?: number;
+  modelBacked?: boolean;
+  onEvent?: (event: RunEvent) => void;
 }
 
-export async function orchestrateBaseline(
-  options: OrchestrateOptions,
-): Promise<OrchestratorResult> {
+export async function orchestrateBaseline(options: OrchestrateOptions): Promise<OrchestratorResult> {
   const events: RunEvent[] = [];
+  const emit = createEventSink(events, options.onEvent);
   const project = await loadProject(options.projectRoot);
-  events.push({ type: "project-loaded", root: project.root });
+  emit({ type: "project-loaded", root: project.root });
   validateConfiguredFlueRoles(project.config, await loadAvailableFlueRoles());
+  const costTracker = new ModelRunCostTracker(
+    createModelCallPreview(project, {
+      withBaseline: options.withBaseline,
+      runResearch: options.runResearch,
+      modelBacked: options.modelBacked
+    }),
+    options.budgetUsd ?? project.config.budget_usd
+  );
+  emit({ type: "cost-preview", summary: costTracker.summary() });
 
   const expectedEvalIds = project.evals.evals.map((evalCase) => evalCase.id);
   const baselineScores = options.withBaseline
-    ? await importRequiredBaseline(project, expectedEvalIds, events)
-    : await generateInitialBaseline(project, options.agent, events);
+    ? await importRequiredBaseline(project, expectedEvalIds, emit)
+    : await generateInitialBaseline(project, options.agent, emit, costTracker);
 
   const aggregate = aggregateScores(project.config, baselineScores);
-  events.push({ type: "aggregated", aggregate });
+  emit({ type: "aggregated", aggregate });
 
   if (
     options.runResearch &&
     !options.forceResearch &&
     aggregate.overall.normalizedScore >= project.config.target_score
   ) {
-    events.push({
+    emit({
       type: "baseline-target-score-reached",
       normalizedScore: aggregate.overall.normalizedScore,
-      targetScore: project.config.target_score,
+      targetScore: project.config.target_score
     });
-    return { project, baselineScores, aggregate, completedIterations: 0, iterations: [], events };
+    return finishRun(project, emit, events, costTracker, {
+      project,
+      baselineScores,
+      aggregate,
+      completedIterations: 0,
+      iterations: []
+    });
   }
 
-  events.push({
+  emit({
     type: "research-loop-ready",
     completedIterations: 0,
-    maxIterations: project.config.max_iterations,
+    maxIterations: project.config.max_iterations
   });
 
   if (!options.runResearch) {
-    return { project, baselineScores, aggregate, completedIterations: 0, iterations: [], events };
+    return finishRun(project, emit, events, costTracker, {
+      project,
+      baselineScores,
+      aggregate,
+      completedIterations: 0,
+      iterations: []
+    });
   }
 
-  const research = await runResearchIterations(project, baselineScores, aggregate, options, events);
+  const research = await runResearchIterations(project, baselineScores, aggregate, options, emit, costTracker);
 
-  return {
+  return finishRun(project, emit, events, costTracker, {
     project,
     baselineScores,
     aggregate: research.bestIteration?.aggregate ?? aggregate,
     completedIterations: research.iterations.length,
     iterations: research.iterations,
-    bestIteration: research.bestIteration,
-    events,
-  };
+    bestIteration: research.bestIteration
+  });
 }
 
 async function importRequiredBaseline(
   project: ProjectInputs,
   expectedEvalIds: string[],
-  events: RunEvent[],
+  emit: (event: RunEvent) => void
 ): Promise<EvalScore[]> {
   if (!project.baselineDir) {
     throw new Error(
-      "Run was started with --with-baseline, but workspace/baseline was not found. Remove --with-baseline to generate an initial baseline run.",
+      "Run was started with --with-baseline, but workspace/baseline was not found. Remove --with-baseline to generate an initial baseline run."
     );
   }
 
   const baseline = await importBaselineArtefacts(project.baselineDir, expectedEvalIds);
-  events.push({
+  emit({
     type: "baseline-imported",
     scores: baseline.scores.length,
-    missing: baseline.missing,
+    missing: baseline.missing
   });
 
-  const missingScores = expectedEvalIds.filter(
-    (evalId) => !baseline.scores.some((score) => score.eval_id === evalId),
-  );
+  const missingScores = expectedEvalIds.filter((evalId) => !baseline.scores.some((score) => score.eval_id === evalId));
   if (missingScores.length > 0 || baseline.missing.length > 0) {
     throw new Error(
       `Run was started with --with-baseline, but baseline artefacts are incomplete. Missing: ${[
         ...missingScores.map((evalId) => `score:${evalId}`),
-        ...baseline.missing,
-      ].join(", ")}`,
+        ...baseline.missing
+      ].join(", ")}`
     );
   }
 
@@ -176,36 +201,35 @@ async function importRequiredBaseline(
 async function generateInitialBaseline(
   project: ProjectInputs,
   agent: EvalAgent | undefined,
-  events: RunEvent[],
+  emit: (event: RunEvent) => void,
+  costTracker: ModelRunCostTracker
 ): Promise<EvalScore[]> {
   if (!agent) {
     throw new Error("No eval agent was provided to generate the initial baseline run");
   }
 
-  events.push({
+  emit({
     type: "baseline-started",
     evals: project.evals.evals.length,
-    countsTowardIterations: false,
+    countsTowardIterations: false
   });
 
   const outputRoot = join(project.root, "workspace", "baseline");
-  const baselineScores = await runWithConcurrency(
-    project.evals.evals,
-    project.config.max_concurrency,
-    (evalCase) =>
-      runEval(
-        {
-          config: project.config,
-          projectRoot: project.root,
-          evalCase,
-          baseline: true,
-          outputRoot,
-        },
-        agent,
-      ),
+  const baselineScores = await runWithConcurrency(project.evals.evals, project.config.max_concurrency, (evalCase) =>
+    runEval(
+      {
+        config: project.config,
+        projectRoot: project.root,
+        evalCase,
+        baseline: true,
+        outputRoot,
+        costTracker
+      },
+      agent
+    )
   );
   await persistBaselineScores(project.root, baselineScores);
-  events.push({ type: "baseline-generated", scores: baselineScores.length });
+  emit({ type: "baseline-generated", scores: baselineScores.length });
   return baselineScores;
 }
 
@@ -215,9 +239,9 @@ async function persistBaselineScores(projectRoot: string, scores: EvalScore[]): 
   await Promise.all(
     scores.map((score, index) =>
       writeFile(join(baselineDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
-        flag: "wx",
-      }),
-    ),
+        flag: "wx"
+      })
+    )
   );
 }
 
@@ -226,7 +250,8 @@ async function runResearchIterations(
   baselineScores: EvalScore[],
   baselineAggregate: AggregateReport,
   options: OrchestrateOptions,
-  events: RunEvent[],
+  emit: (event: RunEvent) => void,
+  costTracker: ModelRunCostTracker
 ): Promise<{ iterations: IterationResult[]; bestIteration?: IterationResult }> {
   if (!options.agent) {
     throw new Error("No eval agent was provided to run research iterations");
@@ -237,14 +262,8 @@ async function runResearchIterations(
 
   const agent = options.agent;
   const seedSkillDir = await resolveSeedSkillDir(project, options.seedSkillDir);
-  const guidanceSkillDir = await resolveGuidanceSkillDir(
-    project,
-    options.guidanceSkillDir,
-    seedSkillDir,
-  );
-  const guidanceLedgerPath = guidanceSkillDir
-    ? join(project.root, "workspace", "guidance-ledger.json")
-    : undefined;
+  const guidanceSkillDir = await resolveGuidanceSkillDir(project, options.guidanceSkillDir, seedSkillDir);
+  const guidanceLedgerPath = guidanceSkillDir ? join(project.root, "workspace", "guidance-ledger.json") : undefined;
   const iterations: IterationResult[] = [];
   let previousSkillDir = await resolveInitialResearchSkillDir(project, seedSkillDir);
   let previousScores = baselineScores;
@@ -256,7 +275,7 @@ async function runResearchIterations(
     const iterationDir = join(project.root, "workspace", "iterations", String(iteration));
     const candidateSkillDir = join(iterationDir, "skill");
     await mkdir(iterationDir, { recursive: true });
-    events.push({ type: "iteration-started", iteration, previousSkillDir, candidateSkillDir });
+    emit({ type: "iteration-started", iteration, previousSkillDir, candidateSkillDir });
 
     await options.researcher.improve({
       project,
@@ -268,28 +287,32 @@ async function runResearchIterations(
       baselineScores,
       previousScores,
       previousAggregate,
+      costTracker
     });
     await assertExists(
       candidateSkillDir,
-      `Researcher did not create candidate skill directory for iteration ${iteration}`,
+      `Researcher did not create candidate skill directory for iteration ${iteration}`
     );
-    events.push({ type: "iteration-generated", iteration, candidateSkillDir });
+    emit({ type: "iteration-generated", iteration, candidateSkillDir });
 
-    const scores = await runWithConcurrency(
-      project.evals.evals,
-      project.config.max_concurrency,
-      (evalCase) =>
-        runEval(
-          {
-            config: project.config,
-            projectRoot: project.root,
-            evalCase,
-            baseline: false,
-            targetSkillDir: candidateSkillDir,
-            outputRoot: join(iterationDir, "outputs"),
-          },
-          agent,
-        ),
+    if (costTracker.isBudgetReached()) {
+      emitBudgetReached(emit, costTracker, iterations.length);
+      break;
+    }
+
+    const scores = await runWithConcurrency(project.evals.evals, project.config.max_concurrency, (evalCase) =>
+      runEval(
+        {
+          config: project.config,
+          projectRoot: project.root,
+          evalCase,
+          baseline: false,
+          targetSkillDir: candidateSkillDir,
+          outputRoot: join(iterationDir, "outputs"),
+          costTracker
+        },
+        agent
+      )
     );
     await persistIterationScores(iterationDir, scores);
 
@@ -297,34 +320,36 @@ async function runResearchIterations(
     await persistAggregate(join(iterationDir, "summary.json"), aggregate);
     const result = { iteration, skillDir: candidateSkillDir, scores, aggregate };
     iterations.push(result);
-    events.push({ type: "iteration-scored", iteration, scores: scores.length, aggregate });
+    emit({ type: "iteration-scored", iteration, scores: scores.length, aggregate });
 
-    if (
-      !bestIteration ||
-      aggregate.overall.normalizedScore > bestIteration.aggregate.overall.normalizedScore
-    ) {
+    if (!bestIteration || aggregate.overall.normalizedScore > bestIteration.aggregate.overall.normalizedScore) {
       bestIteration = result;
     }
     if (aggregate.overall.normalizedScore >= project.config.target_score) {
       const regressions = findScoreRegressions(baselineScores, scores);
       if (regressions.length > 0) {
-        events.push({
+        emit({
           type: "target-score-blocked-by-regression",
           iteration,
           normalizedScore: aggregate.overall.normalizedScore,
           targetScore: project.config.target_score,
-          regressions,
+          regressions
         });
       } else {
-        events.push({
+        emit({
           type: "target-score-reached",
           iteration,
           normalizedScore: aggregate.overall.normalizedScore,
-          targetScore: project.config.target_score,
+          targetScore: project.config.target_score
         });
         reachedTarget = true;
         break;
       }
+    }
+
+    if (costTracker.isBudgetReached()) {
+      emitBudgetReached(emit, costTracker, iterations.length);
+      break;
     }
 
     previousSkillDir = candidateSkillDir;
@@ -333,20 +358,52 @@ async function runResearchIterations(
   }
 
   if (!reachedTarget && iterations.length === project.config.max_iterations) {
-    events.push({
+    emit({
       type: "max-iterations-reached",
       completedIterations: iterations.length,
-      maxIterations: project.config.max_iterations,
+      maxIterations: project.config.max_iterations
     });
   }
 
   return { iterations, bestIteration };
 }
 
-function findScoreRegressions(
-  baselineScores: EvalScore[],
-  candidateScores: EvalScore[],
-): ScoreRegression[] {
+function createEventSink(events: RunEvent[], onEvent: OrchestrateOptions["onEvent"]): (event: RunEvent) => void {
+  return (event) => {
+    events.push(event);
+    onEvent?.(event);
+  };
+}
+
+async function finishRun(
+  project: ProjectInputs,
+  emit: (event: RunEvent) => void,
+  events: RunEvent[],
+  costTracker: ModelRunCostTracker,
+  result: Omit<OrchestratorResult, "cost" | "events">
+): Promise<OrchestratorResult> {
+  const cost = costTracker.summary();
+  await persistCostSummary(project.root, cost);
+  return { ...result, cost, events };
+}
+
+function emitBudgetReached(
+  emit: (event: RunEvent) => void,
+  costTracker: ModelRunCostTracker,
+  completedIterations: number
+): void {
+  if (costTracker.budgetUsd === undefined || costTracker.actualCostUsd === undefined) {
+    return;
+  }
+  emit({
+    type: "budget-reached",
+    budgetUsd: costTracker.budgetUsd,
+    actualCostUsd: costTracker.actualCostUsd,
+    completedIterations
+  });
+}
+
+function findScoreRegressions(baselineScores: EvalScore[], candidateScores: EvalScore[]): ScoreRegression[] {
   const baselineByEval = new Map(baselineScores.map((score) => [score.eval_id, score]));
   return candidateScores
     .map((candidate) => {
@@ -357,7 +414,7 @@ function findScoreRegressions(
       return {
         evalId: candidate.eval_id,
         baselineScore: baseline.total_score,
-        candidateScore: candidate.total_score,
+        candidateScore: candidate.total_score
       };
     })
     .filter((regression): regression is ScoreRegression => Boolean(regression));
@@ -366,13 +423,9 @@ function findScoreRegressions(
 async function resolveSeedSkillDir(project: ProjectInputs, seedSkillDir?: string): Promise<string> {
   const configured = seedSkillDir ?? project.config.origin_skill;
   if (!configured) {
-    throw new Error(
-      "No seed skill directory was provided. Set origin_skill in config.json or pass seedSkillDir.",
-    );
+    throw new Error("No seed skill directory was provided. Set origin_skill in config.json or pass seedSkillDir.");
   }
-  const resolved = seedSkillDir
-    ? resolve(seedSkillDir)
-    : resolveProjectConfigPath(project, configured);
+  const resolved = seedSkillDir ? resolve(seedSkillDir) : resolveProjectConfigPath(project, configured);
   await assertExists(resolved, `Seed skill directory was not found: ${resolved}`);
   return resolved;
 }
@@ -380,7 +433,7 @@ async function resolveSeedSkillDir(project: ProjectInputs, seedSkillDir?: string
 async function resolveGuidanceSkillDir(
   project: ProjectInputs,
   guidanceSkillDir: string | undefined,
-  seedSkillDir: string,
+  seedSkillDir: string
 ): Promise<string | undefined> {
   const resolved = resolveConfiguredGuidanceSkillDir(project, guidanceSkillDir, seedSkillDir);
   if (!resolved) {
@@ -393,7 +446,7 @@ async function resolveGuidanceSkillDir(
 function resolveConfiguredGuidanceSkillDir(
   project: ProjectInputs,
   guidanceSkillDir: string | undefined,
-  seedSkillDir: string,
+  seedSkillDir: string
 ): string | undefined {
   if (guidanceSkillDir) {
     return resolve(guidanceSkillDir);
@@ -404,10 +457,7 @@ function resolveConfiguredGuidanceSkillDir(
   return project.config.research_start === "empty" ? seedSkillDir : undefined;
 }
 
-async function resolveInitialResearchSkillDir(
-  project: ProjectInputs,
-  seedSkillDir: string,
-): Promise<string> {
+async function resolveInitialResearchSkillDir(project: ProjectInputs, seedSkillDir: string): Promise<string> {
   if ((project.config.research_start ?? "seed") !== "empty") {
     return seedSkillDir;
   }
@@ -434,9 +484,9 @@ async function persistIterationScores(iterationDir: string, scores: EvalScore[])
   await Promise.all(
     scores.map((score, index) =>
       writeFile(join(iterationDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
-        flag: "wx",
-      }),
-    ),
+        flag: "wx"
+      })
+    )
   );
 }
 
@@ -448,6 +498,6 @@ export async function copySkillSnapshot(from: string, to: string): Promise<void>
   await cp(from, to, {
     recursive: true,
     errorOnExist: true,
-    force: false,
+    force: false
   });
 }

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,0 +1,43 @@
+import { ModelConfig } from "./schemas.js";
+
+export interface TokenPricing {
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  cacheCreationUsdPerMillion: number;
+  cacheReadUsdPerMillion: number;
+}
+
+export interface ModelPricingRule {
+  provider: ModelConfig["provider"];
+  modelPattern: RegExp;
+  pricing: TokenPricing;
+}
+
+export const MODEL_PRICING_RULES: readonly ModelPricingRule[] = [
+  {
+    provider: "anthropic",
+    modelPattern: /claude-haiku-4-5/,
+    pricing: {
+      inputUsdPerMillion: 1,
+      outputUsdPerMillion: 5,
+      cacheCreationUsdPerMillion: 1.25,
+      cacheReadUsdPerMillion: 0.1
+    }
+  },
+  {
+    provider: "anthropic",
+    modelPattern: /claude-sonnet-4(?:-\d)?/,
+    pricing: {
+      inputUsdPerMillion: 3,
+      outputUsdPerMillion: 15,
+      cacheCreationUsdPerMillion: 3.75,
+      cacheReadUsdPerMillion: 0.3
+    }
+  }
+];
+
+export function pricingForModel(model: ModelConfig): TokenPricing | undefined {
+  return MODEL_PRICING_RULES.find(
+    (rule) => rule.provider === model.provider && rule.modelPattern.test(model.name)
+  )?.pricing;
+}

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -16,7 +16,7 @@ export interface ModelPricingRule {
 export const MODEL_PRICING_RULES: readonly ModelPricingRule[] = [
   {
     provider: "anthropic",
-    modelPattern: /claude-haiku-4-5/,
+    modelPattern: /^claude-haiku-4-5(?:-\d+)?$/,
     pricing: {
       inputUsdPerMillion: 1,
       outputUsdPerMillion: 5,
@@ -26,7 +26,7 @@ export const MODEL_PRICING_RULES: readonly ModelPricingRule[] = [
   },
   {
     provider: "anthropic",
-    modelPattern: /claude-sonnet-4(?:-\d)?/,
+    modelPattern: /^claude-sonnet-4(?:-\d+)?$/,
     pricing: {
       inputUsdPerMillion: 3,
       outputUsdPerMillion: 15,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { ModelRunCostTracker } from "./cost.js";
 import { resolveModel } from "./model.js";
 import { trackForEval } from "./project.js";
 import { createEvalSandbox, EvalSandbox } from "./sandbox.js";
@@ -12,18 +13,21 @@ export interface EvalRunRequest {
   targetSkillDir?: string;
   outputRoot: string;
   model?: Partial<ModelConfig>;
+  costTracker?: ModelRunCostTracker;
 }
 
 export interface EvalAgentRequest {
   evalCase: EvalCase;
   track: Track;
   role: string;
+  baseline?: boolean;
   modelRoles?: {
     judge?: string;
   };
   targetSkill?: string;
   model: ModelConfig;
   models?: RoleModels;
+  costTracker?: ModelRunCostTracker;
   sandbox: EvalSandbox;
 }
 
@@ -48,12 +52,14 @@ export async function runEval(request: EvalRunRequest, agent: EvalAgent): Promis
     evalCase: request.evalCase,
     track,
     role,
+    baseline: request.baseline,
     modelRoles: {
       judge: request.config.roles.judge
     },
     targetSkill: request.baseline ? undefined : track.target_skill,
     model,
     models: request.config.models,
+    costTracker: request.costTracker,
     sandbox
   });
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4,18 +4,18 @@ export const ModelProviderSchema = v.picklist(["anthropic"]);
 
 export const ModelConfigSchema = v.object({
   provider: ModelProviderSchema,
-  name: v.pipe(v.string(), v.minLength(1)),
+  name: v.pipe(v.string(), v.minLength(1))
 });
 
 export const RoleModelsSchema = v.object({
   producer: v.optional(ModelConfigSchema),
   judge: v.optional(ModelConfigSchema),
-  researcher: v.optional(ModelConfigSchema),
+  researcher: v.optional(ModelConfigSchema)
 });
 
 export const RolesConfigSchema = v.object({
   judge: v.pipe(v.string(), v.minLength(1)),
-  skill_builder: v.pipe(v.string(), v.minLength(1)),
+  skill_builder: v.pipe(v.string(), v.minLength(1))
 });
 
 export const TrackSchema = v.object({
@@ -23,7 +23,7 @@ export const TrackSchema = v.object({
   eval_type: v.pipe(v.string(), v.minLength(1)),
   role: v.pipe(v.string(), v.minLength(1)),
   target_skill: v.pipe(v.string(), v.minLength(1)),
-  requires_description: v.optional(v.boolean(), false),
+  requires_description: v.optional(v.boolean(), false)
 });
 
 export const ProjectConfigSchema = v.object({
@@ -35,16 +35,17 @@ export const ProjectConfigSchema = v.object({
   target_score: v.pipe(v.number(), v.minValue(0)),
   max_iterations: v.pipe(v.number(), v.integer(), v.minValue(1)),
   max_concurrency: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  budget_usd: v.optional(v.pipe(v.number(), v.minValue(0))),
   model: v.optional(ModelConfigSchema),
   models: v.optional(RoleModelsSchema),
   roles: RolesConfigSchema,
-  tracks: v.pipe(v.array(TrackSchema), v.minLength(1)),
+  tracks: v.pipe(v.array(TrackSchema), v.minLength(1))
 });
 
 export const ScoreDimensionSchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   label: v.pipe(v.string(), v.minLength(1)),
-  max_score: v.pipe(v.number(), v.minValue(0)),
+  max_score: v.pipe(v.number(), v.minValue(0))
 });
 
 export const EvalExpectationSchema = v.record(v.string(), v.unknown());
@@ -55,18 +56,18 @@ export const EvalCaseSchema = v.object({
   title: v.pipe(v.string(), v.minLength(1)),
   input: v.optional(v.record(v.string(), v.unknown()), {}),
   expectations: v.optional(EvalExpectationSchema, {}),
-  scoring_dimensions: v.pipe(v.array(ScoreDimensionSchema), v.minLength(1)),
+  scoring_dimensions: v.pipe(v.array(ScoreDimensionSchema), v.minLength(1))
 });
 
 export const EvalCasesFileSchema = v.object({
-  evals: v.pipe(v.array(EvalCaseSchema), v.minLength(1)),
+  evals: v.pipe(v.array(EvalCaseSchema), v.minLength(1))
 });
 
 export const EvalScoreDimensionSchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   score: v.pipe(v.number(), v.minValue(0)),
   max_score: v.pipe(v.number(), v.minValue(0)),
-  rationale: v.pipe(v.string(), v.minLength(1)),
+  rationale: v.pipe(v.string(), v.minLength(1))
 });
 
 export const EvalScoreSchema = v.object({
@@ -76,16 +77,16 @@ export const EvalScoreSchema = v.object({
   total_score: v.pipe(v.number(), v.minValue(0)),
   max_score: v.pipe(v.number(), v.minValue(0)),
   dimensions: v.pipe(v.array(EvalScoreDimensionSchema), v.minLength(1)),
-  summary: v.pipe(v.string(), v.minLength(1)),
+  summary: v.pipe(v.string(), v.minLength(1))
 });
 
 export const OutputFileSchema = v.object({
   path: v.pipe(v.string(), v.minLength(1)),
-  contents: v.string(),
+  contents: v.string()
 });
 
 export const ModelProduceResponseSchema = v.object({
-  output_files: v.pipe(v.array(OutputFileSchema), v.minLength(1)),
+  output_files: v.pipe(v.array(OutputFileSchema), v.minLength(1))
 });
 
 export const SkillMetadataSchema = v.object({
@@ -93,12 +94,12 @@ export const SkillMetadataSchema = v.object({
   description: v.pipe(v.string(), v.minLength(1)),
   contentHash: v.pipe(v.string(), v.minLength(1)),
   constructionNotes: v.optional(v.string(), ""),
-  changelog: v.optional(v.array(v.string()), []),
+  changelog: v.optional(v.array(v.string()), [])
 });
 
 export const SkillFileChangeSchema = v.object({
   path: v.pipe(v.string(), v.minLength(1)),
-  contents: v.string(),
+  contents: v.string()
 });
 
 export const GuidanceLedgerEntrySchema = v.object({
@@ -107,17 +108,17 @@ export const GuidanceLedgerEntrySchema = v.object({
   action: v.picklist(["used", "deferred", "ignored", "requested"]),
   reason: v.pipe(v.string(), v.minLength(1)),
   section: v.optional(v.pipe(v.string(), v.minLength(1))),
-  appliedTo: v.optional(v.pipe(v.string(), v.minLength(1))),
+  appliedTo: v.optional(v.pipe(v.string(), v.minLength(1)))
 });
 
 export const GuidanceLedgerSchema = v.object({
-  entries: v.optional(v.array(GuidanceLedgerEntrySchema), []),
+  entries: v.optional(v.array(GuidanceLedgerEntrySchema), [])
 });
 
 export const SkillResearchPatchSchema = v.object({
   summary: v.pipe(v.string(), v.minLength(1)),
   guidance: v.optional(v.array(v.omit(GuidanceLedgerEntrySchema, ["iteration"])), []),
-  changes: v.pipe(v.array(SkillFileChangeSchema), v.minLength(1)),
+  changes: v.pipe(v.array(SkillFileChangeSchema), v.minLength(1))
 });
 
 export type ModelProvider = v.InferOutput<typeof ModelProviderSchema>;
@@ -137,16 +138,16 @@ export type GuidanceLedgerEntry = v.InferOutput<typeof GuidanceLedgerEntrySchema
 export type GuidanceLedger = v.InferOutput<typeof GuidanceLedgerSchema>;
 export type SkillResearchPatch = v.InferOutput<typeof SkillResearchPatchSchema>;
 
-export function parseWithSchema<
-  TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
->(schema: TSchema, value: unknown, label: string): v.InferOutput<TSchema> {
+export function parseWithSchema<TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>>(
+  schema: TSchema,
+  value: unknown,
+  label: string
+): v.InferOutput<TSchema> {
   const result = v.safeParse(schema, value);
   if (result.success) {
     return result.output;
   }
 
-  const details = result.issues.map(
-    (issue) => `${issue.path?.map((p) => p.key).join(".") || label}: ${issue.message}`,
-  );
+  const details = result.issues.map((issue) => `${issue.path?.map((p) => p.key).join(".") || label}: ${issue.message}`);
   throw new Error(`Invalid ${label}: ${details.join("; ")}`);
 }

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -9,33 +9,32 @@ test("parseCliArgs validates currently required adapters", () => {
   expect(parseCliArgs(["--project", "/tmp/project", "--with-baseline"])).toMatchObject({
     projectRoot: "/tmp/project",
     withBaseline: true,
-    runResearch: false,
+    runResearch: false
   });
-  expect(
-    parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--seed-skill", "/tmp/skill"]),
-  ).toMatchObject({
+  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--seed-skill", "/tmp/skill"])).toMatchObject({
     scoreDir: "/tmp/scores",
     runResearch: true,
-    seedSkillDir: "/tmp/skill",
+    seedSkillDir: "/tmp/skill"
   });
   expect(parseCliArgs(["--model-client", "anthropic", "--research"])).toMatchObject({
     modelClient: "anthropic",
-    runResearch: true,
+    runResearch: true
   });
-  expect(
-    parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--force-research"]),
-  ).toMatchObject({
+  expect(parseCliArgs(["--model-client", "anthropic", "--budget-usd", "0.25"])).toMatchObject({
+    budgetUsd: 0.25
+  });
+  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--force-research"])).toMatchObject({
     forceResearch: true,
-    runResearch: true,
+    runResearch: true
   });
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
-    /Research iterations require --score-dir or --model-client/,
+    /Research iterations require --score-dir or --model-client/
   );
-  expect(() => parseCliArgs(["--score-dir", "/tmp/scores", "--model-client", "anthropic"])).toThrow(
-    /either/,
-  );
+  expect(() => parseCliArgs(["--score-dir", "/tmp/scores", "--model-client", "anthropic"])).toThrow(/either/);
   expect(() => parseCliArgs(["--model-client", "unknown"])).toThrow(/Unsupported model client/);
+  expect(() => parseCliArgs(["--model-client", "anthropic", "--budget-usd=-1"])).toThrow(/non-negative/);
+  expect(() => parseCliArgs(["--model-client", "anthropic", "--budget-usd", "nope"])).toThrow(/non-negative/);
   expect(() => parseCliArgs(["--project"])).toThrow(/argument missing/);
 });
 
@@ -43,10 +42,7 @@ test("FileScoreAgent returns eval scores from explicit files", async () => {
   const root = await tempProject();
   const scoreDir = join(root, "scores");
   await mkdir(scoreDir, { recursive: true });
-  await writeFile(
-    join(scoreDir, "xss-001.json"),
-    JSON.stringify(score("xss-001", "detect-and-fix", "audit", 2, 2)),
-  );
+  await writeFile(join(scoreDir, "xss-001.json"), JSON.stringify(score("xss-001", "detect-and-fix", "audit", 2, 2)));
 
   const evalCase = securityEvals.evals[0];
   const agent = new FileScoreAgent({ scoreDir });
@@ -55,7 +51,7 @@ test("FileScoreAgent returns eval scores from explicit files", async () => {
     track: trackForEval(securityConfig, evalCase.eval_type),
     role: "security-auditor",
     model: { provider: "anthropic", name: "claude-sonnet-4-6" },
-    sandbox: {} as never,
+    sandbox: {} as never
   });
 
   expect(result.total_score).toBe(2);
@@ -82,13 +78,13 @@ test("SnapshotResearcher copies the previous skill and writes iteration metadata
         score: 0,
         maxScore: 1,
         normalizedScore: syntheticConfig.target_score,
-        evalCount: 0,
-      },
-    },
+        evalCount: 0
+      }
+    }
   });
 
   await expect(readFile(join(candidateSkillDir, "SKILL.md"), "utf8")).resolves.toBe("# Skill\n");
-  await expect(
-    readFile(join(candidateSkillDir, ".autoresearch-iteration.json"), "utf8"),
-  ).resolves.toContain("previousNormalizedScore");
+  await expect(readFile(join(candidateSkillDir, ".autoresearch-iteration.json"), "utf8")).resolves.toContain(
+    "previousNormalizedScore"
+  );
 });

--- a/tests/e2e-dry-run.test.ts
+++ b/tests/e2e-dry-run.test.ts
@@ -2,9 +2,10 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   ModelClient,
+  ModelCompletion,
   ModelEvalAgent,
   ModelRequest,
-  ModelSkillResearcher,
+  ModelSkillResearcher
 } from "../src/model-agent.js";
 import { orchestrateBaseline } from "../src/orchestrator.js";
 import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } from "./helpers.js";
@@ -12,9 +13,9 @@ import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } fro
 class QueueModelClient implements ModelClient {
   requests: ModelRequest[] = [];
 
-  constructor(private readonly responses: string[]) {}
+  constructor(private readonly responses: ModelCompletion[]) {}
 
-  async complete(request: ModelRequest): Promise<string> {
+  async complete(request: ModelRequest): Promise<ModelCompletion> {
     this.requests.push(request);
     const response = this.responses.shift();
     if (!response) {
@@ -29,21 +30,18 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
   const config = {
     ...syntheticConfig,
     target_score: 0.8,
-    max_iterations: 1,
+    max_iterations: 1
   };
   await writeFixture(root, config, syntheticEvals);
 
   const seedSkillDir = join(root, "seed-skill");
   await mkdir(seedSkillDir, { recursive: true });
-  await writeFile(
-    join(seedSkillDir, "SKILL.md"),
-    "# Release Summary\n\nSummarise changes briefly.\n",
-  );
+  await writeFile(join(seedSkillDir, "SKILL.md"), "# Release Summary\n\nSummarise changes briefly.\n");
 
   const evalCase = syntheticEvals.evals[0];
   const client = new QueueModelClient([
     JSON.stringify({
-      output_files: [{ path: "RESULT.md", contents: "Baseline summary was too thin.\n" }],
+      output_files: [{ path: "RESULT.md", contents: "Baseline summary was too thin.\n" }]
     }),
     JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.4)),
     JSON.stringify({
@@ -51,17 +49,14 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
       changes: [
         {
           path: "SKILL.md",
-          contents:
-            "# Release Summary\n\nSummarise changes with concrete user-facing impact and risk notes.\n",
-        },
-      ],
+          contents: "# Release Summary\n\nSummarise changes with concrete user-facing impact and risk notes.\n"
+        }
+      ]
     }),
     JSON.stringify({
-      output_files: [
-        { path: "RESULT.md", contents: "Improved summary with impact and risk notes.\n" },
-      ],
+      output_files: [{ path: "RESULT.md", contents: "Improved summary with impact and risk notes.\n" }]
     }),
-    JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.9)),
+    JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.9))
   ]);
 
   const result = await orchestrateBaseline({
@@ -69,7 +64,7 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
     agent: new ModelEvalAgent(client),
     researcher: new ModelSkillResearcher(client),
     runResearch: true,
-    seedSkillDir,
+    seedSkillDir
   });
 
   expect(result.completedIterations).toBe(1);
@@ -81,26 +76,102 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
       ["baseline judge", "eval-judge"],
       ["researcher", "skill-builder"],
       ["candidate producer", "task-producer"],
-      ["candidate judge", "eval-judge"],
-    ].map(([, system]) => system),
+      ["candidate judge", "eval-judge"]
+    ].map(([, system]) => system)
   );
 
+  await expect(readFile(join(root, "workspace", "baseline", evalCase.id, "RESULT.md"), "utf8")).resolves.toBe(
+    "Baseline summary was too thin.\n"
+  );
+  await expect(readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8")).resolves.toContain(
+    "concrete user-facing impact"
+  );
   await expect(
-    readFile(join(root, "workspace", "baseline", evalCase.id, "RESULT.md"), "utf8"),
-  ).resolves.toBe("Baseline summary was too thin.\n");
-  await expect(
-    readFile(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"), "utf8"),
-  ).resolves.toContain("concrete user-facing impact");
-  await expect(
-    readFile(
-      join(root, "workspace", "iterations", "1", "outputs", evalCase.id, "RESULT.md"),
-      "utf8",
-    ),
+    readFile(join(root, "workspace", "iterations", "1", "outputs", evalCase.id, "RESULT.md"), "utf8")
   ).resolves.toBe("Improved summary with impact and risk notes.\n");
   await expect(
-    readFile(
-      join(root, "workspace", "iterations", "1", "skill", ".autoresearch-transcript.json"),
-      "utf8",
-    ),
+    readFile(join(root, "workspace", "iterations", "1", "skill", ".autoresearch-transcript.json"), "utf8")
   ).resolves.toContain("Add concrete output guidance");
+});
+
+test("dry run previews, tracks, persists, and stops after the observed budget is reached", async () => {
+  const root = await tempProject();
+  const config = {
+    ...syntheticConfig,
+    target_score: 0.8,
+    max_iterations: 2,
+    budget_usd: 0.01
+  };
+  await writeFixture(root, config, syntheticEvals);
+
+  const seedSkillDir = join(root, "seed-skill");
+  await mkdir(seedSkillDir, { recursive: true });
+  await writeFile(join(seedSkillDir, "SKILL.md"), "# Release Summary\n");
+
+  const evalCase = syntheticEvals.evals[0];
+  const client = new QueueModelClient([
+    {
+      text: JSON.stringify({
+        output_files: [{ path: "RESULT.md", contents: "Baseline summary was too thin.\n" }]
+      }),
+      usage: { inputTokens: 10, outputTokens: 10 }
+    },
+    {
+      text: JSON.stringify(score(evalCase.id, evalCase.eval_type, "summarise", 0.4)),
+      usage: { inputTokens: 10, outputTokens: 10 }
+    },
+    {
+      text: JSON.stringify({
+        summary: "Add concrete output guidance.",
+        changes: [
+          {
+            path: "SKILL.md",
+            contents: "# Release Summary\n\nSummarise changes with concrete user-facing impact and risk notes.\n"
+          }
+        ]
+      }),
+      usage: { inputTokens: 2_000, outputTokens: 1_000 }
+    }
+  ]);
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    agent: new ModelEvalAgent(client),
+    researcher: new ModelSkillResearcher(client),
+    runResearch: true,
+    seedSkillDir
+  });
+
+  expect(result.completedIterations).toBe(0);
+  expect(result.events[1]).toMatchObject({
+    type: "cost-preview",
+    summary: {
+      budgetUsd: 0.01,
+      planned: {
+        totalCalls: 8,
+        calls: {
+          baseline_producer: 1,
+          baseline_judge: 1,
+          researcher: 2,
+          iteration_producer: 2,
+          iteration_judge: 2
+        }
+      }
+    }
+  });
+  expect(result.events).toContainEqual({
+    type: "budget-reached",
+    budgetUsd: 0.01,
+    actualCostUsd: result.cost.actual.costUsd,
+    completedIterations: 0
+  });
+  expect(result.cost.actual.calls).toMatchObject({
+    baseline_producer: 1,
+    baseline_judge: 1,
+    researcher: 1,
+    iteration_producer: 0,
+    iteration_judge: 0
+  });
+  expect(result.cost.actual.costUsd).toBeGreaterThan(0.01);
+  await expect(readFile(join(root, "workspace", "cost-summary.json"), "utf8")).resolves.toContain("baseline_producer");
 });

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -445,9 +445,15 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
   const calls: Array<{ url: string; init: RequestInit }> = [];
   const fetchStub: typeof fetch = async (url, init) => {
     calls.push({ url: String(url), init: init ?? {} });
-    return new Response(JSON.stringify({ content: [{ type: "text", text: "Done" }] }), {
-      status: 200
-    });
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "Done" }],
+        usage: { input_tokens: 12, output_tokens: 3 }
+      }),
+      {
+        status: 200
+      }
+    );
   };
   const client = new AnthropicMessagesClient({ apiKey: "test-key", fetch: fetchStub });
 
@@ -457,7 +463,7 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
     prompt: "user prompt"
   });
 
-  expect(result).toBe("Done");
+  expect(result).toMatchObject({ text: "Done", usage: { inputTokens: 12, outputTokens: 3 } });
   expect(calls[0].url).toBe("https://api.anthropic.com/v1/messages");
   expect((calls[0].init.headers as Record<string, string>)["x-api-key"]).toBe("test-key");
   expect(JSON.parse(String(calls[0].init.body))).toMatchObject({

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,0 +1,13 @@
+import { pricingForModel } from "../src/pricing.js";
+
+test("pricingForModel matches only intended full Anthropic model names", () => {
+  expect(pricingForModel({ provider: "anthropic", name: "claude-haiku-4-5" })).toBeDefined();
+  expect(pricingForModel({ provider: "anthropic", name: "claude-haiku-4-5-20260201" })).toBeDefined();
+  expect(pricingForModel({ provider: "anthropic", name: "x-claude-haiku-4-5" })).toBeUndefined();
+  expect(pricingForModel({ provider: "anthropic", name: "claude-haiku-4-5-beta" })).toBeUndefined();
+
+  expect(pricingForModel({ provider: "anthropic", name: "claude-sonnet-4" })).toBeDefined();
+  expect(pricingForModel({ provider: "anthropic", name: "claude-sonnet-4-20260201" })).toBeDefined();
+  expect(pricingForModel({ provider: "anthropic", name: "x-claude-sonnet-4" })).toBeUndefined();
+  expect(pricingForModel({ provider: "anthropic", name: "claude-sonnet-4-beta" })).toBeUndefined();
+});

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -10,7 +10,7 @@ import {
   syntheticConfig,
   syntheticEvals,
   tempProject,
-  writeFixture,
+  writeFixture
 } from "./helpers.js";
 
 test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
@@ -27,7 +27,7 @@ test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
     referenceDir: join(root, "reference"),
     evalsDir: join(root, "evals"),
     skillDir: join(root, "skill"),
-    outputDir: join(root, "out"),
+    outputDir: join(root, "out")
   });
 
   const readonlyPaths = [
@@ -36,7 +36,7 @@ test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
     () => sandbox.mkdir(join(root, "evals", "new")),
     () => sandbox.rm(join(root, "skill", "SKILL.md")),
     () => sandbox.cp(join(root, "reference", "ref.txt"), join(root, "input", "copy.txt")),
-    () => sandbox.chmod(join(root, "reference", "ref.txt"), 0o600),
+    () => sandbox.chmod(join(root, "reference", "ref.txt"), 0o600)
   ];
 
   for (const action of readonlyPaths) {
@@ -55,7 +55,7 @@ test("runEval maps eval type to role and target skill through config", async () 
     async run(request) {
       calls.push(request);
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 1, 2);
-    },
+    }
   };
 
   await runEval(
@@ -64,9 +64,9 @@ test("runEval maps eval type to role and target skill through config", async () 
       projectRoot: root,
       evalCase: securityEvals.evals[0],
       baseline: true,
-      outputRoot: join(root, "workspace", "baseline", "outputs"),
+      outputRoot: join(root, "workspace", "baseline", "outputs")
     },
-    agent,
+    agent
   );
   await runEval(
     {
@@ -75,22 +75,18 @@ test("runEval maps eval type to role and target skill through config", async () 
       evalCase: securityEvals.evals[1],
       baseline: false,
       targetSkillDir: join(root, "skills", "secure-authoring"),
-      outputRoot: join(root, "workspace", "iterations", "1"),
+      outputRoot: join(root, "workspace", "iterations", "1")
     },
-    agent,
+    agent
   );
 
   expect(calls).toHaveLength(2);
   expect((calls[0] as any).role).toBe("security-auditor");
   expect((calls[0] as any).targetSkill).toBeUndefined();
-  expect((calls[0] as any).sandbox.mounts.some((mount: any) => mount.target === "/skill")).toBe(
-    false,
-  );
+  expect((calls[0] as any).sandbox.mounts.some((mount: any) => mount.target === "/skill")).toBe(false);
   expect((calls[1] as any).role).toBe("secure-author");
   expect((calls[1] as any).targetSkill).toBe("secure-authoring");
-  expect(
-    (calls[1] as any).sandbox.mounts.find((mount: any) => mount.target === "/skill").readOnly,
-  ).toBe(true);
+  expect((calls[1] as any).sandbox.mounts.find((mount: any) => mount.target === "/skill").readOnly).toBe(true);
 });
 
 test("runWithConcurrency respects the configured limit", async () => {
@@ -114,36 +110,24 @@ test("orchestrator requires complete artefacts when started with withBaseline", 
   await mkdir(join(reuseRoot, "workspace", "baseline", "notes-001", "output"), { recursive: true });
   await writeFile(
     join(reuseRoot, "workspace", "baseline", "scores-0.json"),
-    JSON.stringify(score("notes-001", "summarise-changelog", "summarise")),
+    JSON.stringify(score("notes-001", "summarise-changelog", "summarise"))
   );
   await writeFile(join(reuseRoot, "workspace", "baseline", "notes-001", "task.md"), "Task");
-  await writeFile(
-    join(reuseRoot, "workspace", "baseline", "notes-001", "input", "SPEC.md"),
-    "Input",
-  );
-  await writeFile(
-    join(reuseRoot, "workspace", "baseline", "notes-001", "output", "SPEC.md"),
-    "Output",
-  );
-  await writeFile(
-    join(reuseRoot, "workspace", "baseline", "summary.json"),
-    JSON.stringify({ average: 1 }),
-  );
-  await writeFile(
-    join(reuseRoot, "workspace", "baseline", "summary-summarise.json"),
-    JSON.stringify({ average: 1 }),
-  );
+  await writeFile(join(reuseRoot, "workspace", "baseline", "notes-001", "input", "SPEC.md"), "Input");
+  await writeFile(join(reuseRoot, "workspace", "baseline", "notes-001", "output", "SPEC.md"), "Output");
+  await writeFile(join(reuseRoot, "workspace", "baseline", "summary.json"), JSON.stringify({ average: 1 }));
+  await writeFile(join(reuseRoot, "workspace", "baseline", "summary-summarise.json"), JSON.stringify({ average: 1 }));
   await writeFile(join(reuseRoot, "workspace", "baseline", "analysis-summarise.md"), "Analysis");
 
   const reused = await orchestrateBaseline({ projectRoot: reuseRoot, withBaseline: true });
-  expect(reused.events[1]).toMatchObject({ type: "baseline-imported", scores: 1 });
+  expect(reused.events[2]).toMatchObject({ type: "baseline-imported", scores: 1 });
   expect(reused.completedIterations).toBe(0);
 
   const missingRoot = await tempProject();
   await writeFixture(missingRoot, syntheticConfig, syntheticEvals);
-  await expect(
-    orchestrateBaseline({ projectRoot: missingRoot, withBaseline: true }),
-  ).rejects.toThrow(/--with-baseline/);
+  await expect(orchestrateBaseline({ projectRoot: missingRoot, withBaseline: true })).rejects.toThrow(
+    /--with-baseline/
+  );
 });
 
 test("orchestrator rejects missing configured judge role before baseline work", async () => {
@@ -154,10 +138,10 @@ test("orchestrator rejects missing configured judge role before baseline work", 
       ...syntheticConfig,
       roles: {
         ...syntheticConfig.roles,
-        judge: "release-notes-judge",
-      },
+        judge: "release-notes-judge"
+      }
     },
-    syntheticEvals,
+    syntheticEvals
   );
 
   await expect(orchestrateBaseline({ projectRoot: root, withBaseline: true })).rejects.toThrow(
@@ -166,12 +150,12 @@ test("orchestrator rejects missing configured judge role before baseline work", 
         "Configured Flue roles are not registered.",
         "release-notes-judge: roles.judge",
         "Available roles: eval-judge, skill-builder, task-producer",
-        "Define roles as markdown files in roles/ or .flue/roles/.",
-      ].join("(.|\n)*"),
-    ),
+        "Define roles as markdown files in roles/ or .flue/roles/."
+      ].join("(.|\n)*")
+    )
   );
   await expect(stat(join(root, "workspace", "baseline"))).rejects.toMatchObject({
-    code: "ENOENT",
+    code: "ENOENT"
   });
 });
 
@@ -184,26 +168,24 @@ test("orchestrator rejects missing producer track role before running evals", as
       tracks: [
         {
           ...syntheticConfig.tracks[0],
-          role: "release-editor",
-        },
-      ],
+          role: "release-editor"
+        }
+      ]
     },
-    syntheticEvals,
+    syntheticEvals
   );
   let agentRuns = 0;
   const agent: EvalAgent = {
     async run(request) {
       agentRuns++;
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
-    },
+    }
   };
 
-  await expect(orchestrateBaseline({ projectRoot: root, agent })).rejects.toThrow(
-    /release-editor: tracks\[0\]\.role/,
-  );
+  await expect(orchestrateBaseline({ projectRoot: root, agent })).rejects.toThrow(/release-editor: tracks\[0\]\.role/);
   expect(agentRuns).toBe(0);
   await expect(stat(join(root, "workspace", "baseline"))).rejects.toMatchObject({
-    code: "ENOENT",
+    code: "ENOENT"
   });
 });
 
@@ -215,13 +197,13 @@ test("orchestrator accepts valid configured Flue roles", async () => {
     async run(request) {
       agentRuns++;
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
-    },
+    }
   };
 
   const result = await orchestrateBaseline({ projectRoot: root, agent });
 
   expect(agentRuns).toBe(1);
-  expect(result.events[1]).toMatchObject({ type: "baseline-started" });
+  expect(result.events[2]).toMatchObject({ type: "baseline-started" });
 });
 
 test("orchestrator generates initial baseline by default without counting it as an iteration", async () => {
@@ -230,22 +212,22 @@ test("orchestrator generates initial baseline by default without counting it as 
   const agent: EvalAgent = {
     async run(request) {
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
-    },
+    }
   };
   const generated = await orchestrateBaseline({ projectRoot: generateRoot, agent });
-  expect(generated.events[1]).toMatchObject({
+  expect(generated.events[2]).toMatchObject({
     type: "baseline-started",
-    countsTowardIterations: false,
+    countsTowardIterations: false
   });
-  expect(generated.events[2]).toMatchObject({ type: "baseline-generated", scores: 1 });
+  expect(generated.events[3]).toMatchObject({ type: "baseline-generated", scores: 1 });
   expect(generated.completedIterations).toBe(0);
   expect(generated.events.at(-1)).toMatchObject({
     type: "research-loop-ready",
-    completedIterations: 0,
+    completedIterations: 0
   });
-  await expect(
-    readFile(join(generateRoot, "workspace", "baseline", "scores-0.json"), "utf8"),
-  ).resolves.toContain("notes-001");
+  await expect(readFile(join(generateRoot, "workspace", "baseline", "scores-0.json"), "utf8")).resolves.toContain(
+    "notes-001"
+  );
 });
 
 test("orchestrator skips research when the baseline already reaches target score", async () => {
@@ -254,19 +236,19 @@ test("orchestrator skips research when the baseline already reaches target score
   const agent: EvalAgent = {
     async run(request) {
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.95);
-    },
+    }
   };
   const researcher: SkillResearcher = {
     async improve() {
       throw new Error("researcher should not run when baseline reaches target");
-    },
+    }
   };
 
   const result = await orchestrateBaseline({
     projectRoot: root,
     agent,
     researcher,
-    runResearch: true,
+    runResearch: true
   });
 
   expect(result.completedIterations).toBe(0);
@@ -275,10 +257,10 @@ test("orchestrator skips research when the baseline already reaches target score
   expect(result.events.at(-1)).toMatchObject({
     type: "baseline-target-score-reached",
     normalizedScore: 0.95,
-    targetScore: syntheticConfig.target_score,
+    targetScore: syntheticConfig.target_score
   });
   await expect(stat(join(root, "workspace", "iterations", "1"))).rejects.toMatchObject({
-    code: "ENOENT",
+    code: "ENOENT"
   });
 });
 
@@ -295,12 +277,12 @@ test("orchestrator can force research when the baseline already reaches target s
       return request.targetSkill
         ? score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.96)
         : score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.95);
-    },
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-    },
+    }
   };
 
   const result = await orchestrateBaseline({
@@ -309,7 +291,7 @@ test("orchestrator can force research when the baseline already reaches target s
     researcher,
     runResearch: true,
     forceResearch: true,
-    seedSkillDir: seedSkill,
+    seedSkillDir: seedSkill
   });
 
   expect(result.completedIterations).toBe(1);
@@ -334,16 +316,13 @@ test("orchestrator runs research iterations until target score is reached", asyn
       evalRuns++;
       const total = evalRuns === 1 ? 0.5 : 0.9;
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, total);
-    },
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-      await writeFile(
-        join(request.candidateSkillDir, `iteration-${request.iteration}.txt`),
-        "candidate\n",
-      );
-    },
+      await writeFile(join(request.candidateSkillDir, `iteration-${request.iteration}.txt`), "candidate\n");
+    }
   };
 
   const result = await orchestrateBaseline({
@@ -351,19 +330,19 @@ test("orchestrator runs research iterations until target score is reached", asyn
     agent,
     researcher,
     runResearch: true,
-    seedSkillDir: seedSkill,
+    seedSkillDir: seedSkill
   });
 
   expect(result.completedIterations).toBe(2);
   expect(result.bestIteration?.iteration).toBe(2);
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
   expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 2 });
-  await expect(
-    readFile(join(root, "workspace", "iterations", "2", "scores-0.json"), "utf8"),
-  ).resolves.toContain("notes-001");
-  await expect(
-    readFile(join(root, "workspace", "iterations", "2", "skill", "iteration-2.txt"), "utf8"),
-  ).resolves.toBe("candidate\n");
+  await expect(readFile(join(root, "workspace", "iterations", "2", "scores-0.json"), "utf8")).resolves.toContain(
+    "notes-001"
+  );
+  await expect(readFile(join(root, "workspace", "iterations", "2", "skill", "iteration-2.txt"), "utf8")).resolves.toBe(
+    "candidate\n"
+  );
 });
 
 test("orchestrator keeps iterating when aggregate target has a baseline regression", async () => {
@@ -375,23 +354,23 @@ test("orchestrator keeps iterating when aggregate target has a baseline regressi
     tracks: [
       {
         ...syntheticConfig.tracks[0],
-        eval_type: "two-case-eval",
-      },
-    ],
+        eval_type: "two-case-eval"
+      }
+    ]
   };
   const evals = {
     evals: [
       {
         ...syntheticEvals.evals[0],
         id: "case-a",
-        eval_type: "two-case-eval",
+        eval_type: "two-case-eval"
       },
       {
         ...syntheticEvals.evals[0],
         id: "case-b",
-        eval_type: "two-case-eval",
-      },
-    ],
+        eval_type: "two-case-eval"
+      }
+    ]
   };
   await writeFixture(root, config, evals);
   const seedSkill = join(root, "seed-skill");
@@ -409,16 +388,16 @@ test("orchestrator keeps iterating when aggregate target has a baseline regressi
           request.evalCase.id,
           request.evalCase.eval_type,
           request.track.id,
-          request.evalCase.id === "case-a" ? 1 : 0.7,
+          request.evalCase.id === "case-a" ? 1 : 0.7
         );
       }
       return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9);
-    },
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-    },
+    }
   };
 
   const result = await orchestrateBaseline({
@@ -426,7 +405,7 @@ test("orchestrator keeps iterating when aggregate target has a baseline regressi
     agent,
     researcher,
     runResearch: true,
-    seedSkillDir: seedSkill,
+    seedSkillDir: seedSkill
   });
 
   expect(result.completedIterations).toBe(2);
@@ -435,7 +414,7 @@ test("orchestrator keeps iterating when aggregate target has a baseline regressi
     iteration: 1,
     normalizedScore: 0.85,
     targetScore: 0.85,
-    regressions: [{ evalId: "case-b", baselineScore: 0.8, candidateScore: 0.7 }],
+    regressions: [{ evalId: "case-b", baselineScore: 0.8, candidateScore: 0.7 }]
   });
   expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 2 });
 });
@@ -457,31 +436,23 @@ test("orchestrator can start research from an empty skill while using the seed a
         return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
       }
       evalRuns++;
-      return score(
-        request.evalCase.id,
-        request.evalCase.eval_type,
-        request.track.id,
-        evalRuns === 1 ? 0.5 : 0.9,
-      );
-    },
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, evalRuns === 1 ? 0.5 : 0.9);
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       previousSkillDirs.push(request.previousSkillDir);
       guidanceSkillDirs.push(request.guidanceSkillDir);
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-      await writeFile(
-        join(request.candidateSkillDir, `iteration-${request.iteration}.txt`),
-        "candidate\n",
-      );
-    },
+      await writeFile(join(request.candidateSkillDir, `iteration-${request.iteration}.txt`), "candidate\n");
+    }
   };
 
   const result = await orchestrateBaseline({
     projectRoot: root,
     agent,
     researcher,
-    runResearch: true,
+    runResearch: true
   });
 
   expect(result.completedIterations).toBe(2);
@@ -489,10 +460,8 @@ test("orchestrator can start research from an empty skill while using the seed a
   expect(await readdir(previousSkillDirs[0])).toEqual([]);
   expect(previousSkillDirs[1]).toBe(join(root, "workspace", "iterations", "1", "skill"));
   expect(guidanceSkillDirs).toEqual([seedSkill, seedSkill]);
-  await expect(
-    stat(join(root, "workspace", "iterations", "1", "skill", "SKILL.md")),
-  ).rejects.toMatchObject({
-    code: "ENOENT",
+  await expect(stat(join(root, "workspace", "iterations", "1", "skill", "SKILL.md"))).rejects.toMatchObject({
+    code: "ENOENT"
   });
 });
 
@@ -505,7 +474,7 @@ test("orchestrator resolves config skill paths relative to the project root", as
     origin_skill: "skills/security-audit",
     guidance_skill: "skills/guidance-reference",
     research_start: "empty" as const,
-    max_iterations: 1,
+    max_iterations: 1
   };
   await writeFixture(root, config, syntheticEvals);
   await mkdir(seedSkill, { recursive: true });
@@ -517,13 +486,8 @@ test("orchestrator resolves config skill paths relative to the project root", as
   let guidanceSkillDir = "";
   const agent: EvalAgent = {
     async run(request) {
-      return score(
-        request.evalCase.id,
-        request.evalCase.eval_type,
-        request.track.id,
-        request.targetSkill ? 0.9 : 0.2,
-      );
-    },
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, request.targetSkill ? 0.9 : 0.2);
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
@@ -531,14 +495,14 @@ test("orchestrator resolves config skill paths relative to the project root", as
       guidanceSkillDir = request.guidanceSkillDir ?? "";
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
       await writeFile(join(request.candidateSkillDir, "SKILL.md"), "# Candidate\n");
-    },
+    }
   };
 
   const result = await orchestrateBaseline({
     projectRoot: root,
     agent,
     researcher,
-    runResearch: true,
+    runResearch: true
   });
 
   expect(result.completedIterations).toBe(1);
@@ -549,37 +513,28 @@ test("orchestrator resolves config skill paths relative to the project root", as
 test("orchestrator preserves absolute origin_skill paths", async () => {
   const root = await tempProject();
   const seedSkill = join(root, "absolute-seed");
-  await writeFixture(
-    root,
-    { ...syntheticConfig, origin_skill: seedSkill, max_iterations: 1 },
-    syntheticEvals,
-  );
+  await writeFixture(root, { ...syntheticConfig, origin_skill: seedSkill, max_iterations: 1 }, syntheticEvals);
   await mkdir(seedSkill, { recursive: true });
   await writeFile(join(seedSkill, "SKILL.md"), "# Seed\n");
 
   let previousSkillDir = "";
   const agent: EvalAgent = {
     async run(request) {
-      return score(
-        request.evalCase.id,
-        request.evalCase.eval_type,
-        request.track.id,
-        request.targetSkill ? 0.9 : 0.2,
-      );
-    },
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, request.targetSkill ? 0.9 : 0.2);
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       previousSkillDir = request.previousSkillDir;
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-    },
+    }
   };
 
   await orchestrateBaseline({
     projectRoot: root,
     agent,
     researcher,
-    runResearch: true,
+    runResearch: true
   });
 
   expect(previousSkillDir).toBe(seedSkill);
@@ -599,18 +554,13 @@ test("orchestrator stops research at max iterations and keeps the best candidate
         return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
       }
       candidateRuns++;
-      return score(
-        request.evalCase.id,
-        request.evalCase.eval_type,
-        request.track.id,
-        candidateRuns === 2 ? 0.6 : 0.4,
-      );
-    },
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, candidateRuns === 2 ? 0.6 : 0.4);
+    }
   };
   const researcher: SkillResearcher = {
     async improve(request) {
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
-    },
+    }
   };
 
   const result = await orchestrateBaseline({
@@ -618,7 +568,7 @@ test("orchestrator stops research at max iterations and keeps the best candidate
     agent,
     researcher,
     runResearch: true,
-    seedSkillDir: seedSkill,
+    seedSkillDir: seedSkill
   });
 
   expect(result.completedIterations).toBe(syntheticConfig.max_iterations);
@@ -626,6 +576,6 @@ test("orchestrator stops research at max iterations and keeps the best candidate
   expect(result.aggregate.overall.normalizedScore).toBe(0.6);
   expect(result.events.at(-1)).toMatchObject({
     type: "max-iterations-reached",
-    completedIterations: syntheticConfig.max_iterations,
+    completedIterations: syntheticConfig.max_iterations
   });
 });


### PR DESCRIPTION
## Summary
- Add cost preview and budget guardrails across the Flue workflow and CLI
- Thread pricing and cost estimation through orchestration, model-agent, runner, and schema layers
- Update docs and workflow wiring to reflect the new preview behavior
- Expand tests for CLI adapters, dry-run orchestration, model-agent behavior, and sandbox runner flow

## Testing
- Added and updated unit and integration coverage for cost preview and guardrail paths
- Validated harness behavior through dry-run and orchestration-focused tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New --budget-usd CLI flag to set per-run spending limits and trigger automatic stop when reached
  * Cost preview shows estimated model call counts and costs before/during runs
  * End-of-run compact summary includes final score, model call counts, and observed cost
  * Persisted cost summary produced with call-level details

* **Documentation**
  * Added guide explaining cost preview, budget_usd config, CLI override, and cost-summary output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->