### PR TITLE
Add phase-aware run resume

### DIFF
--- a/.agents/skills/encode-project-learning/SKILL.md
+++ b/.agents/skills/encode-project-learning/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: encode-project-learning
+description: Convert durable lessons discovered while implementing, debugging, investigating, or reviewing a codebase into repository infrastructure that helps future contributors and agents. Use when work reveals a recurring failure mode, hidden domain rule, surprising architectural constraint, repeated manual step, missing validation, undocumented convention, reviewer correction, or other knowledge worth preserving as types, tests, lint rules, CI checks, tooling, agent instructions, review guidance, documentation, or comments. Also use at the end of substantive coding or review work when it surfaced concrete evidence of a reusable lesson.
+---
+
+# Encode Project Learning
+
+Turn repository discoveries into the strongest practical safeguard. Solve the immediate task first, then prevent the same class of friction or failure from recurring.
+
+## Respect Scope
+
+Match the action to the user's authorization:
+
+- For implementation or fix requests, make small related safeguards and documentation updates when they are clearly within scope.
+- For diagnostic, explanatory, or review-only requests, report the proposed learning update instead of changing files unless the user also authorized changes.
+- Request direction before establishing a broad architectural, product, security, or process policy that is not already supported by repository evidence.
+- Preserve unrelated user changes and follow repository-local instructions.
+
+Do not let this review displace the requested work. Treat no durable update as a valid result.
+
+## Run the Learning Loop
+
+### 1. Notice friction
+
+Look for discoveries such as:
+
+- A defect pattern that could recur elsewhere
+- An invariant, domain rule, or framework requirement that was not apparent
+- Reviewer feedback that could have been predicted before review
+- A manual check or setup step that contributors repeatedly perform
+- A repository convention that required archaeology or private context
+- Misleading, missing, duplicated, or stale guidance
+- A useful command or workflow that was difficult to discover
+
+Do not treat ordinary implementation effort, speculative preferences, or isolated accidents as durable learning.
+
+### 2. Gather evidence
+
+Before encoding a rule:
+
+- Search for related code, tests, configuration, instructions, and documentation.
+- Determine whether a canonical rule already exists and is merely undiscoverable or unenforced.
+- Confirm that the lesson applies beyond the exact line or incident that exposed it.
+- Distinguish an intentional constraint from legacy code, coincidence, or a temporary workaround.
+- Use review comments, issue context, failures, or repeated examples as evidence when available.
+
+If evidence is weak or contradictory, record the uncertainty in the task report rather than inventing policy.
+
+### 3. Classify the learning
+
+Classify it as one or more of:
+
+- **Invariant:** invalid states or inputs should be impossible or rejected.
+- **Regression risk:** known behavior needs protection.
+- **Pattern violation:** code can be recognized as acceptable or unacceptable.
+- **Workflow requirement:** a repeatable command or sequence is required.
+- **Repository convention:** contributors need guidance that is not fully machine-enforceable.
+- **Architectural or domain rationale:** future changes require the reason behind a constraint.
+- **One-off detail:** retain locally, or do not encode.
+
+### 4. Choose the strongest practical layer
+
+Prefer prevention and executable checks over prose. Use the highest suitable layer in this order, combining layers only when they serve different purposes:
+
+1. Types, schemas, API boundaries, or configuration constraints
+2. Lint rules, formatters, or static analysis
+3. Focused unit, integration, regression, contract, or end-to-end tests
+4. CI checks and validation scripts
+5. Reusable helpers, generators, development tooling, or automated workflows
+6. Repository agent instructions such as `AGENTS.md` or `CLAUDE.md`
+7. Review guidance such as `REVIEW.md`, checklists, or pull-request templates
+8. Architecture, contributor, operational, or domain documentation
+9. Local code comments for non-obvious rationale tied to nearby code
+
+Do not use a comment or document as the only safeguard when a reliable executable check is proportionate. Do not build expensive automation for a rare, low-impact condition when concise guidance is sufficient.
+
+### 5. Make the smallest durable change
+
+- Update the existing source of truth instead of creating a competing document.
+- State what to do, when it applies, and why it matters.
+- Keep guidance concrete enough for an unfamiliar contributor or agent to act on without private context.
+- Link guidance to the relevant check, command, decision record, or canonical document when helpful.
+- Encode the general rule while using the current incident only as evidence.
+- Keep tests focused on observable behavior rather than reproducing implementation details.
+- Avoid sweeping cleanup or unrelated policy changes.
+
+When no suitable destination exists, select one consistent with the repository's existing organization. Do not introduce new top-level instruction or review files casually.
+
+### 6. Verify the safeguard
+
+Verify in proportion to the change:
+
+- Demonstrate that a new automated check fails for the relevant bad case and passes for the corrected case when practical.
+- Run the affected tests, lint rules, type checks, validation scripts, or documentation checks.
+- Re-read modified guidance alongside nearby instructions to detect contradictions and duplication.
+- Check that the rule does not reject legitimate variants or overfit the triggering incident.
+- Confirm that paths, commands, and examples are accurate.
+
+If verification cannot be completed, say exactly what remains unverified.
+
+### 7. Report the result
+
+At handoff, briefly state:
+
+- The durable lesson, if any
+- Where it was encoded and why that layer was chosen
+- What future failure or friction it should prevent
+- How it was verified
+- Any candidate learning deliberately not encoded because it was one-off, uncertain, duplicative, disproportionate, or outside scope
+
+Keep this report subordinate to the primary task outcome. If nothing qualified, say so only when the skill was explicitly requested or the result is otherwise useful.
+
+## Apply Guardrails
+
+- Do not turn personal preference into repository policy.
+- Do not infer a universal rule from a single unexplained example.
+- Do not copy the same instruction into several files for visibility; improve discovery from one canonical source.
+- Do not preserve secrets, personal data, transient logs, or incident-specific sensitive details in durable guidance.
+- Do not weaken an existing check merely to accommodate the current implementation.
+- Do not add brittle checks whose maintenance cost exceeds the recurring problem.
+- Do not claim a class of issue is prevented when the safeguard covers only one example.
+- Do not update generated or vendored files when their source can be updated instead.
+
+## Use Common Mappings
+
+| Discovery                                            | Prefer                                                            |
+| ---------------------------------------------------- | ----------------------------------------------------------------- |
+| Input or state must be valid                         | Type, schema, boundary validation, and focused tests              |
+| A forbidden or required code pattern is recognizable | Lint rule or static analysis                                      |
+| Behavior could regress                               | Regression test at the lowest effective level                     |
+| Every change must perform a mechanical check         | CI validation                                                     |
+| Contributors repeat a fragile sequence               | Script, task, generator, or workflow automation                   |
+| Framework or architecture choice requires judgment   | Agent instructions plus review guidance                           |
+| Setup or operational step is hard to discover        | Automation plus canonical contributor or operations documentation |
+| Local code has a surprising reason                   | Test where possible, plus a concise rationale comment             |
+| Reviewer repeatedly supplies the same context        | Enforce it mechanically; otherwise update canonical instructions  |
+
+## Revisit Repeated Guidance
+
+When the same prose rule is violated repeatedly, treat that as evidence that documentation alone is insufficient. Look for a stronger constraint, check, template, or workflow. When an automated safeguard repeatedly produces false positives or requires exceptions, revisit whether the encoded rule is too broad.

--- a/.agents/skills/encode-project-learning/agents/openai.yaml
+++ b/.agents/skills/encode-project-learning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Encode Project Learning"
+  short_description: "Turn discoveries into durable safeguards"
+  default_prompt: "Use $encode-project-learning to assess what this work taught us and encode only well-supported durable lessons."

--- a/.flue/workflows/autoresearch.ts
+++ b/.flue/workflows/autoresearch.ts
@@ -9,6 +9,7 @@ interface AutoresearchPayload {
   withBaseline?: boolean;
   runResearch?: boolean;
   forceResearch?: boolean;
+  resume?: boolean;
   seedSkillDir?: string;
   guidanceSkillDir?: string;
   budgetUsd?: number;
@@ -31,6 +32,7 @@ export async function run({ init, payload, env }: FlueContext<AutoresearchPayloa
     withBaseline: payload.withBaseline,
     runResearch: payload.runResearch,
     forceResearch: payload.forceResearch,
+    resume: payload.resume,
     seedSkillDir: payload.seedSkillDir,
     guidanceSkillDir: payload.guidanceSkillDir,
     budgetUsd: payload.budgetUsd

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ pnpm-debug.log*
 playwright-report/
 test-results/
 **/full-report.json
+
+# generated autoresearch artifacts
+**/workspace/.phase-workspaces/
+**/workspace/iterations/
+**/workspace/cost-summary.json

--- a/GOAL.md
+++ b/GOAL.md
@@ -63,6 +63,8 @@ The current alpha is centered on `fixtures/projects/release-notes-alpha/`, a sin
 
 Near-term work should keep tightening reliability, auditability, and documentation around that loop before broadening the surface area.
 
+The next milestone is a dependable single-skill research loop: a user can install the harness, run or import a baseline, complete or resume a model-backed iteration, understand the evidence, and rerun safely without hand-editing Flue payloads or deleting artifacts manually.
+
 Cross-provider judging becomes active focus after the single-provider flow is stable enough to make comparisons meaningful.
 
 ## Open Questions

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -71,6 +71,18 @@ If the imported baseline already meets `target_score`, the run emits `baseline-t
 
 During research, an iteration that reaches the aggregate target but lowers any eval case below its baseline score emits `target-score-blocked-by-regression` and continues until a non-regressing candidate reaches the target or `max_iterations` is exhausted.
 
+## Resume An Interrupted Run
+
+If a model-backed run stops after writing some artifacts, rerun with the same run-defining payload and add `"resume": true`. The `sessionId` may be changed to distinguish the resumed invocation, as in this example:
+
+```bash
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-resume"}'
+```
+
+Resume validates and reuses completed scores, candidate research, producer output, and judge transcripts, then runs only missing phases. It rebuilds a missing iteration summary after all scores are present. Incomplete research or producer artifacts that are safe to retry are moved to `workspace/resume-backups/`; invalid or inconsistent artifacts stop the run with an actionable error rather than being overwritten.
+
+Use resume only when project config, evals, inputs, reference material, models, and the seed skill are unchanged from the interrupted run. The resumed invocation's cost summary covers calls made during that invocation, not calls from earlier failed attempts.
+
 ## Model Split
 
 The alpha fixture config assigns different models per phase:

--- a/docs/blog-tutorial-draft.md
+++ b/docs/blog-tutorial-draft.md
@@ -1,0 +1,488 @@
+# Teaching an Agent When It Needs a Skill: A Hands-On Autoresearch Tutorial
+
+> Draft based on a real run performed on 16 July 2026. The project is alpha software; the rough edges documented here were reproduced rather than inferred.
+
+Agent skills are easy to add and surprisingly hard to justify. A detailed `SKILL.md` may improve a model's work, but it also consumes context, adds maintenance overhead, and can become obsolete as models improve. How do we know whether a skill is helping? If it is helping, how much of it do we actually need?
+
+`skills-autoresearch-flue` is an experimental harness for answering those questions with evidence. It runs a task against a small eval fixture, scores the result, lets a researcher model make the smallest useful change to the skill, and evaluates the candidate again. Each phase leaves behind enough artifacts to inspect what happened.
+
+In this tutorial, we will run the project's release-notes fixture from beginning to end. We will start with a baseline score of `0.6`, let the harness improve a deliberately thin skill, and finish with a candidate that scores `1.0`. Along the way, we will also encounter the kind of alpha-quality dependency failures, noisy output, and missing recovery behavior that a polished product would need to solve.
+
+## The project in one sentence
+
+The current north star is:
+
+> Build a small, auditable Flue-based autoresearch harness that helps maintainers decide when skill context is worth using, and what the smallest useful skill should contain.
+
+The important word is _decide_. The harness should not assume that every weak output needs a larger skill. The evidence may instead suggest a smaller skill, better reference material, another producer model, a narrower eval, or no skill at all.
+
+## What is Flue?
+
+[Flue](https://github.com/withastro/flue) is an open-source TypeScript framework for building AI agents around a programmable agent harness. It provides primitives for agents, sessions, tools, skills, sandboxes, structured results, and deployable workflows.
+
+This project uses Flue as the layer that runs and isolates the researcher, producer, and judge. Flue manages their model sessions and working environments, while `skills-autoresearch-flue` supplies the research loop, eval fixtures, scoring rules, stopping conditions, and audit artifacts.
+
+## The three roles in a run
+
+The model-backed path keeps three responsibilities separate:
+
+1. The **researcher** reads score feedback and changes the skill.
+2. The **producer** uses the candidate skill to perform the eval task and write output files.
+3. The **judge** scores only the producer's output against the eval and rubric.
+
+The producer does not grade itself, and the judge does not reward instructions merely because they appear in `SKILL.md`. This separation is one of the project's most important constraints.
+
+The bundled fixture uses Claude Sonnet 4.6 for research and judging, and Claude Haiku 4.5 for production. The configuration assigns a model to each responsibility independently, so different models can already be mixed within the currently supported Anthropic provider. The longer-term intent is to allow any supported provider and model combination—for example, evaluating one provider's producer model with another provider's judge—but the committed schema and model client are Anthropic-only today.
+
+## What we are going to produce
+
+The fixture starts with this skill:
+
+```md
+# Release Summary
+
+Summarise changelog entries for a developer audience.
+
+Keep the output concise and focus on what changed.
+```
+
+That is enough to produce something plausible, but not enough to reliably cover migration risk. Our tangible outcome will be:
+
+- an improved candidate `SKILL.md`;
+- a release-note `RESULT.md` produced with that candidate;
+- an independent judge score and rationale;
+- a before/after score of `0.6 → 1.0`;
+- transcripts and a call-count summary that make the run auditable.
+
+## Prerequisites
+
+The repository requires Node 24 or newer and pnpm. The walkthrough used:
+
+```text
+Node v24.18.0
+pnpm 11.1.2
+```
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+### Alpha warning: the committed dependency graph was broken
+
+On the checkout used for this walkthrough, the first smoke run failed because Wrangler `4.95.0` did not satisfy `@cloudflare/vite-plugin`'s `^4.98.0` peer requirement. After correcting Wrangler, execution failed again because `@flue/cli` was `0.9.2` while `@flue/runtime` was `0.10.1`.
+
+The verified fix was to align the Flue packages, declare a compatible Wrangler, and update the removed runtime type entrypoint:
+
+```bash
+pnpm add --save-dev @flue/cli@0.10.1
+pnpm add --save-dev wrangler@^4.98.0
+```
+
+The source import also changed from `@flue/runtime/client` to `@flue/runtime`. This is tracked in [issue #84](https://github.com/schalkneethling/skills-autoresearch-flue/issues/84). If that issue is closed by the time you read this, a fresh `pnpm install` should be enough.
+
+## Tour the fixture before running it
+
+The example project lives under:
+
+```text
+fixtures/projects/release-notes-alpha/
+├── config.json
+├── evals/
+│   ├── eval-cases.json
+│   └── rubric.md
+├── input/CHANGELOG.md
+├── reference/context.md
+├── seed-skill/SKILL.md
+└── workspace/baseline/
+```
+
+This is a useful mental model for any autoresearch project:
+
+- `input/` contains task-specific material.
+- `reference/` contains stable context that is not itself skill guidance.
+- `seed-skill/` contains the starting instructions to improve.
+- `evals/` defines the task and what good work means.
+- `workspace/` contains the evidence produced by runs.
+
+The task input is deliberately small. `input/CHANGELOG.md` contains:
+
+```md
+# Changelog
+
+## 0.4.0
+
+- Replaced the markdown parser with a stricter CommonMark-compatible parser.
+- Deprecated the legacy `parseReleaseNotes()` helper.
+- Added migration notes for custom renderer integrations.
+```
+
+The complete eval case in `evals/eval-cases.json` is:
+
+```json
+{
+  "evals": [
+    {
+      "id": "notes-001",
+      "eval_type": "summarise-changelog",
+      "title": "Summarise a small changelog for users",
+      "input": {
+        "file": "CHANGELOG.md"
+      },
+      "expectations": {
+        "must_include": ["parser", "migration note", "risk"]
+      },
+      "scoring_dimensions": [
+        {
+          "id": "clarity",
+          "label": "Clear user-facing summary",
+          "max_score": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+Finally, `evals/rubric.md` tells the judge how to interpret that clarity dimension:
+
+```md
+# Rubric
+
+Score the release note output for clarity and usefulness to a developer audience.
+
+A high-scoring answer:
+
+- Names the user-visible change.
+- Mentions migration or compatibility impact.
+- Notes meaningful risk or verification guidance.
+```
+
+Taken together, these files make the task and its success criteria inspectable: summarize three concrete changelog facts, explicitly cover the parser, migration notes, and risk, and present them clearly for developers.
+
+The imported baseline has a normalized score of `0.6`, below the configured target of `0.8`.
+
+## Step 1: validate the no-cost path
+
+Run the committed baseline smoke test:
+
+```bash
+pnpm run alpha:smoke
+```
+
+This imports existing baseline artifacts and does not call a model. After fixing the dependency mismatch, the walkthrough produced:
+
+```json
+{
+  "completedIterations": 0,
+  "normalizedScore": 0.6,
+  "events": ["project-loaded", "cost-preview", "baseline-imported", "aggregated", "research-loop-ready"]
+}
+```
+
+The cost preview correctly planned zero calls because this command only validates and aggregates a committed baseline.
+
+This is a valuable first gate. It tells us that project paths, config parsing, baseline loading, and aggregation work before credentials or model spend enter the picture.
+
+## Step 2: understand why the baseline falls short
+
+Open these two files:
+
+```text
+workspace/baseline/notes-001/output/RESULT.md
+workspace/baseline/scores-0.json
+```
+
+The baseline producer output is only one sentence:
+
+```md
+The release updates the markdown parser and adds migration notes.
+```
+
+The corresponding score artifact records both the result and the judge's reasoning:
+
+```json
+{
+  "eval_id": "notes-001",
+  "eval_type": "summarise-changelog",
+  "track_id": "summarise",
+  "total_score": 0.6,
+  "max_score": 1,
+  "dimensions": [
+    {
+      "id": "clarity",
+      "score": 0.6,
+      "max_score": 1,
+      "rationale": "The summary identifies the parser change but omits risk and deprecation details."
+    }
+  ],
+  "summary": "Baseline is understandable but incomplete."
+}
+```
+
+The output mentions the parser change and migration guidance, but the rationale makes the shortfall concrete: it says nothing about risk or the deprecated helper. This is exactly the kind of specific gap a researcher should be able to act on.
+
+The goal is not “write a better skill” in the abstract. It is “make the smallest change that addresses observed failures without bloating the skill or overfitting to one example.”
+
+## Step 3: configure credentials
+
+[Varlock](https://varlock.dev/guides/schema/) is an environment-variable toolkit. This project uses it to declare that `ANTHROPIC_API_KEY` is required and sensitive, validate that a value is available, and inject the resolved configuration into the Flue process without hard-coding a key in the repository.
+
+The committed `.env.schema` uses Varlock's optional [1Password plugin](https://varlock.dev/plugins/1password/) as its default secret source:
+
+```dotenv
+# @plugin(@varlock/1password-plugin)
+# @initOp(allowAppAuth=true, account=https://my.1password.com/)
+
+# @sensitive @required
+ANTHROPIC_API_KEY=op(op://dev/anthropic/api_key)
+```
+
+In a 1Password secret reference, `op://dev/anthropic/api_key` means:
+
+- `dev`: the name of the maintainer's 1Password vault;
+- `anthropic`: the item stored in that vault;
+- `api_key`: the field containing the secret.
+
+The `dev` name is a repository convention, not a special Varlock environment or a requirement imposed by the harness.
+
+You do not need 1Password to run the project. Varlock gives values already present in the process environment higher precedence than values in `.env.schema`; its [environment documentation](https://varlock.dev/guides/environments/) describes the complete precedence order. You can therefore supply `ANTHROPIC_API_KEY` through your shell, CI secret store, or another secret manager before invoking the same script:
+
+```bash
+ANTHROPIC_API_KEY="your-key" pnpm run alpha:research
+```
+
+You could also place the value in a gitignored `.env.local` file for local development, although an external secret manager avoids storing the key as plaintext on disk. Never commit the resolved key.
+
+Validate resolution without printing the secret:
+
+```bash
+pnpm run env:check
+```
+
+A successful check marks `ANTHROPIC_API_KEY` and `FLUE_MODEL` as resolved and sensitive. When the key comes from the shell, Varlock reports it as a `process.env override`; otherwise, the committed setup fetches it from 1Password.
+
+Varlock therefore handles validation and injection, while 1Password is only the default secret backend chosen for this checkout. The model client itself remains Anthropic-only; cross-provider model support is a separate piece of future work.
+
+## Step 4: run one real research iteration
+
+Run:
+
+```bash
+pnpm run alpha:research
+```
+
+The script invokes Flue with an imported baseline, research enabled, and the release-notes seed skill selected. Because `0.6` is below the `0.8` target, the harness continues into research.
+
+Before spending, it plans three calls:
+
+```text
+researcher            1
+iteration producer    1
+iteration judge       1
+total                 3
+```
+
+The researcher identifies the score gap and patches the skill. The candidate adds four practical instructions:
+
+```md
+For each notable change:
+
+- Name the user-visible change clearly.
+- Include any migration or compatibility notes (e.g. deprecations, breaking changes, required action).
+- Note meaningful risk or verification guidance so developers know what to test or watch for.
+
+Avoid marketing language. Prioritise completeness for migration risk over brevity.
+```
+
+This is a modest change, not a rewrite. The producer then uses that candidate to create release notes with explicit parser, migration, deprecation, and verification sections. Finally, the independent judge awards `1/1` for clarity.
+
+The completed workflow reports:
+
+```json
+{
+  "completedIterations": 1,
+  "normalizedScore": 1,
+  "events": [
+    "project-loaded",
+    "cost-preview",
+    "baseline-imported",
+    "aggregated",
+    "research-loop-ready",
+    "iteration-started",
+    "iteration-generated",
+    "iteration-scored",
+    "target-score-reached"
+  ]
+}
+```
+
+## Step 5: inspect the evidence, not only the score
+
+The most useful output is not the terminal's final `1.0`. Inspect:
+
+```text
+workspace/iterations/1/
+├── skill/
+│   ├── SKILL.md
+│   ├── RESEARCH.md
+│   └── .autoresearch-flue-transcript.json
+├── outputs/notes-001/
+│   ├── RESULT.md
+│   ├── producer-flue-transcript.json
+│   └── judge-flue-transcript.json
+├── scores-0.json
+└── summary.json
+```
+
+Ask five questions:
+
+1. Did the candidate change only what the feedback justified?
+2. Is the produced result factually grounded in the changelog and reference material?
+3. Does the judge rationale cite evidence from the output?
+4. Did the aggregate improve without hiding a per-eval regression?
+5. Would the candidate remain useful outside this one fixture?
+
+For this run, the score improvement is easy to explain. The seed asked only for concision and a description of what changed. The candidate explicitly requested migration impact and risk guidance. The output contains both, and the judge rationale points to those sections.
+
+There is still a caveat: one eval with one binary scoring point is weak evidence. The run proves the machinery and produces a plausible improvement; it does not establish that the candidate generalizes across diverse changelogs.
+
+## Step 6: inspect model calls and cost
+
+The run writes `workspace/cost-summary.json`. Planned and actual call counts both equal three, which is useful. However, every token counter is zero for this Flue run, so no observed dollar estimate is available.
+
+Cost preview and budget support are documented and implemented in part, but [issue #19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19) remains open. The issue should be reconciled with current behavior: call-count preview exists, while Flue token usage and reliable dollar enforcement remain incomplete.
+
+## Step 7: rerunning is deliberately awkward today
+
+Iteration files are written conservatively to preserve evidence. Running the same research fixture again can collide with existing artifacts. The current workaround is to remove generated iterations before starting over:
+
+```bash
+rm -rf fixtures/projects/release-notes-alpha/workspace/iterations
+```
+
+That is risky tutorial ergonomics and easy to forget. A supported cleanup flag is tracked in [issue #10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10).
+
+More importantly, if a provider or network failure happens halfway through an expensive run, the harness cannot yet resume at the missing phase. Phase-aware recovery is the project's only current `p0` feature issue: [issue #55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55).
+
+## What is possible today
+
+The alpha can already:
+
+- import or generate a baseline;
+- stop before research when the baseline already reaches the target;
+- start from a seed skill or an empty candidate with the seed used as reference;
+- run separate researcher, producer, and judge phases;
+- use multiple eval cases with bounded concurrency;
+- reject a target-reaching aggregate when an individual eval regresses below baseline;
+- write candidate skills, outputs, scores, summaries, transcripts, and call counts;
+- improve one seed skill per invocation.
+
+## Current bugs and rough edges
+
+| Finding from this walkthrough                                                                  | Status                                                                             |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Clean install could not run Flue because CLI/runtime and Wrangler versions were incompatible   | [#84](https://github.com/schalkneethling/skills-autoresearch-flue/issues/84)       |
+| Normal terminal output exposes long model reasoning and generated content                      | [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17)       |
+| Common runs require long, plumbing-heavy Flue payloads outside the convenience fixture scripts | [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)       |
+| Reruns require manual cleanup                                                                  | [#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10)       |
+| Failed runs cannot resume from the latest trustworthy phase                                    | [#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55)       |
+| Flue call counts are captured, but this run exposed no token usage or dollar estimate          | [#19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19)       |
+| Generated phase workspaces and iteration artifacts were not ignored by Git                     | Fixed in the walkthrough branch; should be included with #84 or tracked separately |
+| `pnpm run format:check` fails on existing repository files                                     | Not currently tracked                                                              |
+
+Two tracker housekeeping items are also worth noting. [Issue #65](https://github.com/schalkneethling/skills-autoresearch-flue/issues/65) asks for skill-creator attribution, but the README already contains an acknowledgements section. [Issue #19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19) describes capabilities now partly present. Both need acceptance-criteria review rather than being presented as wholly missing.
+
+## What is coming next
+
+The issue tracker points to a coherent progression:
+
+- Reliability first: resume failed runs ([#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55)) and support safe reruns ([#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10)).
+- Make the tool pleasant to operate: shorter commands ([#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)), quiet output ([#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17)), and a richer run report ([#18](https://github.com/schalkneethling/skills-autoresearch-flue/issues/18)).
+- Improve the quality of researched skills: place durable material in references, scripts, or assets ([#64](https://github.com/schalkneethling/skills-autoresearch-flue/issues/64)); review the candidate skill itself ([#63](https://github.com/schalkneethling/skills-autoresearch-flue/issues/63)); and evaluate trigger phrasing ([#61](https://github.com/schalkneethling/skills-autoresearch-flue/issues/61)).
+- Broaden only after the loop is dependable: multi-skill runs ([#8](https://github.com/schalkneethling/skills-autoresearch-flue/issues/8)) and cross-provider judging.
+
+## What this run taught us about the project's goal
+
+The existing goal is strong and does not need a conceptual rewrite. The useful sharpening is about sequencing:
+
+> Before expanding providers, skill formats, or multi-skill orchestration, make one small run dependable, restartable, affordable to inspect, and easy to invoke.
+
+The next milestone should therefore be a **reliable single-skill research loop**. A user should be able to install the project, run a baseline, complete or resume one research iteration, understand the result, and rerun safely without editing JSON payloads or deleting evidence by hand.
+
+That milestone would turn today's promising alpha into a trustworthy foundation for the more ambitious question at the heart of the project: when does an agent genuinely need a skill, and what is the smallest skill worth keeping?
+
+---
+
+## Author notes for the next draft — remove before publishing
+
+This first walkthrough served its purpose as a maintainer reorientation exercise. It reconstructed the project goal, proved that the core loop still works, exposed dependency and workflow gaps, and produced real before-and-after evidence. It should not, however, be treated as the final reader journey.
+
+### Change the primary scenario to an external project
+
+The current article runs `fixtures/projects/release-notes-alpha/`, which lives inside the harness repository and benefits from repository-specific scripts such as `pnpm run alpha:smoke` and `pnpm run alpha:research`. That is useful for harness development, but it is not the common end-user setup.
+
+The final tutorial should start with two separate directories:
+
+```text
+/path/to/skills-autoresearch-flue/  # the installed or cloned harness
+/path/to/the-user-project/          # the skill project being researched
+```
+
+The user should run the harness against an external, absolute `projectRoot` and point `seedSkillDir` at a skill in that project. The walkthrough must verify path resolution from the harness working directory, where config and eval artifacts are written, which files remain in the external repository, and how the generated candidate is adopted after a successful run.
+
+Use a realistic project and skill rather than moving the release-notes fixture elsewhere merely to demonstrate an absolute path. The scenario should begin with a recognizable user problem, exercise more than one representative eval if affordable, and finish with an artifact the reader would plausibly keep or ship.
+
+The revised article should answer these questions explicitly:
+
+- What must be installed in the harness checkout versus the user's project?
+- Which command is run from which directory?
+- Which paths in `config.json` resolve relative to the external project root?
+- Which payload paths resolve relative to the shell working directory?
+- Does the user's repository need Flue, Varlock, or harness dependencies installed locally?
+- Where do baseline, iteration, transcript, and cost artifacts land?
+- How does the user review and adopt the winning candidate skill?
+- How can generated evidence be ignored or retained intentionally in the user's repository?
+- How does the user rerun or resume without deleting valuable evidence?
+
+Retain the local release-notes fixture as one of the following, rather than the main tutorial:
+
+- a short maintainer-focused smoke-test sidebar;
+- an appendix explaining the smallest possible fixture;
+- a development diary describing what the reorientation run uncovered.
+
+### Establish a publication gate
+
+Do not publish the final tutorial until the path it recommends works from a clean checkout against a separate external repository. At minimum, rerun that journey on the exact commit the article will link to and record the commands and artifacts from that run.
+
+Likely blockers to land or explicitly resolve before publication:
+
+- [#84](https://github.com/schalkneethling/skills-autoresearch-flue/issues/84): a clean install must produce a compatible Flue CLI/runtime/Wrangler dependency graph.
+- [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12): a normal external-project run needs a short, config-driven command instead of a long inline Flue payload.
+- [#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55): failed model-backed work should resume from the latest trustworthy phase.
+- [#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10): rerunning should not require a tutorial to recommend manual recursive deletion.
+
+Strong candidates for the same publication milestone:
+
+- [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17): default terminal output should be readable and should not dump long reasoning or generated content.
+- [#19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19): reconcile the issue with the implemented call preview and clearly describe the remaining token-usage and dollar-budget limitations.
+- Add or update documentation for secret injection without 1Password, making the maintainer's `dev` vault convention clearly optional.
+- Fix or intentionally baseline the existing repository-wide `format:check` failures.
+- Confirm that generated `.phase-workspaces/`, `iterations/`, and `cost-summary.json` files have an intentional version-control policy.
+
+Review open issues immediately before the next draft. Some tracker descriptions already lag behind the implementation—particularly #19 and #65—so the article should describe verified behavior, not repeat issue titles as if every acceptance criterion were still missing.
+
+### Evidence worth carrying forward
+
+Keep these findings from the first walkthrough available when rebuilding the article:
+
+- The seed skill was deliberately thin and the baseline output scored `0.6`.
+- The researcher made a small, explainable change instead of rewriting the skill.
+- Separate researcher, producer, and judge calls produced a `1.0` candidate.
+- The planned and actual call counts matched at three.
+- Flue call records exposed no token usage, so observed dollar cost remained unknown.
+- The dependency failures demonstrated the need to test installation and packaged execution, not only unit tests.
+- One eval with one scoring point proves the loop but is not strong evidence of generalization.
+
+For the final post, preserve this evidence-first style: show relevant file contents before interpreting them, explain unfamiliar infrastructure at the point where it appears, distinguish project conventions from actual requirements, and link to authoritative external documentation when a full explanation would distract from the tutorial.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -389,6 +389,7 @@ The payload fields are:
 - `withBaseline`: tells the harness to load or validate the baseline artifacts for the project.
 - `runResearch`: controls whether the researcher should patch the skill. `false` makes this a smoke run that stops before model-backed research.
 - `forceResearch`: optional override for research runs. When omitted or `false`, `runResearch:true` stops before the researcher if the baseline aggregate score already meets `target_score`.
+- `resume`: optional recovery mode. When `true`, the harness validates and reuses completed baseline scores, candidate research, producer output, and iteration scores before running only the missing phases.
 - `sessionId`: run/session name passed in the payload and used when writing harness artifacts.
 
 This should return events ending with `research-loop-ready`.
@@ -462,10 +463,35 @@ Key questions:
 
 ## Repeat Runs
 
-Generated iteration artifacts are written with exclusive file creation. To rerun the same fixture from scratch, remove the generated iterations first:
+Use resume mode after a provider error, network failure, quota limit, or interrupted process:
 
 ```bash
-rm -rf path/to/my-autoresearch-project/workspace/iterations
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-resume"}'
 ```
+
+Resume walks the run in order and validates artifacts before trusting them:
+
+- A valid positional `scores-<n>.json` skips both producer and judge for that eval.
+- A completed candidate skill with a recognized research transcript skips the researcher.
+- A valid producer transcript whose declared output files still exist and match skips the producer and runs only the judge.
+- A valid judge transcript without its positional score file is used to rebuild that score without another model call.
+- When all iteration scores exist but `summary.json` is missing, the summary is rebuilt.
+- A malformed, mismatched, stale, or ambiguous artifact stops recovery with an error instead of being silently overwritten.
+
+Incomplete candidate research and producer output directories that are safe to retry are moved under `workspace/resume-backups/` before that phase runs again, preserving the interrupted artifacts for audit.
+
+`resume:true` without `withBaseline` recovers a baseline that the harness was generating when it failed. `resume:true` with `withBaseline:true` keeps the strict imported-baseline behavior, then recovers research iterations.
+
+Resume assumes that `config.json`, eval cases, input, reference material, models, and seed skill have not changed since the interrupted run. There is not yet a run manifest that fingerprints those inputs. Start a fresh run after changing them.
+
+The cost summary and actual call counts written by a resumed invocation describe that invocation, while the call preview remains the configured maximum. Consult earlier transcripts and provider records for costs from previous failed attempts.
+
+To intentionally rerun research from an imported baseline, remove generated iterations and any prior resume backups:
+
+```bash
+rm -rf path/to/my-autoresearch-project/workspace/iterations path/to/my-autoresearch-project/workspace/resume-backups
+```
+
+If the harness generated the baseline too, also remove `workspace/baseline` before a fresh run. Do not remove an imported baseline unless you intend to regenerate or replace it.
 
 Keep committed fixtures baseline-only unless you intentionally want to preserve a specific alpha run artifact.

--- a/github-issue-triage-report.html
+++ b/github-issue-triage-report.html
@@ -1,0 +1,510 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GitHub Issue Triage Report</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fa;
+        --panel: #ffffff;
+        --text: #20242a;
+        --muted: #5b6472;
+        --border: #d9dee7;
+        --p0: #b60205;
+        --p1: #d93f0b;
+        --p2: #9a7400;
+        --p3: #0e8a16;
+        --link: #0759c8;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          14px/1.5 -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+      }
+
+      main {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+      }
+
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin: 0 0 12px;
+      }
+
+      h1 {
+        font-size: 28px;
+      }
+
+      h2 {
+        font-size: 20px;
+        margin-top: 28px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin-top: 20px;
+      }
+
+      p {
+        margin: 0 0 12px;
+      }
+
+      a {
+        color: var(--link);
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+      }
+
+      .meta,
+      .note {
+        color: var(--muted);
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+        margin: 18px 0 26px;
+      }
+
+      .metric {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px;
+      }
+
+      .metric strong {
+        display: block;
+        font-size: 22px;
+        line-height: 1.1;
+        margin-bottom: 4px;
+      }
+
+      details {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-top: 18px;
+        overflow: hidden;
+      }
+
+      summary {
+        cursor: pointer;
+        font-weight: 700;
+        padding: 16px 18px;
+        background: #eef2f7;
+      }
+
+      .details-body {
+        padding: 18px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 14px;
+      }
+
+      th,
+      td {
+        border-top: 1px solid var(--border);
+        padding: 10px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: #303844;
+        font-size: 12px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        background: #fafbfc;
+      }
+
+      .badge {
+        display: inline-block;
+        min-width: 2.4em;
+        border-radius: 999px;
+        color: #fff;
+        font-weight: 700;
+        padding: 2px 8px;
+        text-align: center;
+      }
+
+      .p0 {
+        background: var(--p0);
+      }
+      .p1 {
+        background: var(--p1);
+      }
+      .p2 {
+        background: var(--p2);
+      }
+      .p3 {
+        background: var(--p3);
+      }
+
+      code,
+      .label {
+        background: #eef2f7;
+        border: 1px solid #dbe1ea;
+        border-radius: 999px;
+        color: #2f3742;
+        display: inline-block;
+        font:
+          12px/1.3 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
+        margin: 0 3px 3px 0;
+        padding: 2px 7px;
+      }
+
+      .status-ok {
+        color: #116329;
+        font-weight: 700;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>GitHub Issue Triage Report</h1>
+      <p class="meta">Generated: 2026-06-14T21:27:47Z</p>
+      <p>
+        Input repositories:
+        <a href="https://github.com/schalkneethling/skills-autoresearch-flue"
+          >schalkneethling/skills-autoresearch-flue</a
+        >
+      </p>
+
+      <h2>Summary</h2>
+      <div class="summary-grid" aria-label="Repository triage summary">
+        <div class="metric"><strong>1</strong>Repository triaged</div>
+        <div class="metric"><strong>18</strong>Open issues</div>
+        <div class="metric"><strong>1</strong>p0</div>
+        <div class="metric"><strong>5</strong>p1</div>
+        <div class="metric"><strong>9</strong>p2</div>
+        <div class="metric"><strong>3</strong>p3</div>
+      </div>
+
+      <details open>
+        <summary>
+          schalkneethling/skills-autoresearch-flue - 18 open issues - p0: 1, p1: 5, p2: 9, p3: 3 - next: #55 Resume
+          failed runs from latest completed phase
+        </summary>
+        <div class="details-body">
+          <h2>Project Goal Summary</h2>
+          <p>
+            The project aims to build a small, auditable Flue-based autoresearch harness for deciding when skill context
+            is useful, comparing no-skill and skill-guided performance, improving the smallest useful skill, and
+            preserving enough artifacts to reconstruct each run. Near-term work should tighten reliability,
+            auditability, cost visibility, documentation, schema-validated outputs, and recovery around the single-skill
+            release-notes alpha loop before broadening the surface area.
+          </p>
+
+          <h3>Label Update Status</h3>
+          <p class="status-ok">Applied on GitHub.</p>
+          <p>
+            Created missing canonical labels <code>p0</code>, <code>p1</code>, <code>p2</code>, and <code>p3</code>.
+            Each open issue now has exactly one canonical priority label. Existing non-priority labels, such as
+            <code>enhancement</code>, were preserved.
+          </p>
+
+          <h3>Next Issue Nomination</h3>
+          <p>
+            <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/55"
+              >#55 Resume failed runs from latest completed phase</a
+            >
+            should be worked on next. It directly addresses the project goal of recoverable, auditable model-backed runs
+            and prevents expensive completed work from being lost after quota, provider, network, or interruption
+            failures.
+          </p>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Priority</th>
+                <th>Issue</th>
+                <th>Rationale tied to GOAL.md</th>
+                <th>Impact</th>
+                <th>Current labels</th>
+                <th>Notes or uncertainty</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="badge p0">p0</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/55"
+                    >#55 Resume failed runs from latest completed phase</a
+                  >
+                </td>
+                <td>
+                  Recovery from interrupted or failed runs is a core goal and success criterion. This issue covers
+                  baseline reuse, research reuse, producer-output reuse, missing judge scoring, and summary rebuilds.
+                </td>
+                <td>Critical reliability and cost protection for real model-backed alpha runs.</td>
+                <td><span class="label">p0</span></td>
+                <td>Best next issue because it is goal-critical and has concrete acceptance criteria.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p1">p1</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/19"
+                    >#19 Add cost preview and budget guardrails for autoresearch runs</a
+                  >
+                </td>
+                <td>
+                  The goal explicitly requires making costs and planned model calls visible before spending model-backed
+                  effort.
+                </td>
+                <td>High user trust and adoption impact; protects users from expensive runs.</td>
+                <td><span class="label">p1</span></td>
+                <td>
+                  Some follow-up issues split out deeper pricing details, but the base guardrail remains high priority.
+                </td>
+              </tr>
+              <tr>
+                <td><span class="badge p1">p1</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/17"
+                    >#17 Make run logging quiet by default with verbose mode</a
+                  >
+                </td>
+                <td>
+                  Auditability is central, but normal terminal output must remain readable enough to understand progress
+                  and stop reasons.
+                </td>
+                <td>High usability and debugging impact for repeated alpha runs.</td>
+                <td><span class="label">p1</span></td>
+                <td>Pairs naturally with richer reporting, but can land independently.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p1">p1</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/12"
+                    >#12 Simplify autoresearch runs with config-driven commands</a
+                  >
+                </td>
+                <td>
+                  The harness is for maintainers running their own eval projects; current long payload commands add
+                  avoidable onboarding friction.
+                </td>
+                <td>High adoption impact and reduces operator error.</td>
+                <td><span class="label">p1</span></td>
+                <td>Good candidate after the recovery and logging fundamentals stabilize.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p1">p1</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/10"
+                    >#10 Add rerun flag to clean or overwrite generated iterations</a
+                  >
+                </td>
+                <td>
+                  Exclusive artifact writes preserve auditability, but supported cleanup is needed for practical fixture
+                  iteration.
+                </td>
+                <td>High alpha workflow impact; removes manual risky cleanup steps.</td>
+                <td><span class="label">p1</span></td>
+                <td>Scope should remain limited to generated iteration artifacts.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p1">p1</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/64"
+                    >#64 Teach researcher to recommend skill resources and validate generated scripts</a
+                  >
+                </td>
+                <td>
+                  The north star is the smallest useful skill. Resource placement supports concise skills and
+                  progressive disclosure rather than dumping everything into SKILL.md.
+                </td>
+                <td>High quality impact for candidate skill usefulness and portability.</td>
+                <td><span class="label">enhancement</span><span class="label">p1</span></td>
+                <td>Important once the end-to-end loop is reliable enough to evaluate richer candidate artifacts.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/76"
+                    >#76 Add soft warning threshold before hard model budget stop</a
+                  >
+                </td>
+                <td>Extends cost visibility after the hard budget cap exists.</td>
+                <td>Medium impact refinement to cost guardrails.</td>
+                <td><span class="label">enhancement</span><span class="label">p2</span></td>
+                <td>Depends conceptually on the base budget guardrail work.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/75"
+                    >#75 Support configurable cost currency and model pricing</a
+                  >
+                </td>
+                <td>Improves auditability of cost summaries and prepares for non-default provider pricing.</td>
+                <td>Medium impact; useful after basic budget tracking is in place.</td>
+                <td><span class="label">enhancement</span><span class="label">p2</span></td>
+                <td>Cross-provider work is planned but not yet the active focus.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/65"
+                    >#65 Document skill-creator inspiration and attribution</a
+                  >
+                </td>
+                <td>Keeps docs and provenance clear as skill-creation ideas influence the harness.</td>
+                <td>Medium documentation and trust impact.</td>
+                <td><span class="label">enhancement</span><span class="label">p2</span></td>
+                <td>Important, but not blocking core harness behavior.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/63"
+                    >#63 Add candidate skill quality review pass</a
+                  >
+                </td>
+                <td>
+                  Complements producer-output judging by assessing whether candidate skill guidance is concise,
+                  portable, and not overfit.
+                </td>
+                <td>Medium-to-high quality impact, but optional relative to the core producer/judge loop.</td>
+                <td><span class="label">enhancement</span><span class="label">p2</span></td>
+                <td>Could rise after resource-placement support lands.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/61"
+                    >#61 Add trigger phrasing eval cases for generated skills</a
+                  >
+                </td>
+                <td>Helps determine whether generated skills are discoverable for the right user requests.</td>
+                <td>Medium quality and portability impact.</td>
+                <td><span class="label">enhancement</span><span class="label">p2</span></td>
+                <td>Likely follows the compatibility spike in #60.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/60"
+                    >#60 Evaluate skill trigger metadata and frontmatter compatibility</a
+                  >
+                </td>
+                <td>
+                  Supports portable skill metadata decisions across agent surfaces without relying on assumptions.
+                </td>
+                <td>Medium research and docs impact.</td>
+                <td><span class="label">enhancement</span><span class="label">p2</span></td>
+                <td>Mostly a spike; evidence gathered here can guide later implementation.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/23"
+                    >#23 Explore programmatic Flue compaction at phase boundaries</a
+                  >
+                </td>
+                <td>
+                  Addresses long-run context growth, which can break model-backed runs and threaten audit continuity.
+                </td>
+                <td>Medium reliability impact; not the whole context-control solution.</td>
+                <td><span class="label">p2</span></td>
+                <td>Lower than resume because it depends on Flue API reality and scoped-session decisions.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/18"
+                    >#18 Build a richer feedback UI for autoresearch runs</a
+                  >
+                </td>
+                <td>Strongly supports artifact inspection and understandable run outcomes.</td>
+                <td>Medium user experience and auditability impact, but broad.</td>
+                <td><span class="label">p2</span></td>
+                <td>A static report slice may be a useful first step before a live UI.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p2">p2</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/9"
+                    >#9 Support human-friendly eval authoring</a
+                  >
+                </td>
+                <td>
+                  Small, inspectable fixtures are a project constraint; Markdown authoring would make eval review
+                  easier.
+                </td>
+                <td>Medium usability and contribution impact.</td>
+                <td><span class="label">p2</span></td>
+                <td>Useful after the alpha fixture flow is stable.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p3">p3</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/62"
+                    >#62 Add optional masked comparison for subjective evals</a
+                  >
+                </td>
+                <td>
+                  Could improve subjective review quality, but it is optional and not required for the current
+                  single-provider alpha loop.
+                </td>
+                <td>Lower immediate impact than core scoring, recovery, and logging work.</td>
+                <td><span class="label">enhancement</span><span class="label">p3</span></td>
+                <td>Revisit when subjective eval coverage grows.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p3">p3</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/13"
+                    >#13 Use skills-autoresearch as the future global CLI name</a
+                  >
+                </td>
+                <td>
+                  Useful naming polish for a future public CLI, but less urgent than simplifying the actual run
+                  workflow.
+                </td>
+                <td>Low immediate alpha impact.</td>
+                <td><span class="label">p3</span></td>
+                <td>Can be folded into broader CLI work later.</td>
+              </tr>
+              <tr>
+                <td><span class="badge p3">p3</span></td>
+                <td>
+                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/8"
+                    >#8 Support multi-skill improvement runs</a
+                  >
+                </td>
+                <td>Documented as a post-alpha capability; current focus is proving one seed skill per invocation.</td>
+                <td>Low immediate impact for the active alpha focus.</td>
+                <td><span class="label">p3</span></td>
+                <td>Could rise after the single-skill run loop is stable.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </main>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@flue/cli": "0.9.2",
+    "@flue/cli": "0.10.1",
     "@types/node": "^25.9.1",
     "@varlock/1password-plugin": "^1.1.0",
     "eslint": "^10.4.1",
@@ -34,7 +34,8 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1",
     "varlock": "^1.5.1",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "wrangler": "^4.111.0"
   },
   "engines": {
     "node": ">=24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1)
       '@flue/cli':
-        specifier: 0.9.2
-        version: 0.9.2(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.27.3)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260526.1)(wrangler@4.95.0)(yaml@2.9.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.10.1
+        version: 0.10.1(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260710.1)(wrangler@4.111.0)(yaml@2.9.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -44,7 +44,10 @@ importers:
         version: 1.5.1
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0))
+      wrangler:
+        specifier: ^4.111.0
+        version: 4.111.0
 
 packages:
 
@@ -185,22 +188,16 @@ packages:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.98.0
 
-  '@cloudflare/workerd-darwin-64@1.20260526.1':
-    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-64@1.20260603.1':
     resolution: {integrity: sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260526.1':
-    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==}
+  '@cloudflare/workerd-darwin-64@1.20260710.1':
+    resolution: {integrity: sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw==}
     engines: {node: '>=16'}
-    cpu: [arm64]
+    cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260603.1':
@@ -209,11 +206,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260526.1':
-    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==}
+  '@cloudflare/workerd-darwin-arm64@1.20260710.1':
+    resolution: {integrity: sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw==}
     engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
+    cpu: [arm64]
+    os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20260603.1':
     resolution: {integrity: sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==}
@@ -221,10 +218,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260526.1':
-    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==}
+  '@cloudflare/workerd-linux-64@1.20260710.1':
+    resolution: {integrity: sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ==}
     engines: {node: '>=16'}
-    cpu: [arm64]
+    cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260603.1':
@@ -233,14 +230,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260526.1':
-    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==}
+  '@cloudflare/workerd-linux-arm64@1.20260710.1':
+    resolution: {integrity: sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
+    resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260603.1':
-    resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
+  '@cloudflare/workerd-windows-64@1.20260710.1':
+    resolution: {integrity: sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -267,158 +270,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -462,22 +465,13 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@flue/cli@0.9.2':
-    resolution: {integrity: sha512-3S66gtPDlND1RaLG/NpFE/wmVY+3e1NK52bcP8tzHv47b77+M9sPOygM26rZVl3GABRayp18o0CpoH7/HnnrrQ==}
+  '@flue/cli@0.10.1':
+    resolution: {integrity: sha512-cOejGFqgCZJB09m297VNPesKENmIWi8jXy7fxR6KW0GWwoEzeDivO2oNavlPD6Og9h4+i42VeJ+KEhyvoXFUbw==}
     engines: {node: '>=22.18.0'}
     hasBin: true
-    peerDependencies:
-      wrangler: ^4.94.0
-    peerDependenciesMeta:
-      wrangler:
-        optional: true
 
   '@flue/runtime@0.10.1':
     resolution: {integrity: sha512-W37iGDjgQsgTfSkCjqrxbgU0Wmv5AAuThJnEJb0jlbTxt3kVk0gmN79c1i1JDfaZVQslCKs+oXGiHpLl5s4QkA==}
-    engines: {node: '>=22.18.0'}
-
-  '@flue/runtime@0.9.2':
-    resolution: {integrity: sha512-BOwVfqsNhyyhHV6fdU0lv7X5LjF8twZUe55uVzWSimO2s0JTZ40JeU47xaexkx9cV5I0emwNKHD2yK/bXSeXJg==}
     engines: {node: '>=22.18.0'}
 
   '@google/genai@1.52.0':
@@ -1323,8 +1317,8 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1785,13 +1779,13 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@4.20260526.0:
-    resolution: {integrity: sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==}
+  miniflare@4.20260603.0:
+    resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@4.20260603.0:
-    resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
+  miniflare@4.20260710.0:
+    resolution: {integrity: sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2028,26 +2022,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rosie-skills-darwin-arm64@0.6.4:
-    resolution: {integrity: sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  rosie-skills-freebsd-x64@0.6.4:
-    resolution: {integrity: sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==}
-    cpu: [x64]
-    os: [freebsd]
-
-  rosie-skills-linux-x64@0.6.4:
-    resolution: {integrity: sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==}
-    cpu: [x64]
-    os: [linux]
-
-  rosie-skills@0.6.4:
-    resolution: {integrity: sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -2064,11 +2038,6 @@ packages:
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2254,6 +2223,10 @@ packages:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -2386,22 +2359,22 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260526.1:
-    resolution: {integrity: sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workerd@1.20260603.1:
     resolution: {integrity: sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.95.0:
-    resolution: {integrity: sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==}
+  workerd@1.20260710.1:
+    resolution: {integrity: sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.111.0:
+    resolution: {integrity: sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260526.1
+      '@cloudflare/workers-types': ^5.20260710.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -2697,53 +2670,53 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260710.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260526.1
+      workerd: 1.20260710.1
 
-  '@cloudflare/vite-plugin@1.40.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0))(workerd@1.20260526.1)(wrangler@4.95.0)':
+  '@cloudflare/vite-plugin@1.40.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0))(workerd@1.20260710.1)(wrangler@4.111.0)':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260710.1)
       miniflare: 4.20260603.0
       unenv: 2.0.0-rc.24
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0)
-      wrangler: 4.95.0
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0)
+      wrangler: 4.111.0
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/workerd-darwin-64@1.20260526.1':
-    optional: true
-
   '@cloudflare/workerd-darwin-64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260526.1':
+  '@cloudflare/workerd-darwin-64@1.20260710.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260526.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260710.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260526.1':
+  '@cloudflare/workerd-linux-64@1.20260710.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260526.1':
+  '@cloudflare/workerd-linux-arm64@1.20260710.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260603.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260710.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -2800,82 +2773,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)':
@@ -2912,16 +2885,14 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@flue/cli@0.9.2(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.27.3)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260526.1)(wrangler@4.95.0)(yaml@2.9.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+  '@flue/cli@0.10.1(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260710.1)(wrangler@4.111.0)(yaml@2.9.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.40.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0))(workerd@1.20260526.1)(wrangler@4.95.0)
-      '@flue/runtime': 0.9.2(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+      '@cloudflare/vite-plugin': 1.40.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0))(workerd@1.20260710.1)(wrangler@4.111.0)
+      '@flue/runtime': 0.10.1(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@vercel/detect-agent': 1.2.3
       package-up: 5.0.0
       valibot: 1.4.1(typescript@6.0.3)
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0)
-    optionalDependencies:
-      wrangler: 4.95.0
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@standard-schema/spec'
@@ -2946,47 +2917,13 @@ snapshots:
       - typescript
       - utf-8-validate
       - workerd
+      - wrangler
       - yaml
       - zod
       - zod-openapi
       - zod-to-json-schema
 
   '@flue/runtime@0.10.1(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.79.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@hono/node-server': 2.0.4(hono@4.12.25)
-      '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.25)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
-      '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
-      hono: 4.12.25
-      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.25))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.25)(openapi-types@12.1.3)
-      js-yaml: 4.2.0
-      just-bash: 3.0.1
-      openapi-types: 12.1.3
-      quansync: 0.2.11
-      ulidx: 2.4.1
-      valibot: 1.4.1(typescript@6.0.3)
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@standard-schema/spec'
-      - '@types/json-schema'
-      - arktype
-      - bufferutil
-      - effect
-      - supports-color
-      - sury
-      - typebox
-      - typescript
-      - utf-8-validate
-      - zod
-      - zod-openapi
-      - zod-to-json-schema
-
-  '@flue/runtime@0.9.2(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -3546,13 +3483,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -3755,34 +3692,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.27.3:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-html@1.0.3: {}
 
@@ -4275,18 +4212,6 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  miniflare@4.20260526.0:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.34.5
-      undici: 7.24.8
-      workerd: 1.20260526.1
-      ws: 8.20.1
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   miniflare@4.20260603.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -4294,6 +4219,18 @@ snapshots:
       undici: 7.24.8
       workerd: 1.20260603.1
       ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@4.20260710.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260710.1
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -4541,21 +4478,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
-  rosie-skills-darwin-arm64@0.6.4:
-    optional: true
-
-  rosie-skills-freebsd-x64@0.6.4:
-    optional: true
-
-  rosie-skills-linux-x64@0.6.4:
-    optional: true
-
-  rosie-skills@0.6.4:
-    optionalDependencies:
-      rosie-skills-darwin-arm64: 0.6.4
-      rosie-skills-freebsd-x64: 0.6.4
-      rosie-skills-linux-x64: 0.6.4
-
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -4576,10 +4498,7 @@ snapshots:
 
   semver@7.8.1: {}
 
-  semver@7.8.2: {}
-
-  semver@7.8.4:
-    optional: true
+  semver@7.8.4: {}
 
   send@1.2.1:
     dependencies:
@@ -4612,7 +4531,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.2
+      semver: 7.8.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -4805,6 +4724,8 @@ snapshots:
 
   undici@7.24.8: {}
 
+  undici@7.28.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -4826,7 +4747,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4835,14 +4756,14 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
-      esbuild: 0.27.3
+      esbuild: 0.28.1
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -4859,7 +4780,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
@@ -4879,14 +4800,6 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260526.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260526.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260526.1
-      '@cloudflare/workerd-linux-64': 1.20260526.1
-      '@cloudflare/workerd-linux-arm64': 1.20260526.1
-      '@cloudflare/workerd-windows-64': 1.20260526.1
-
   workerd@1.20260603.1:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20260603.1
@@ -4895,17 +4808,24 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260603.1
       '@cloudflare/workerd-windows-64': 1.20260603.1
 
-  wrangler@4.95.0:
+  workerd@1.20260710.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260710.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260710.1
+      '@cloudflare/workerd-linux-64': 1.20260710.1
+      '@cloudflare/workerd-linux-arm64': 1.20260710.1
+      '@cloudflare/workerd-windows-64': 1.20260710.1
+
+  wrangler@4.111.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260710.1)
       blake3-wasm: 2.1.5
-      esbuild: 0.27.3
-      miniflare: 4.20260526.0
+      esbuild: 0.28.1
+      miniflare: 4.20260710.0
       path-to-regexp: 6.3.0
-      rosie-skills: 0.6.4
       unenv: 2.0.0-rc.24
-      workerd: 1.20260526.1
+      workerd: 1.20260710.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { copySkillSnapshot, SkillResearcher } from "./orchestrator.js";
+import { createResearchSnapshotManifest } from "./resume.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
 import { EvalScore, EvalScoreSchema, parseWithSchema } from "./schemas.js";
 
@@ -15,6 +16,7 @@ export class SnapshotResearcher implements SkillResearcher {
           iteration: request.iteration,
           previousSkillDir: request.previousSkillDir,
           previousNormalizedScore: request.previousAggregate.overall.normalizedScore,
+          manifest: await createResearchSnapshotManifest(request.candidateSkillDir),
         },
         null,
         2,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,10 +79,10 @@ export function parseCliArgs(argv: string[]): CliOptions {
   if (options.scoreDir && options.modelClient) {
     throw new Error("Use either --score-dir or --model-client, not both.");
   }
-  if (!options.withBaseline && !options.scoreDir && !options.modelClient) {
+  if (!options.resume && !options.withBaseline && !options.scoreDir && !options.modelClient) {
     throw new Error("Generating a baseline requires --score-dir or --model-client anthropic.");
   }
-  if (options.runResearch && !options.scoreDir && !options.modelClient) {
+  if (!options.resume && options.runResearch && !options.scoreDir && !options.modelClient) {
     throw new Error("Research iterations require --score-dir or --model-client anthropic.");
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ interface CliOptions {
   withBaseline: boolean;
   runResearch: boolean;
   forceResearch: boolean;
+  resume: boolean;
   seedSkillDir?: string;
   scoreDir?: string;
   modelClient?: "anthropic";
@@ -27,6 +28,7 @@ function usage(): string {
     "  --with-baseline       Import workspace/baseline instead of generating it.",
     "  --research            Run research iterations after baseline.",
     "  --force-research      Run research even when the baseline already reaches target_score.",
+    "  --resume              Continue from validated baseline and iteration artifacts.",
     "  --seed-skill <dir>    Seed skill directory for research iterations.",
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
@@ -44,6 +46,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       "with-baseline": { type: "boolean" },
       research: { type: "boolean" },
       "force-research": { type: "boolean" },
+      resume: { type: "boolean" },
       "seed-skill": { type: "string" },
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
@@ -65,6 +68,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     withBaseline: parsed.values["with-baseline"] ?? false,
     runResearch: parsed.values.research ?? false,
     forceResearch: parsed.values["force-research"] ?? false,
+    resume: parsed.values.resume ?? false,
     seedSkillDir: parsed.values["seed-skill"],
     scoreDir: parsed.values["score-dir"],
     modelClient: parseModelClient(parsed.values["model-client"]),
@@ -118,6 +122,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     withBaseline: cli.withBaseline,
     runResearch: cli.runResearch,
     forceResearch: cli.forceResearch,
+    resume: cli.resume,
     seedSkillDir: cli.seedSkillDir,
     budgetUsd: cli.budgetUsd,
     modelBacked: Boolean(modelClient),
@@ -187,6 +192,11 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
       return { level: "log", message: `Generating baseline: ${event.evals} evals` };
     case "baseline-generated":
       return { level: "log", message: `Generated baseline: ${event.scores} scores` };
+    case "baseline-resumed":
+      return {
+        level: "log",
+        message: `Resumed baseline: reused ${event.scores} score(s), ${event.remaining} remaining`
+      };
     case "aggregated":
       return {
         level: "log",
@@ -203,6 +213,31 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
       return {
         level: "debug",
         message: `Iteration ${event.iteration} skill: ${event.candidateSkillDir}`
+      };
+    case "iteration-research-resumed":
+      return {
+        level: "log",
+        message: `Iteration ${event.iteration}: reused completed research`
+      };
+    case "eval-score-resumed":
+      return {
+        level: "log",
+        message: `Iteration ${event.iteration}: reused score for ${event.evalId}`
+      };
+    case "eval-producer-resumed":
+      return {
+        level: "log",
+        message: `Iteration ${event.iteration}: reused producer output for ${event.evalId}`
+      };
+    case "eval-judge-resumed":
+      return {
+        level: "log",
+        message: `Iteration ${event.iteration}: recovered judge score for ${event.evalId}`
+      };
+    case "iteration-summary-rebuilt":
+      return {
+        level: "log",
+        message: `Iteration ${event.iteration}: rebuilt summary from persisted scores`
       };
     case "iteration-scored":
       return {

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -1,4 +1,4 @@
-import type { FlueSession } from "@flue/runtime/client";
+import type { FlueSession } from "@flue/runtime";
 import { ModelCallRole } from "./cost.js";
 import {
   applyOutputFiles,
@@ -18,6 +18,7 @@ import {
   EvalScoreSchema,
   ModelConfig,
   ModelProduceResponseSchema,
+  OutputFile,
   SkillResearchPatchSchema
 } from "./schemas.js";
 import { cp, mkdir, rm, writeFile } from "node:fs/promises";
@@ -54,7 +55,11 @@ export class FlueEvalAgent implements EvalAgent {
       response: produced
     });
 
-    const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
+    return this.judge(request, produced.output_files);
+  }
+
+  async judge(request: EvalAgentRequest, outputFiles: OutputFile[]): Promise<EvalScore> {
+    const judgeRequest = await buildJudgeModelRequest(request, outputFiles);
     request.costTracker?.assertCanStartModelCall();
     const { data: score } = await this.#session.task(judgeRequest.prompt, {
       result: EvalScoreSchema,

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -140,7 +140,11 @@ export class ModelEvalAgent implements EvalAgent {
     const produced = parseModelProduceResponse(produceResponse);
     await applyOutputFiles(request.sandbox.outputDir, produced.output_files);
 
-    const judgeRequest = await buildJudgeModelRequest(request, produced.output_files);
+    return this.judge(request, produced.output_files);
+  }
+
+  async judge(request: EvalAgentRequest, outputFiles: OutputFile[]): Promise<EvalScore> {
+    const judgeRequest = await buildJudgeModelRequest(request, outputFiles);
     const judgeResponse = await completeTrackedModelRequest(
       this.#client,
       judgeRequest,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,6 @@
 import { cp, mkdir, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
 import { createModelCallPreview, ModelRunCostSummary, ModelRunCostTracker, persistCostSummary } from "./cost.js";
@@ -263,17 +264,13 @@ async function resumeInitialBaseline(
 ): Promise<EvalScore[]> {
   const baselineDir = join(project.root, "workspace", "baseline");
   await assertNoUnexpectedScores(baselineDir, project.evals.evals.length);
-  const existing = await inspectConfiguredScores(project, baselineDir);
+  const existing = await inspectConfiguredScores(project, baselineDir, baselineDir);
   const remaining = existing.filter((score) => score === undefined).length;
   emit({
     type: "baseline-resumed",
     scores: existing.length - remaining,
     remaining
   });
-
-  if (remaining > 0 && !agent) {
-    throw new Error("No eval agent was provided to resume the incomplete baseline run");
-  }
 
   const outputRoot = baselineDir;
   const scores = await runWithConcurrency(
@@ -307,6 +304,9 @@ async function resumeInitialBaseline(
       if (producerArtifact.status === "invalid") {
         throw new Error(`Cannot resume baseline producer for eval "${evalCase.id}": ${producerArtifact.reason}`);
       }
+      if (!agent) {
+        throw new Error("No eval agent was provided to resume the incomplete baseline run");
+      }
       if (
         producerArtifact.status === "incomplete" ||
         (producerArtifact.status === "absent" && (await pathExists(evalOutputDir)))
@@ -315,8 +315,8 @@ async function resumeInitialBaseline(
       }
       const score =
         producerArtifact.status === "complete"
-          ? await judgeEval(request, agent as EvalAgent, producerArtifact.value.outputFiles)
-          : await runEval(request, agent as EvalAgent);
+          ? await judgeEval(request, agent, producerArtifact.value.outputFiles)
+          : await runEval(request, agent);
       await persistEvalScore(outputRoot, index, score);
       return score;
     }
@@ -335,13 +335,6 @@ async function runResearchIterations(
   emit: (event: RunEvent) => void,
   costTracker: ModelRunCostTracker
 ): Promise<{ iterations: IterationResult[]; bestIteration?: IterationResult }> {
-  if (!options.agent) {
-    throw new Error("No eval agent was provided to run research iterations");
-  }
-  if (!options.researcher) {
-    throw new Error("No skill researcher was provided to run research iterations");
-  }
-
   const agent = options.agent;
   const seedSkillDir = await resolveSeedSkillDir(project, options.seedSkillDir);
   const guidanceSkillDir = await resolveGuidanceSkillDir(project, options.guidanceSkillDir, seedSkillDir);
@@ -369,6 +362,9 @@ async function runResearchIterations(
       } else {
         await assertNoIterationEvaluationArtifacts(iterationDir, iteration);
         await assertNoFutureIterationArtifacts(project.root, iteration);
+        if (!options.researcher) {
+          throw new Error("No skill researcher was provided to resume the incomplete research run");
+        }
         if (researchArtifact.status === "incomplete") {
           await archiveIncompleteArtifact(project.root, candidateSkillDir, `iteration-${iteration}-research`);
         }
@@ -391,6 +387,9 @@ async function runResearchIterations(
         emit({ type: "iteration-generated", iteration, candidateSkillDir });
       }
     } else {
+      if (!options.researcher) {
+        throw new Error("No skill researcher was provided to run research iterations");
+      }
       if (iteration === 1) {
         previousSkillDir = await prepareInitialResearchSkillDir(project, seedSkillDir);
       }
@@ -417,7 +416,13 @@ async function runResearchIterations(
 
     const scores = options.resume
       ? await resumeIterationScores(project, iteration, iterationDir, candidateSkillDir, agent, emit, costTracker)
-      : await runFreshIterationScores(project, iterationDir, candidateSkillDir, agent, costTracker);
+      : await runFreshIterationScores(
+          project,
+          iterationDir,
+          candidateSkillDir,
+          requireEvalAgent(agent, "run research iterations"),
+          costTracker
+        );
 
     const aggregate = aggregateScores(project.config, scores);
     const summaryPath = join(iterationDir, "summary.json");
@@ -544,12 +549,13 @@ async function resumeIterationScores(
   iteration: number,
   iterationDir: string,
   candidateSkillDir: string,
-  agent: EvalAgent,
+  agent: EvalAgent | undefined,
   emit: (event: RunEvent) => void,
   costTracker: ModelRunCostTracker
 ): Promise<EvalScore[]> {
   await assertNoUnexpectedScores(iterationDir, project.evals.evals.length);
-  const existing = await inspectConfiguredScores(project, iterationDir);
+  const outputRoot = join(iterationDir, "outputs");
+  const existing = await inspectConfiguredScores(project, iterationDir, outputRoot);
 
   return runWithConcurrency(project.evals.evals, project.config.max_concurrency, async (evalCase, index) => {
     const reused = existing[index];
@@ -558,7 +564,6 @@ async function resumeIterationScores(
       return reused;
     }
 
-    const outputRoot = join(iterationDir, "outputs");
     const evalOutputDir = join(outputRoot, evalCase.id);
     const track = trackForEval(project.config, evalCase.eval_type);
     const judgeArtifact = await inspectJudgeArtifact(evalOutputDir, evalCase, track);
@@ -576,6 +581,9 @@ async function resumeIterationScores(
       throw new Error(
         `Cannot resume iteration ${iteration} producer for eval "${evalCase.id}": ${producerArtifact.reason}`
       );
+    }
+    if (!agent) {
+      throw new Error("No eval agent was provided to resume the incomplete research run");
     }
     if (
       producerArtifact.status === "incomplete" ||
@@ -607,7 +615,8 @@ async function resumeIterationScores(
 
 async function inspectConfiguredScores(
   project: ProjectInputs,
-  directory: string
+  directory: string,
+  outputRoot: string
 ): Promise<Array<EvalScore | undefined>> {
   return Promise.all(
     project.evals.evals.map(async (evalCase, index) => {
@@ -620,9 +629,33 @@ async function inspectConfiguredScores(
       if (artifact.status === "invalid") {
         throw new Error(`Cannot resume score ${index} for eval "${evalCase.id}": ${artifact.reason}`);
       }
-      return artifact.status === "complete" ? artifact.value : undefined;
+      if (artifact.status !== "complete") {
+        return undefined;
+      }
+
+      const judgeArtifact = await inspectJudgeArtifact(
+        join(outputRoot, evalCase.id),
+        evalCase,
+        trackForEval(project.config, evalCase.eval_type)
+      );
+      if (judgeArtifact.status === "invalid" || judgeArtifact.status === "incomplete") {
+        throw new Error(`Cannot reconcile score ${index} for eval "${evalCase.id}": ${judgeArtifact.reason}`);
+      }
+      if (judgeArtifact.status === "complete" && !isDeepStrictEqual(artifact.value, judgeArtifact.value.score)) {
+        throw new Error(
+          `Cannot resume score ${index} for eval "${evalCase.id}": persisted score does not match judge transcript`
+        );
+      }
+      return artifact.value;
     })
   );
+}
+
+function requireEvalAgent(agent: EvalAgent | undefined, action: string): EvalAgent {
+  if (!agent) {
+    throw new Error(`No eval agent was provided to ${action}`);
+  }
+  return agent;
 }
 
 async function assertNoUnexpectedScores(directory: string, expectedCount: number): Promise<void> {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,11 +1,19 @@
-import { cp, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
 import { createModelCallPreview, ModelRunCostSummary, ModelRunCostTracker, persistCostSummary } from "./cost.js";
 import { loadAvailableFlueRoles, validateConfiguredFlueRoles } from "./flue-roles.js";
-import { loadProject, ProjectInputs } from "./project.js";
-import { runEval, runWithConcurrency, EvalAgent } from "./runner.js";
+import { loadProject, ProjectInputs, trackForEval } from "./project.js";
+import {
+  findUnexpectedScoreFiles,
+  inspectProducerArtifact,
+  inspectJudgeArtifact,
+  inspectResearchArtifact,
+  inspectScoreArtifact,
+  inspectSummaryArtifact
+} from "./resume.js";
+import { judgeEval, runEval, runWithConcurrency, EvalAgent } from "./runner.js";
 import { EvalScore } from "./schemas.js";
 
 export type RunEvent =
@@ -14,6 +22,7 @@ export type RunEvent =
   | { type: "baseline-imported"; scores: number; missing: string[] }
   | { type: "baseline-started"; evals: number; countsTowardIterations: false }
   | { type: "baseline-generated"; scores: number }
+  | { type: "baseline-resumed"; scores: number; remaining: number }
   | {
       type: "iteration-started";
       iteration: number;
@@ -21,6 +30,11 @@ export type RunEvent =
       candidateSkillDir: string;
     }
   | { type: "iteration-generated"; iteration: number; candidateSkillDir: string }
+  | { type: "iteration-research-resumed"; iteration: number; candidateSkillDir: string }
+  | { type: "eval-score-resumed"; iteration: number; evalId: string }
+  | { type: "eval-producer-resumed"; iteration: number; evalId: string }
+  | { type: "eval-judge-resumed"; iteration: number; evalId: string }
+  | { type: "iteration-summary-rebuilt"; iteration: number }
   | { type: "iteration-scored"; iteration: number; scores: number; aggregate: AggregateReport }
   | { type: "baseline-target-score-reached"; normalizedScore: number; targetScore: number }
   | {
@@ -89,6 +103,7 @@ export interface OrchestrateOptions {
   withBaseline?: boolean;
   runResearch?: boolean;
   forceResearch?: boolean;
+  resume?: boolean;
   seedSkillDir?: string;
   guidanceSkillDir?: string;
   budgetUsd?: number;
@@ -115,7 +130,9 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
   const expectedEvalIds = project.evals.evals.map((evalCase) => evalCase.id);
   const baselineScores = options.withBaseline
     ? await importRequiredBaseline(project, expectedEvalIds, emit)
-    : await generateInitialBaseline(project, options.agent, emit, costTracker);
+    : options.resume
+      ? await resumeInitialBaseline(project, options.agent, emit, costTracker)
+      : await generateInitialBaseline(project, options.agent, emit, costTracker);
 
   const aggregate = aggregateScores(project.config, baselineScores);
   emit({ type: "aggregated", aggregate });
@@ -215,34 +232,99 @@ async function generateInitialBaseline(
   });
 
   const outputRoot = join(project.root, "workspace", "baseline");
-  const baselineScores = await runWithConcurrency(project.evals.evals, project.config.max_concurrency, (evalCase) =>
-    runEval(
-      {
+  const baselineScores = await runWithConcurrency(
+    project.evals.evals,
+    project.config.max_concurrency,
+    async (evalCase, index) => {
+      const score = await runEval(
+        {
+          config: project.config,
+          projectRoot: project.root,
+          evalCase,
+          baseline: true,
+          outputRoot,
+          costTracker
+        },
+        agent
+      );
+      await persistEvalScore(outputRoot, index, score);
+      return score;
+    }
+  );
+  emit({ type: "baseline-generated", scores: baselineScores.length });
+  return baselineScores;
+}
+
+async function resumeInitialBaseline(
+  project: ProjectInputs,
+  agent: EvalAgent | undefined,
+  emit: (event: RunEvent) => void,
+  costTracker: ModelRunCostTracker
+): Promise<EvalScore[]> {
+  const baselineDir = join(project.root, "workspace", "baseline");
+  await assertNoUnexpectedScores(baselineDir, project.evals.evals.length);
+  const existing = await inspectConfiguredScores(project, baselineDir);
+  const remaining = existing.filter((score) => score === undefined).length;
+  emit({
+    type: "baseline-resumed",
+    scores: existing.length - remaining,
+    remaining
+  });
+
+  if (remaining > 0 && !agent) {
+    throw new Error("No eval agent was provided to resume the incomplete baseline run");
+  }
+
+  const outputRoot = baselineDir;
+  const scores = await runWithConcurrency(
+    project.evals.evals,
+    project.config.max_concurrency,
+    async (evalCase, index) => {
+      const reused = existing[index];
+      if (reused) {
+        return reused;
+      }
+      const request = {
         config: project.config,
         projectRoot: project.root,
         evalCase,
         baseline: true,
         outputRoot,
         costTracker
-      },
-      agent
-    )
-  );
-  await persistBaselineScores(project.root, baselineScores);
-  emit({ type: "baseline-generated", scores: baselineScores.length });
-  return baselineScores;
-}
+      };
+      const evalOutputDir = join(outputRoot, evalCase.id);
+      const track = trackForEval(project.config, evalCase.eval_type);
+      const judgeArtifact = await inspectJudgeArtifact(evalOutputDir, evalCase, track);
+      if (judgeArtifact.status === "invalid" || judgeArtifact.status === "incomplete") {
+        throw new Error(`Cannot resume baseline judge for eval "${evalCase.id}": ${judgeArtifact.reason}`);
+      }
+      if (judgeArtifact.status === "complete") {
+        await persistEvalScore(outputRoot, index, judgeArtifact.value.score);
+        return judgeArtifact.value.score;
+      }
 
-async function persistBaselineScores(projectRoot: string, scores: EvalScore[]): Promise<void> {
-  const baselineDir = join(projectRoot, "workspace", "baseline");
-  await mkdir(baselineDir, { recursive: true });
-  await Promise.all(
-    scores.map((score, index) =>
-      writeFile(join(baselineDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
-        flag: "wx"
-      })
-    )
+      const producerArtifact = await inspectProducerArtifact(evalOutputDir, evalCase.id);
+      if (producerArtifact.status === "invalid") {
+        throw new Error(`Cannot resume baseline producer for eval "${evalCase.id}": ${producerArtifact.reason}`);
+      }
+      if (
+        producerArtifact.status === "incomplete" ||
+        (producerArtifact.status === "absent" && (await pathExists(evalOutputDir)))
+      ) {
+        await archiveIncompleteArtifact(project.root, evalOutputDir, `baseline-${evalCase.id}-producer`);
+      }
+      const score =
+        producerArtifact.status === "complete"
+          ? await judgeEval(request, agent as EvalAgent, producerArtifact.value.outputFiles)
+          : await runEval(request, agent as EvalAgent);
+      await persistEvalScore(outputRoot, index, score);
+      return score;
+    }
   );
+  if (remaining > 0) {
+    emit({ type: "baseline-generated", scores: scores.length });
+  }
+  return scores;
 }
 
 async function runResearchIterations(
@@ -265,7 +347,7 @@ async function runResearchIterations(
   const guidanceSkillDir = await resolveGuidanceSkillDir(project, options.guidanceSkillDir, seedSkillDir);
   const guidanceLedgerPath = guidanceSkillDir ? join(project.root, "workspace", "guidance-ledger.json") : undefined;
   const iterations: IterationResult[] = [];
-  let previousSkillDir = await resolveInitialResearchSkillDir(project, seedSkillDir);
+  let previousSkillDir = resolveInitialResearchSkillDir(project, seedSkillDir);
   let previousScores = baselineScores;
   let previousAggregate = baselineAggregate;
   let bestIteration: IterationResult | undefined;
@@ -277,47 +359,80 @@ async function runResearchIterations(
     await mkdir(iterationDir, { recursive: true });
     emit({ type: "iteration-started", iteration, previousSkillDir, candidateSkillDir });
 
-    await options.researcher.improve({
-      project,
-      iteration,
-      previousSkillDir,
-      candidateSkillDir,
-      guidanceSkillDir,
-      guidanceLedgerPath,
-      baselineScores,
-      previousScores,
-      previousAggregate,
-      costTracker
-    });
-    await assertExists(
-      candidateSkillDir,
-      `Researcher did not create candidate skill directory for iteration ${iteration}`
-    );
-    emit({ type: "iteration-generated", iteration, candidateSkillDir });
+    if (options.resume) {
+      const researchArtifact = await inspectResearchArtifact(candidateSkillDir, iteration);
+      if (researchArtifact.status === "invalid") {
+        throw new Error(`Cannot resume iteration ${iteration} research: ${researchArtifact.reason}`);
+      }
+      if (researchArtifact.status === "complete") {
+        emit({ type: "iteration-research-resumed", iteration, candidateSkillDir });
+      } else {
+        await assertNoIterationEvaluationArtifacts(iterationDir, iteration);
+        await assertNoFutureIterationArtifacts(project.root, iteration);
+        if (researchArtifact.status === "incomplete") {
+          await archiveIncompleteArtifact(project.root, candidateSkillDir, `iteration-${iteration}-research`);
+        }
+        if (iteration === 1) {
+          previousSkillDir = await prepareInitialResearchSkillDir(project, seedSkillDir);
+        }
+        await improveSkill(
+          options.researcher,
+          project,
+          iteration,
+          previousSkillDir,
+          candidateSkillDir,
+          guidanceSkillDir,
+          guidanceLedgerPath,
+          baselineScores,
+          previousScores,
+          previousAggregate,
+          costTracker
+        );
+        emit({ type: "iteration-generated", iteration, candidateSkillDir });
+      }
+    } else {
+      if (iteration === 1) {
+        previousSkillDir = await prepareInitialResearchSkillDir(project, seedSkillDir);
+      }
+      await improveSkill(
+        options.researcher,
+        project,
+        iteration,
+        previousSkillDir,
+        candidateSkillDir,
+        guidanceSkillDir,
+        guidanceLedgerPath,
+        baselineScores,
+        previousScores,
+        previousAggregate,
+        costTracker
+      );
+      emit({ type: "iteration-generated", iteration, candidateSkillDir });
+    }
 
     if (costTracker.isBudgetReached()) {
       emitBudgetReached(emit, costTracker, iterations.length);
       break;
     }
 
-    const scores = await runWithConcurrency(project.evals.evals, project.config.max_concurrency, (evalCase) =>
-      runEval(
-        {
-          config: project.config,
-          projectRoot: project.root,
-          evalCase,
-          baseline: false,
-          targetSkillDir: candidateSkillDir,
-          outputRoot: join(iterationDir, "outputs"),
-          costTracker
-        },
-        agent
-      )
-    );
-    await persistIterationScores(iterationDir, scores);
+    const scores = options.resume
+      ? await resumeIterationScores(project, iteration, iterationDir, candidateSkillDir, agent, emit, costTracker)
+      : await runFreshIterationScores(project, iterationDir, candidateSkillDir, agent, costTracker);
 
     const aggregate = aggregateScores(project.config, scores);
-    await persistAggregate(join(iterationDir, "summary.json"), aggregate);
+    const summaryPath = join(iterationDir, "summary.json");
+    if (options.resume) {
+      const summary = await inspectSummaryArtifact(summaryPath, aggregate);
+      if (summary.status === "invalid") {
+        throw new Error(`Cannot resume iteration ${iteration} summary: ${summary.reason}`);
+      }
+      if (summary.status === "absent") {
+        await persistAggregate(summaryPath, aggregate);
+        emit({ type: "iteration-summary-rebuilt", iteration });
+      }
+    } else {
+      await persistAggregate(summaryPath, aggregate);
+    }
     const result = { iteration, skillDir: candidateSkillDir, scores, aggregate };
     iterations.push(result);
     emit({ type: "iteration-scored", iteration, scores: scores.length, aggregate });
@@ -366,6 +481,225 @@ async function runResearchIterations(
   }
 
   return { iterations, bestIteration };
+}
+
+async function improveSkill(
+  researcher: SkillResearcher,
+  project: ProjectInputs,
+  iteration: number,
+  previousSkillDir: string,
+  candidateSkillDir: string,
+  guidanceSkillDir: string | undefined,
+  guidanceLedgerPath: string | undefined,
+  baselineScores: EvalScore[],
+  previousScores: EvalScore[],
+  previousAggregate: AggregateReport,
+  costTracker: ModelRunCostTracker
+): Promise<void> {
+  await researcher.improve({
+    project,
+    iteration,
+    previousSkillDir,
+    candidateSkillDir,
+    guidanceSkillDir,
+    guidanceLedgerPath,
+    baselineScores,
+    previousScores,
+    previousAggregate,
+    costTracker
+  });
+  await assertExists(
+    candidateSkillDir,
+    `Researcher did not create candidate skill directory for iteration ${iteration}`
+  );
+}
+
+async function runFreshIterationScores(
+  project: ProjectInputs,
+  iterationDir: string,
+  candidateSkillDir: string,
+  agent: EvalAgent,
+  costTracker: ModelRunCostTracker
+): Promise<EvalScore[]> {
+  return runWithConcurrency(project.evals.evals, project.config.max_concurrency, async (evalCase, index) => {
+    const score = await runEval(
+      {
+        config: project.config,
+        projectRoot: project.root,
+        evalCase,
+        baseline: false,
+        targetSkillDir: candidateSkillDir,
+        outputRoot: join(iterationDir, "outputs"),
+        costTracker
+      },
+      agent
+    );
+    await persistEvalScore(iterationDir, index, score);
+    return score;
+  });
+}
+
+async function resumeIterationScores(
+  project: ProjectInputs,
+  iteration: number,
+  iterationDir: string,
+  candidateSkillDir: string,
+  agent: EvalAgent,
+  emit: (event: RunEvent) => void,
+  costTracker: ModelRunCostTracker
+): Promise<EvalScore[]> {
+  await assertNoUnexpectedScores(iterationDir, project.evals.evals.length);
+  const existing = await inspectConfiguredScores(project, iterationDir);
+
+  return runWithConcurrency(project.evals.evals, project.config.max_concurrency, async (evalCase, index) => {
+    const reused = existing[index];
+    if (reused) {
+      emit({ type: "eval-score-resumed", iteration, evalId: evalCase.id });
+      return reused;
+    }
+
+    const outputRoot = join(iterationDir, "outputs");
+    const evalOutputDir = join(outputRoot, evalCase.id);
+    const track = trackForEval(project.config, evalCase.eval_type);
+    const judgeArtifact = await inspectJudgeArtifact(evalOutputDir, evalCase, track);
+    if (judgeArtifact.status === "invalid" || judgeArtifact.status === "incomplete") {
+      throw new Error(`Cannot resume iteration ${iteration} judge for eval "${evalCase.id}": ${judgeArtifact.reason}`);
+    }
+    if (judgeArtifact.status === "complete") {
+      emit({ type: "eval-judge-resumed", iteration, evalId: evalCase.id });
+      await persistEvalScore(iterationDir, index, judgeArtifact.value.score);
+      return judgeArtifact.value.score;
+    }
+
+    const producerArtifact = await inspectProducerArtifact(evalOutputDir, evalCase.id);
+    if (producerArtifact.status === "invalid") {
+      throw new Error(
+        `Cannot resume iteration ${iteration} producer for eval "${evalCase.id}": ${producerArtifact.reason}`
+      );
+    }
+    if (
+      producerArtifact.status === "incomplete" ||
+      (producerArtifact.status === "absent" && (await pathExists(evalOutputDir)))
+    ) {
+      await archiveIncompleteArtifact(project.root, evalOutputDir, `iteration-${iteration}-${evalCase.id}-producer`);
+    }
+
+    const request = {
+      config: project.config,
+      projectRoot: project.root,
+      evalCase,
+      baseline: false,
+      targetSkillDir: candidateSkillDir,
+      outputRoot,
+      costTracker
+    };
+    const score =
+      producerArtifact.status === "complete"
+        ? await judgeEval(request, agent, producerArtifact.value.outputFiles)
+        : await runEval(request, agent);
+    if (producerArtifact.status === "complete") {
+      emit({ type: "eval-producer-resumed", iteration, evalId: evalCase.id });
+    }
+    await persistEvalScore(iterationDir, index, score);
+    return score;
+  });
+}
+
+async function inspectConfiguredScores(
+  project: ProjectInputs,
+  directory: string
+): Promise<Array<EvalScore | undefined>> {
+  return Promise.all(
+    project.evals.evals.map(async (evalCase, index) => {
+      const artifact = await inspectScoreArtifact({
+        directory,
+        index,
+        evalCase,
+        track: trackForEval(project.config, evalCase.eval_type)
+      });
+      if (artifact.status === "invalid") {
+        throw new Error(`Cannot resume score ${index} for eval "${evalCase.id}": ${artifact.reason}`);
+      }
+      return artifact.status === "complete" ? artifact.value : undefined;
+    })
+  );
+}
+
+async function assertNoUnexpectedScores(directory: string, expectedCount: number): Promise<void> {
+  const unexpected = await findUnexpectedScoreFiles(directory, expectedCount);
+  if (unexpected.length > 0) {
+    throw new Error(
+      `Cannot resume because unexpected positional score artifacts were found in ${directory}: ${unexpected.join(", ")}`
+    );
+  }
+}
+
+async function assertNoIterationEvaluationArtifacts(iterationDir: string, iteration: number): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(iterationDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  const conflicts = entries.filter(
+    (entry) => /^scores-\d+\.json$/.test(entry) || entry === "summary.json" || entry === "outputs"
+  );
+  if (conflicts.length > 0) {
+    throw new Error(
+      `Cannot resume iteration ${iteration}: evaluation artifacts exist without completed research: ${conflicts.join(", ")}`
+    );
+  }
+}
+
+async function assertNoFutureIterationArtifacts(projectRoot: string, currentIteration: number): Promise<void> {
+  const iterationsDir = join(projectRoot, "workspace", "iterations");
+  let entries: string[];
+  try {
+    entries = await readdir(iterationsDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  const future = entries
+    .filter((entry) => /^\d+$/.test(entry) && Number(entry) > currentIteration)
+    .sort((left, right) => Number(left) - Number(right));
+  if (future.length > 0) {
+    throw new Error(
+      `Cannot resume iteration ${currentIteration}: later iteration artifacts already exist: ${future.join(", ")}`
+    );
+  }
+}
+
+async function archiveIncompleteArtifact(projectRoot: string, source: string, label: string): Promise<void> {
+  if (!(await pathExists(source))) {
+    return;
+  }
+  const backupRoot = join(projectRoot, "workspace", "resume-backups");
+  await mkdir(backupRoot, { recursive: true });
+  let destination = join(backupRoot, label);
+  let suffix = 2;
+  while (await pathExists(destination)) {
+    destination = join(backupRoot, `${label}-${suffix++}`);
+  }
+  await rename(source, destination);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
 }
 
 function createEventSink(events: RunEvent[], onEvent: OrchestrateOptions["onEvent"]): (event: RunEvent) => void {
@@ -457,12 +791,21 @@ function resolveConfiguredGuidanceSkillDir(
   return project.config.research_start === "empty" ? seedSkillDir : undefined;
 }
 
-async function resolveInitialResearchSkillDir(project: ProjectInputs, seedSkillDir: string): Promise<string> {
+function resolveInitialResearchSkillDir(project: ProjectInputs, seedSkillDir: string): string {
   if ((project.config.research_start ?? "seed") !== "empty") {
     return seedSkillDir;
   }
 
-  const emptySkillDir = resolve(project.root, "workspace", "empty-skill");
+  return resolve(project.root, "workspace", "empty-skill");
+}
+
+async function prepareInitialResearchSkillDir(project: ProjectInputs, seedSkillDir: string): Promise<string> {
+  const initialSkillDir = resolveInitialResearchSkillDir(project, seedSkillDir);
+  if ((project.config.research_start ?? "seed") !== "empty") {
+    return initialSkillDir;
+  }
+
+  const emptySkillDir = initialSkillDir;
   await rm(emptySkillDir, { recursive: true, force: true });
   await mkdir(emptySkillDir, { recursive: true });
   return emptySkillDir;
@@ -480,14 +823,11 @@ async function assertExists(path: string, message: string): Promise<void> {
   }
 }
 
-async function persistIterationScores(iterationDir: string, scores: EvalScore[]): Promise<void> {
-  await Promise.all(
-    scores.map((score, index) =>
-      writeFile(join(iterationDir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
-        flag: "wx"
-      })
-    )
-  );
+async function persistEvalScore(dir: string, index: number, score: EvalScore): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, `scores-${index}.json`), `${JSON.stringify(score, null, 2)}\n`, {
+    flag: "wx"
+  });
 }
 
 async function persistAggregate(path: string, aggregate: AggregateReport): Promise<void> {

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,0 +1,457 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { AggregateReport } from "./aggregate.js";
+import {
+  EvalCase,
+  EvalScore,
+  EvalScoreSchema,
+  ModelProduceResponseSchema,
+  OutputFile,
+  SkillResearchPatchSchema,
+  Track,
+  parseWithSchema
+} from "./schemas.js";
+
+export type ArtifactInspection<T> =
+  | { status: "absent" }
+  | { status: "incomplete"; reason: string }
+  | { status: "complete"; value: T }
+  | { status: "invalid"; reason: string };
+
+export interface ScoreArtifactOptions {
+  directory: string;
+  index: number;
+  evalCase: EvalCase;
+  track: Track;
+}
+
+export interface ResearchArtifact {
+  candidateSkillDir: string;
+  markerPath: string;
+}
+
+export interface ProducerArtifact {
+  transcriptPath: string;
+  outputFiles: OutputFile[];
+}
+
+export interface JudgeArtifact {
+  transcriptPath: string;
+  score: EvalScore;
+}
+
+const RESEARCH_MARKERS = [
+  ".autoresearch-flue-transcript.json",
+  ".autoresearch-transcript.json",
+  ".autoresearch-iteration.json"
+] as const;
+
+const PRODUCER_TRANSCRIPTS = ["producer-flue-transcript.json", "producer-transcript.json"] as const;
+const JUDGE_TRANSCRIPTS = ["judge-flue-transcript.json", "judge-transcript.json"] as const;
+
+export async function inspectScoreArtifact(options: ScoreArtifactOptions): Promise<ArtifactInspection<EvalScore>> {
+  const path = join(options.directory, `scores-${options.index}.json`);
+  const contents = await readOptionalFile(path);
+  if (contents.status !== "complete") {
+    return contents;
+  }
+
+  try {
+    const score = parseWithSchema(EvalScoreSchema, JSON.parse(contents.value), path);
+    validateScoreIdentity(score, options.evalCase, options.track, path);
+    return { status: "complete", value: score };
+  } catch (error) {
+    return invalid(path, error);
+  }
+}
+
+export async function findUnexpectedScoreFiles(directory: string, expectedCount: number): Promise<string[]> {
+  let files: string[];
+  try {
+    files = await readdir(directory);
+  } catch (error) {
+    if (isMissing(error)) {
+      return [];
+    }
+    throw error;
+  }
+
+  return files
+    .filter((file) => {
+      const match = /^scores-(\d+)\.json$/.exec(file);
+      return match !== null && Number(match[1]) >= expectedCount;
+    })
+    .sort((left, right) => scoreIndex(left) - scoreIndex(right));
+}
+
+export async function inspectResearchArtifact(
+  candidateSkillDir: string,
+  iteration: number
+): Promise<ArtifactInspection<ResearchArtifact>> {
+  const candidateKind = await pathKind(candidateSkillDir);
+  const markers = await existingPaths(RESEARCH_MARKERS.map((marker) => join(candidateSkillDir, marker)));
+
+  if (candidateKind === "absent" && markers.length === 0) {
+    return { status: "absent" };
+  }
+  if (candidateKind !== "directory") {
+    return {
+      status: "invalid",
+      reason: `Candidate skill path is ${candidateKind}, expected a directory: ${candidateSkillDir}`
+    };
+  }
+  if (markers.length === 0) {
+    return {
+      status: "incomplete",
+      reason: `Candidate skill directory exists without a research completion marker: ${candidateSkillDir}`
+    };
+  }
+  if (markers.length > 1) {
+    return {
+      status: "invalid",
+      reason: `Candidate skill has multiple research completion markers: ${markers.join(", ")}`
+    };
+  }
+
+  const markerPath = markers[0];
+  const contents = await readOptionalFile(markerPath);
+  if (contents.status === "invalid" || contents.status === "incomplete") {
+    return contents;
+  }
+  if (contents.status !== "complete") {
+    return {
+      status: "invalid",
+      reason: `Research completion marker disappeared while inspecting it: ${markerPath}`
+    };
+  }
+
+  try {
+    const marker = JSON.parse(contents.value) as unknown;
+    validateResearchMarker(marker, markerPath, iteration);
+    if (!(await containsSkillFile(candidateSkillDir))) {
+      return {
+        status: "incomplete",
+        reason: `Candidate skill has a research completion marker but no SKILL.md: ${candidateSkillDir}`
+      };
+    }
+    return {
+      status: "complete",
+      value: { candidateSkillDir, markerPath }
+    };
+  } catch (error) {
+    return invalid(markerPath, error);
+  }
+}
+
+export async function inspectProducerArtifact(
+  evalOutputDir: string,
+  expectedEvalId: string
+): Promise<ArtifactInspection<ProducerArtifact>> {
+  const transcripts = await existingPaths(PRODUCER_TRANSCRIPTS.map((transcript) => join(evalOutputDir, transcript)));
+  if (transcripts.length === 0) {
+    return { status: "absent" };
+  }
+  if (transcripts.length > 1) {
+    return {
+      status: "invalid",
+      reason: `Eval output has multiple producer transcripts: ${transcripts.join(", ")}`
+    };
+  }
+
+  const transcriptPath = transcripts[0];
+  const contents = await readOptionalFile(transcriptPath);
+  if (contents.status === "invalid" || contents.status === "incomplete") {
+    return contents;
+  }
+  if (contents.status !== "complete") {
+    return {
+      status: "invalid",
+      reason: `Producer transcript disappeared while inspecting it: ${transcriptPath}`
+    };
+  }
+
+  try {
+    const outputFiles = parseProducerTranscript(transcriptPath, contents.value, expectedEvalId);
+    const outputValidation = await validateOutputFiles(evalOutputDir, outputFiles, transcriptPath);
+    if (outputValidation) {
+      return outputValidation;
+    }
+    return {
+      status: "complete",
+      value: { transcriptPath, outputFiles }
+    };
+  } catch (error) {
+    return invalid(transcriptPath, error);
+  }
+}
+
+export async function inspectJudgeArtifact(
+  evalOutputDir: string,
+  evalCase: EvalCase,
+  track: Track
+): Promise<ArtifactInspection<JudgeArtifact>> {
+  const transcripts = await existingPaths(JUDGE_TRANSCRIPTS.map((transcript) => join(evalOutputDir, transcript)));
+  if (transcripts.length === 0) {
+    return { status: "absent" };
+  }
+  if (transcripts.length > 1) {
+    return {
+      status: "invalid",
+      reason: `Eval output has multiple judge transcripts: ${transcripts.join(", ")}`
+    };
+  }
+
+  const transcriptPath = transcripts[0];
+  const contents = await readOptionalFile(transcriptPath);
+  if (contents.status === "invalid") {
+    return contents;
+  }
+  if (contents.status !== "complete") {
+    return {
+      status: "incomplete",
+      reason: `Judge transcript disappeared while inspecting it: ${transcriptPath}`
+    };
+  }
+
+  try {
+    const transcript = parseTranscript(contents.value, transcriptPath);
+    validateTranscriptPhase(transcript.request, `judge eval ${evalCase.id}`, transcriptPath);
+    const score = parseWithSchema(EvalScoreSchema, parseTranscriptResponse(transcript.response), transcriptPath);
+    validateScoreIdentity(score, evalCase, track, transcriptPath);
+    return { status: "complete", value: { transcriptPath, score } };
+  } catch (error) {
+    return invalid(transcriptPath, error);
+  }
+}
+
+export async function inspectSummaryArtifact(
+  summaryPath: string,
+  expected?: AggregateReport
+): Promise<ArtifactInspection<AggregateReport>> {
+  const contents = await readOptionalFile(summaryPath);
+  if (contents.status !== "complete") {
+    return contents;
+  }
+
+  try {
+    const summary = JSON.parse(contents.value) as unknown;
+    if (!isAggregateReport(summary)) {
+      throw new Error("expected an aggregate report");
+    }
+    if (expected && !isDeepStrictEqual(summary, expected)) {
+      throw new Error("does not match the aggregate recomputed from persisted scores");
+    }
+    return { status: "complete", value: summary };
+  } catch (error) {
+    return invalid(summaryPath, error);
+  }
+}
+
+function validateScoreIdentity(score: EvalScore, evalCase: EvalCase, track: Track, path: string): void {
+  if (score.eval_id !== evalCase.id) {
+    throw new Error(`${path} has eval_id "${score.eval_id}", expected "${evalCase.id}"`);
+  }
+  if (score.eval_type !== evalCase.eval_type) {
+    throw new Error(`${path} has eval_type "${score.eval_type}", expected "${evalCase.eval_type}"`);
+  }
+  if (score.track_id !== track.id) {
+    throw new Error(`${path} has track_id "${score.track_id}", expected "${track.id}"`);
+  }
+
+  const knownDimensions = new Set(evalCase.scoring_dimensions.map((dimension) => dimension.id));
+  const unknownDimensions = score.dimensions.filter((dimension) => !knownDimensions.has(dimension.id));
+  if (unknownDimensions.length > 0) {
+    throw new Error(`${path} has unknown dimensions: ${unknownDimensions.map((dimension) => dimension.id).join(", ")}`);
+  }
+}
+
+function validateResearchMarker(marker: unknown, markerPath: string, iteration: number): void {
+  if (!marker || typeof marker !== "object" || Array.isArray(marker)) {
+    throw new Error("expected a JSON object");
+  }
+
+  if (markerPath.endsWith(".autoresearch-iteration.json")) {
+    if ((marker as { iteration?: unknown }).iteration !== iteration) {
+      throw new Error(`records a different iteration; expected ${iteration}`);
+    }
+    return;
+  }
+
+  const transcript = marker as { request?: unknown; response?: unknown };
+  validateTranscriptPhase(transcript.request, `research iteration ${iteration}`, markerPath);
+  parseWithSchema(SkillResearchPatchSchema, parseTranscriptResponse(transcript.response), markerPath);
+}
+
+function parseProducerTranscript(transcriptPath: string, contents: string, expectedEvalId: string): OutputFile[] {
+  const transcript = parseTranscript(contents, transcriptPath);
+  validateTranscriptPhase(transcript.request, `producer eval ${expectedEvalId}`, transcriptPath);
+  return parseWithSchema(ModelProduceResponseSchema, parseTranscriptResponse(transcript.response), transcriptPath)
+    .output_files;
+}
+
+async function validateOutputFiles(
+  outputDir: string,
+  outputFiles: OutputFile[],
+  transcriptPath: string
+): Promise<ArtifactInspection<never> | undefined> {
+  const seen = new Set<string>();
+  for (const outputFile of outputFiles) {
+    if (isAbsolute(outputFile.path)) {
+      throw new Error(`declares an absolute output path: ${outputFile.path}`);
+    }
+
+    const destination = resolve(outputDir, outputFile.path);
+    const rel = relative(resolve(outputDir), destination);
+    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+      throw new Error(`declares an output path outside its eval directory: ${outputFile.path}`);
+    }
+    if (seen.has(destination)) {
+      throw new Error(`declares the output path more than once: ${outputFile.path}`);
+    }
+    seen.add(destination);
+
+    let actual: string;
+    try {
+      actual = await readFile(destination, "utf8");
+    } catch (error) {
+      if (isMissing(error)) {
+        return {
+          status: "incomplete",
+          reason: `Producer transcript ${transcriptPath} declares a missing output file: ${outputFile.path}`
+        };
+      }
+      throw error;
+    }
+    if (actual !== outputFile.contents) {
+      throw new Error(`does not match persisted output file contents: ${outputFile.path}`);
+    }
+  }
+
+  if (outputFiles.length === 0) {
+    throw new Error(`${transcriptPath} does not declare any output files`);
+  }
+}
+
+function parseTranscript(contents: string, transcriptPath: string): { request: unknown; response: unknown } {
+  const transcript = JSON.parse(contents) as unknown;
+  if (!transcript || typeof transcript !== "object" || Array.isArray(transcript)) {
+    throw new Error("expected a JSON object");
+  }
+  if (!("request" in transcript) || !("response" in transcript)) {
+    throw new Error(`${transcriptPath} must contain request and response fields`);
+  }
+  return transcript as { request: unknown; response: unknown };
+}
+
+function parseTranscriptResponse(response: unknown): unknown {
+  return typeof response === "string" ? JSON.parse(response) : response;
+}
+
+function validateTranscriptPhase(request: unknown, expectedPhase: string, transcriptPath: string): void {
+  if (!request || typeof request !== "object" || Array.isArray(request)) {
+    throw new Error(`${transcriptPath} is missing its request object`);
+  }
+  const phase = (request as { phase?: unknown }).phase;
+  if (phase !== expectedPhase) {
+    throw new Error(`${transcriptPath} records phase "${String(phase)}", expected "${expectedPhase}"`);
+  }
+}
+
+async function containsSkillFile(directory: string): Promise<boolean> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name === "SKILL.md") {
+      return true;
+    }
+    if (entry.isDirectory() && (await containsSkillFile(join(directory, entry.name)))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAggregateReport(value: unknown): value is AggregateReport {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const report = value as { tracks?: unknown; overall?: unknown };
+  if (!Array.isArray(report.tracks) || !isNumericAggregate(report.overall)) {
+    return false;
+  }
+  return report.tracks.every(
+    (track) =>
+      track !== null &&
+      typeof track === "object" &&
+      !Array.isArray(track) &&
+      typeof (track as { trackId?: unknown }).trackId === "string" &&
+      typeof (track as { evalType?: unknown }).evalType === "string" &&
+      typeof (track as { targetSkill?: unknown }).targetSkill === "string" &&
+      isNumericAggregate(track)
+  );
+}
+
+function isNumericAggregate(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const aggregate = value as Record<string, unknown>;
+  return (
+    typeof aggregate.score === "number" &&
+    typeof aggregate.maxScore === "number" &&
+    typeof aggregate.normalizedScore === "number" &&
+    typeof aggregate.evalCount === "number"
+  );
+}
+
+async function existingPaths(paths: string[]): Promise<string[]> {
+  const present = await Promise.all(paths.map(async (path) => ({ path, kind: await pathKind(path) })));
+  return present.filter((item) => item.kind !== "absent").map((item) => item.path);
+}
+
+async function pathKind(path: string): Promise<"absent" | "file" | "directory" | "other"> {
+  try {
+    const value = await stat(path);
+    if (value.isFile()) {
+      return "file";
+    }
+    if (value.isDirectory()) {
+      return "directory";
+    }
+    return "other";
+  } catch (error) {
+    if (isMissing(error)) {
+      return "absent";
+    }
+    throw error;
+  }
+}
+
+async function readOptionalFile(path: string): Promise<ArtifactInspection<string>> {
+  try {
+    return { status: "complete", value: await readFile(path, "utf8") };
+  } catch (error) {
+    if (isMissing(error)) {
+      return { status: "absent" };
+    }
+    if ((error as NodeJS.ErrnoException).code === "EISDIR") {
+      return { status: "invalid", reason: `Invalid resume artifact ${path}: expected a file` };
+    }
+    throw error;
+  }
+}
+
+function invalid(path: string, error: unknown): ArtifactInspection<never> {
+  return {
+    status: "invalid",
+    reason: `Invalid resume artifact ${path}: ${error instanceof Error ? error.message : String(error)}`
+  };
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function scoreIndex(file: string): number {
+  return Number(/^scores-(\d+)\.json$/.exec(file)?.[1] ?? Number.POSITIVE_INFINITY);
+}

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFile, readdir, stat } from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { isAbsolute, join, relative, resolve } from "node:path";
@@ -39,6 +40,11 @@ export interface ProducerArtifact {
 export interface JudgeArtifact {
   transcriptPath: string;
   score: EvalScore;
+}
+
+export interface ResearchSnapshotFile {
+  path: string;
+  sha256: string;
 }
 
 const RESEARCH_MARKERS = [
@@ -128,7 +134,7 @@ export async function inspectResearchArtifact(
 
   try {
     const marker = JSON.parse(contents.value) as unknown;
-    validateResearchMarker(marker, markerPath, iteration);
+    await validateResearchMarker(marker, markerPath, iteration, candidateSkillDir);
     if (!(await containsSkillFile(candidateSkillDir))) {
       return {
         status: "incomplete",
@@ -140,6 +146,12 @@ export async function inspectResearchArtifact(
       value: { candidateSkillDir, markerPath }
     };
   } catch (error) {
+    if (isMissing(error)) {
+      return {
+        status: "incomplete",
+        reason: `Research completion marker declares a missing candidate file: ${markerPath}`
+      };
+    }
     return invalid(markerPath, error);
   }
 }
@@ -264,23 +276,130 @@ function validateScoreIdentity(score: EvalScore, evalCase: EvalCase, track: Trac
   if (unknownDimensions.length > 0) {
     throw new Error(`${path} has unknown dimensions: ${unknownDimensions.map((dimension) => dimension.id).join(", ")}`);
   }
+
+  const counts = new Map<string, number>();
+  for (const dimension of score.dimensions) {
+    counts.set(dimension.id, (counts.get(dimension.id) ?? 0) + 1);
+  }
+  const duplicates = [...counts].filter(([, count]) => count > 1).map(([id]) => id);
+  if (duplicates.length > 0) {
+    throw new Error(`${path} has duplicate dimensions: ${duplicates.join(", ")}`);
+  }
+
+  const missing = evalCase.scoring_dimensions.filter((dimension) => !counts.has(dimension.id));
+  if (missing.length > 0) {
+    throw new Error(`${path} is missing dimensions: ${missing.map((dimension) => dimension.id).join(", ")}`);
+  }
+
+  const configuredById = new Map(evalCase.scoring_dimensions.map((dimension) => [dimension.id, dimension]));
+  for (const dimension of score.dimensions) {
+    const configured = configuredById.get(dimension.id);
+    if (configured && dimension.max_score !== configured.max_score) {
+      throw new Error(
+        `${path} dimension "${dimension.id}" has max_score ${dimension.max_score}, expected ${configured.max_score}`
+      );
+    }
+  }
 }
 
-function validateResearchMarker(marker: unknown, markerPath: string, iteration: number): void {
+async function validateResearchMarker(
+  marker: unknown,
+  markerPath: string,
+  iteration: number,
+  candidateSkillDir: string
+): Promise<void> {
   if (!marker || typeof marker !== "object" || Array.isArray(marker)) {
     throw new Error("expected a JSON object");
   }
 
   if (markerPath.endsWith(".autoresearch-iteration.json")) {
-    if ((marker as { iteration?: unknown }).iteration !== iteration) {
+    const snapshot = marker as { iteration?: unknown; manifest?: unknown };
+    if (snapshot.iteration !== iteration) {
       throw new Error(`records a different iteration; expected ${iteration}`);
+    }
+    const expectedManifest = parseSnapshotManifest(snapshot.manifest, markerPath, candidateSkillDir);
+    const actualManifest = await createResearchSnapshotManifest(candidateSkillDir);
+    if (!isDeepStrictEqual(actualManifest, expectedManifest)) {
+      throw new Error("snapshot manifest does not match candidate files");
     }
     return;
   }
 
   const transcript = marker as { request?: unknown; response?: unknown };
   validateTranscriptPhase(transcript.request, `research iteration ${iteration}`, markerPath);
-  parseWithSchema(SkillResearchPatchSchema, parseTranscriptResponse(transcript.response), markerPath);
+  const patch = parseWithSchema(SkillResearchPatchSchema, parseTranscriptResponse(transcript.response), markerPath);
+  const seen = new Set<string>();
+  for (const change of patch.changes) {
+    const destination = resolveContainedCandidatePath(candidateSkillDir, change.path, markerPath);
+    if (seen.has(destination)) {
+      throw new Error(`declares the research path more than once: ${change.path}`);
+    }
+    seen.add(destination);
+    const actual = await readFile(destination, "utf8");
+    if (actual !== change.contents) {
+      throw new Error(`declared research contents do not match candidate file: ${change.path}`);
+    }
+  }
+}
+
+export async function createResearchSnapshotManifest(directory: string): Promise<ResearchSnapshotFile[]> {
+  const files: ResearchSnapshotFile[] = [];
+
+  async function visit(current: string): Promise<void> {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const absolute = join(current, entry.name);
+      const path = relative(directory, absolute);
+      if (path === entry.name && RESEARCH_MARKERS.includes(entry.name as (typeof RESEARCH_MARKERS)[number])) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await visit(absolute);
+      } else if (entry.isFile()) {
+        const contents = await readFile(absolute);
+        files.push({ path, sha256: createHash("sha256").update(contents).digest("hex") });
+      } else {
+        throw new Error(`Unsupported candidate entry in snapshot: ${path}`);
+      }
+    }
+  }
+
+  await visit(directory);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function parseSnapshotManifest(value: unknown, markerPath: string, candidateSkillDir: string): ResearchSnapshotFile[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${markerPath} must contain a non-empty snapshot manifest`);
+  }
+  const seen = new Set<string>();
+  const manifest = value.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`${markerPath} has an invalid snapshot manifest entry`);
+    }
+    const { path, sha256 } = entry as { path?: unknown; sha256?: unknown };
+    if (typeof path !== "string" || path.length === 0 || typeof sha256 !== "string" || !/^[a-f0-9]{64}$/.test(sha256)) {
+      throw new Error(`${markerPath} has an invalid snapshot manifest entry`);
+    }
+    const destination = resolveContainedCandidatePath(candidateSkillDir, path, markerPath);
+    if (seen.has(destination)) {
+      throw new Error(`${markerPath} has a duplicate snapshot path: ${path}`);
+    }
+    seen.add(destination);
+    return { path, sha256 };
+  });
+  return manifest.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function resolveContainedCandidatePath(root: string, path: string, markerPath: string): string {
+  if (isAbsolute(path)) {
+    throw new Error(`${markerPath} declares an absolute candidate path: ${path}`);
+  }
+  const destination = resolve(root, path);
+  const rel = relative(resolve(root), destination);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`${markerPath} declares a candidate path outside its directory: ${path}`);
+  }
+  return destination;
 }
 
 function parseProducerTranscript(transcriptPath: string, contents: string, expectedEvalId: string): OutputFile[] {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -3,7 +3,7 @@ import { ModelRunCostTracker } from "./cost.js";
 import { resolveModel } from "./model.js";
 import { trackForEval } from "./project.js";
 import { createEvalSandbox, EvalSandbox } from "./sandbox.js";
-import { EvalCase, EvalScore, ModelConfig, ProjectConfig, RoleModels, Track } from "./schemas.js";
+import { EvalCase, EvalScore, ModelConfig, OutputFile, ProjectConfig, RoleModels, Track } from "./schemas.js";
 
 export interface EvalRunRequest {
   config: ProjectConfig;
@@ -33,9 +33,28 @@ export interface EvalAgentRequest {
 
 export interface EvalAgent {
   run(request: EvalAgentRequest): Promise<EvalScore>;
+  judge?(request: EvalAgentRequest, outputFiles: OutputFile[]): Promise<EvalScore>;
 }
 
 export async function runEval(request: EvalRunRequest, agent: EvalAgent): Promise<EvalScore> {
+  return agent.run(createEvalAgentRequest(request));
+}
+
+export async function judgeEval(
+  request: EvalRunRequest,
+  agent: EvalAgent,
+  outputFiles: OutputFile[]
+): Promise<EvalScore> {
+  if (!agent.judge) {
+    throw new Error(
+      `Eval agent cannot resume the judge phase for "${request.evalCase.id}". ` +
+        "Use a model-backed agent that supports judge-only resume."
+    );
+  }
+  return agent.judge(createEvalAgentRequest(request), outputFiles);
+}
+
+function createEvalAgentRequest(request: EvalRunRequest): EvalAgentRequest {
   const track = trackForEval(request.config, request.evalCase.eval_type);
   const model = resolveModel(request.config, request.model);
   const role = track.role;
@@ -48,7 +67,7 @@ export async function runEval(request: EvalRunRequest, agent: EvalAgent): Promis
     skillDir: request.baseline ? undefined : request.targetSkillDir
   });
 
-  return agent.run({
+  return {
     evalCase: request.evalCase,
     track,
     role,
@@ -61,7 +80,7 @@ export async function runEval(request: EvalRunRequest, agent: EvalAgent): Promis
     models: request.config.models,
     costTracker: request.costTracker,
     sandbox
-  });
+  };
 }
 
 export async function runWithConcurrency<TInput, TOutput>(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -91,16 +91,28 @@ export async function runWithConcurrency<TInput, TOutput>(
   const results: TOutput[] = [];
   results.length = inputs.length;
   let cursor = 0;
+  let firstFailure: { error: unknown } | undefined;
 
   async function runNext(): Promise<void> {
+    if (firstFailure) {
+      return;
+    }
     const index = cursor++;
     if (index >= inputs.length) {
       return;
     }
-    results[index] = await worker(inputs[index], index);
+    try {
+      results[index] = await worker(inputs[index], index);
+    } catch (error) {
+      firstFailure ??= { error };
+      return;
+    }
     await runNext();
   }
 
   await Promise.all(Array.from({ length: Math.min(limit, inputs.length) }, () => runNext()));
+  if (firstFailure) {
+    throw firstFailure.error;
+  }
   return results;
 }

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -31,6 +31,8 @@ test("parseCliArgs validates currently required adapters", () => {
     resume: true,
     runResearch: true
   });
+  expect(parseCliArgs(["--resume"])).toMatchObject({ resume: true });
+  expect(parseCliArgs(["--resume", "--research"])).toMatchObject({ resume: true, runResearch: true });
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
     /Research iterations require --score-dir or --model-client/

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -27,6 +27,10 @@ test("parseCliArgs validates currently required adapters", () => {
     forceResearch: true,
     runResearch: true
   });
+  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--resume"])).toMatchObject({
+    resume: true,
+    runResearch: true
+  });
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
     /Research iterations require --score-dir or --model-client/

--- a/tests/flue-harness.test.ts
+++ b/tests/flue-harness.test.ts
@@ -1,4 +1,4 @@
-import type { FlueSession } from "@flue/runtime/client";
+import type { FlueSession } from "@flue/runtime";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { FlueEvalAgent, runFlueAutoresearch } from "../src/flue-harness.js";

--- a/tests/resume-orchestrator.test.ts
+++ b/tests/resume-orchestrator.test.ts
@@ -1,0 +1,454 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ModelClient, ModelCompletion, ModelEvalAgent, ModelRequest } from "../src/model-agent.js";
+import { copySkillSnapshot, orchestrateBaseline, SkillResearcher } from "../src/orchestrator.js";
+import { EvalAgent } from "../src/runner.js";
+import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } from "./helpers.js";
+
+class QueueModelClient implements ModelClient {
+  readonly requests: ModelRequest[] = [];
+
+  constructor(private readonly responses: Array<ModelCompletion | Error>) {}
+
+  async complete(request: ModelRequest): Promise<ModelCompletion> {
+    this.requests.push(request);
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error("No queued model response");
+    }
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  }
+}
+
+async function writeScore(root: string, directory: string, index: number, value: ReturnType<typeof score>) {
+  await mkdir(join(root, directory), { recursive: true });
+  await writeFile(join(root, directory, `scores-${index}.json`), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeSeed(root: string): Promise<string> {
+  const seedSkillDir = join(root, "seed-skill");
+  await mkdir(seedSkillDir, { recursive: true });
+  await writeFile(join(seedSkillDir, "SKILL.md"), "# Seed\n");
+  return seedSkillDir;
+}
+
+async function writeCompletedResearch(root: string, iteration = 1): Promise<string> {
+  const candidateSkillDir = join(root, "workspace", "iterations", String(iteration), "skill");
+  await mkdir(candidateSkillDir, { recursive: true });
+  await writeFile(join(candidateSkillDir, "SKILL.md"), `# Candidate ${iteration}\n`);
+  await writeFile(
+    join(candidateSkillDir, ".autoresearch-transcript.json"),
+    JSON.stringify({
+      request: { phase: `research iteration ${iteration}` },
+      response: JSON.stringify({ summary: "complete", changes: [{ path: "SKILL.md", contents: "# Candidate\n" }] })
+    })
+  );
+  return candidateSkillDir;
+}
+
+const shouldNotResearch: SkillResearcher = {
+  async improve() {
+    throw new Error("completed research must not be rerun");
+  }
+};
+
+test("resume reuses existing baseline scores and generates only missing eval scores", async () => {
+  const root = await tempProject();
+  const evals = {
+    evals: [syntheticEvals.evals[0], { ...syntheticEvals.evals[0], id: "notes-002", title: "Summarise another change" }]
+  };
+  await writeFixture(root, syntheticConfig, evals);
+  const first = score("notes-001", "summarise-changelog", "summarise", 0.4);
+  await writeScore(root, join("workspace", "baseline"), 0, first);
+
+  const calls: string[] = [];
+  const agent: EvalAgent = {
+    async run(request) {
+      calls.push(request.evalCase.id);
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.7);
+    }
+  };
+
+  const result = await orchestrateBaseline({ projectRoot: root, resume: true, agent });
+
+  expect(calls).toEqual(["notes-002"]);
+  expect(result.baselineScores.map((item) => item.eval_id)).toEqual(["notes-001", "notes-002"]);
+  expect(result.events).toContainEqual({ type: "baseline-resumed", scores: 1, remaining: 1 });
+  await expect(readFile(join(root, "workspace", "baseline", "scores-0.json"), "utf8")).resolves.toContain(
+    '"total_score": 0.4'
+  );
+  await expect(readFile(join(root, "workspace", "baseline", "scores-1.json"), "utf8")).resolves.toContain(
+    '"eval_id": "notes-002"'
+  );
+});
+
+test("baseline scores survive another concurrent eval failure and are reused on resume", async () => {
+  const root = await tempProject();
+  const evals = {
+    evals: [syntheticEvals.evals[0], { ...syntheticEvals.evals[0], id: "notes-002", title: "Summarise another change" }]
+  };
+  await writeFixture(root, { ...syntheticConfig, max_concurrency: 2 }, evals);
+
+  const firstAgent: EvalAgent = {
+    async run(request) {
+      if (request.evalCase.id === "notes-002") {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        throw new Error("second eval interrupted");
+      }
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.6);
+    }
+  };
+
+  await expect(orchestrateBaseline({ projectRoot: root, agent: firstAgent })).rejects.toThrow(
+    "second eval interrupted"
+  );
+  await expect(readFile(join(root, "workspace", "baseline", "scores-0.json"), "utf8")).resolves.toContain(
+    '"eval_id": "notes-001"'
+  );
+
+  const resumedCalls: string[] = [];
+  const resumedAgent: EvalAgent = {
+    async run(request) {
+      resumedCalls.push(request.evalCase.id);
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.7);
+    }
+  };
+  const result = await orchestrateBaseline({ projectRoot: root, resume: true, agent: resumedAgent });
+
+  expect(resumedCalls).toEqual(["notes-002"]);
+  expect(result.baselineScores.map((item) => item.total_score)).toEqual([0.6, 0.7]);
+});
+
+test("resume reuses completed research and scores, then rebuilds a missing iteration summary", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  const candidateSkillDir = await writeCompletedResearch(root);
+  await writeScore(
+    root,
+    join("workspace", "iterations", "1"),
+    0,
+    score("notes-001", "summarise-changelog", "summarise", 0.9)
+  );
+
+  const agent: EvalAgent = {
+    async run() {
+      throw new Error("completed score must not be rerun");
+    }
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher: shouldNotResearch,
+    agent
+  });
+
+  expect(result.completedIterations).toBe(1);
+  expect(result.bestIteration?.skillDir).toBe(candidateSkillDir);
+  expect(result.aggregate.overall.normalizedScore).toBe(0.9);
+  expect(result.events).toContainEqual({
+    type: "iteration-research-resumed",
+    iteration: 1,
+    candidateSkillDir
+  });
+  expect(result.events).toContainEqual({ type: "eval-score-resumed", iteration: 1, evalId: "notes-001" });
+  expect(result.events).toContainEqual({ type: "iteration-summary-rebuilt", iteration: 1 });
+  await expect(readFile(join(root, "workspace", "iterations", "1", "summary.json"), "utf8")).resolves.toContain(
+    '"normalizedScore": 0.9'
+  );
+});
+
+test("resume runs only a missing judge from validated producer output", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  await writeCompletedResearch(root);
+  const outputDir = join(root, "workspace", "iterations", "1", "outputs", "notes-001");
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(join(outputDir, "RESULT.md"), "Already produced\n");
+  await writeFile(
+    join(outputDir, "producer-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "producer eval notes-001" },
+      response: { output_files: [{ path: "RESULT.md", contents: "Already produced\n" }] }
+    })
+  );
+
+  let runCalls = 0;
+  let judgeCalls = 0;
+  const agent: EvalAgent = {
+    async run() {
+      runCalls++;
+      throw new Error("producer must not be rerun");
+    },
+    async judge(request, outputFiles) {
+      judgeCalls++;
+      expect(outputFiles).toEqual([{ path: "RESULT.md", contents: "Already produced\n" }]);
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9);
+    }
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher: shouldNotResearch,
+    agent
+  });
+
+  expect(runCalls).toBe(0);
+  expect(judgeCalls).toBe(1);
+  expect(result.events).toContainEqual({ type: "eval-producer-resumed", iteration: 1, evalId: "notes-001" });
+  await expect(readFile(join(outputDir, "RESULT.md"), "utf8")).resolves.toBe("Already produced\n");
+  await expect(readFile(join(root, "workspace", "iterations", "1", "scores-0.json"), "utf8")).resolves.toContain(
+    '"total_score": 0.9'
+  );
+});
+
+test("resume rebuilds a missing score from a completed judge transcript", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  await writeCompletedResearch(root);
+  const outputDir = join(root, "workspace", "iterations", "1", "outputs", "notes-001");
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    join(outputDir, "judge-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "judge eval notes-001" },
+      response: score("notes-001", "summarise-changelog", "summarise", 0.9)
+    })
+  );
+
+  const agent: EvalAgent = {
+    async run() {
+      throw new Error("producer must not run");
+    },
+    async judge() {
+      throw new Error("judge must not run");
+    }
+  };
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher: shouldNotResearch,
+    agent
+  });
+
+  expect(result.events).toContainEqual({ type: "eval-judge-resumed", iteration: 1, evalId: "notes-001" });
+  await expect(readFile(join(root, "workspace", "iterations", "1", "scores-0.json"), "utf8")).resolves.toContain(
+    '"total_score": 0.9'
+  );
+});
+
+test("resume archives incomplete research before rerunning the researcher", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  const partialSkillDir = join(root, "workspace", "iterations", "1", "skill");
+  await mkdir(partialSkillDir, { recursive: true });
+  await writeFile(join(partialSkillDir, "PARTIAL.md"), "interrupted\n");
+
+  let researchCalls = 0;
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      researchCalls++;
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+      await writeFile(
+        join(request.candidateSkillDir, ".autoresearch-iteration.json"),
+        JSON.stringify({ iteration: 1 })
+      );
+    }
+  };
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9);
+    }
+  };
+
+  await orchestrateBaseline({ projectRoot: root, resume: true, runResearch: true, seedSkillDir, researcher, agent });
+
+  expect(researchCalls).toBe(1);
+  await expect(
+    readFile(join(root, "workspace", "resume-backups", "iteration-1-research", "PARTIAL.md"), "utf8")
+  ).resolves.toBe("interrupted\n");
+  await expect(readFile(join(partialSkillDir, "SKILL.md"), "utf8")).resolves.toBe("# Seed\n");
+});
+
+test("resume archives incomplete producer output before rerunning producer and judge", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  await writeCompletedResearch(root);
+  const outputDir = join(root, "workspace", "iterations", "1", "outputs", "notes-001");
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    join(outputDir, "producer-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "producer eval notes-001" },
+      response: { output_files: [{ path: "RESULT.md", contents: "missing\n" }] }
+    })
+  );
+
+  let runCalls = 0;
+  const agent: EvalAgent = {
+    async run(request) {
+      runCalls++;
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9);
+    }
+  };
+  await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher: shouldNotResearch,
+    agent
+  });
+
+  expect(runCalls).toBe(1);
+  await expect(
+    stat(join(root, "workspace", "resume-backups", "iteration-1-notes-001-producer", "producer-flue-transcript.json"))
+  ).resolves.toBeTruthy();
+});
+
+test("resume rejects evaluation artifacts that have no completed candidate research", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  await writeScore(
+    root,
+    join("workspace", "iterations", "1"),
+    0,
+    score("notes-001", "summarise-changelog", "summarise", 0.9)
+  );
+
+  await expect(
+    orchestrateBaseline({
+      projectRoot: root,
+      resume: true,
+      runResearch: true,
+      seedSkillDir,
+      researcher: shouldNotResearch,
+      agent: {
+        async run() {
+          throw new Error("must not run");
+        }
+      }
+    })
+  ).rejects.toThrow("evaluation artifacts exist without completed research: scores-0.json");
+});
+
+test("a second invocation resumes at judge after the first invocation fails there", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  await writeCompletedResearch(root);
+
+  const firstClient = new QueueModelClient([
+    JSON.stringify({ output_files: [{ path: "RESULT.md", contents: "Expensive producer result\n" }] }),
+    new Error("provider quota exhausted")
+  ]);
+
+  await expect(
+    orchestrateBaseline({
+      projectRoot: root,
+      resume: true,
+      runResearch: true,
+      seedSkillDir,
+      researcher: shouldNotResearch,
+      agent: new ModelEvalAgent(firstClient)
+    })
+  ).rejects.toThrow("provider quota exhausted");
+
+  const outputDir = join(root, "workspace", "iterations", "1", "outputs", "notes-001");
+  await expect(readFile(join(outputDir, "RESULT.md"), "utf8")).resolves.toBe("Expensive producer result\n");
+  await expect(stat(join(outputDir, "producer-transcript.json"))).resolves.toBeTruthy();
+  await expect(stat(join(root, "workspace", "iterations", "1", "scores-0.json"))).rejects.toMatchObject({
+    code: "ENOENT"
+  });
+
+  const secondClient = new QueueModelClient([
+    JSON.stringify(score("notes-001", "summarise-changelog", "summarise", 0.9))
+  ]);
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher: shouldNotResearch,
+    agent: new ModelEvalAgent(secondClient)
+  });
+
+  expect(secondClient.requests.map((request) => request.system)).toEqual(["eval-judge"]);
+  expect(result.completedIterations).toBe(1);
+  expect(result.aggregate.overall.normalizedScore).toBe(0.9);
+  expect(result.events).toContainEqual({ type: "eval-producer-resumed", iteration: 1, evalId: "notes-001" });
+  await expect(readFile(join(outputDir, "RESULT.md"), "utf8")).resolves.toBe("Expensive producer result\n");
+  await expect(readFile(join(root, "workspace", "iterations", "1", "summary.json"), "utf8")).resolves.toContain(
+    '"normalizedScore": 0.9'
+  );
+});
+
+test("resume completes the current partial iteration before researching a later iteration", async () => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 2 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  const firstCandidate = await writeCompletedResearch(root, 1);
+
+  const order: string[] = [];
+  const agent: EvalAgent = {
+    async run(request) {
+      order.push(`eval-${request.sandbox.outputDir.includes(join("iterations", "1")) ? 1 : 2}`);
+      return score(
+        request.evalCase.id,
+        request.evalCase.eval_type,
+        request.track.id,
+        request.sandbox.outputDir.includes(join("iterations", "1")) ? 0.5 : 0.9
+      );
+    }
+  };
+  const researcher: SkillResearcher = {
+    async improve(request) {
+      order.push(`research-${request.iteration}`);
+      expect(request.iteration).toBe(2);
+      expect(request.previousSkillDir).toBe(firstCandidate);
+      expect(request.previousScores[0].total_score).toBe(0.5);
+      await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
+      await writeFile(
+        join(request.candidateSkillDir, ".autoresearch-iteration.json"),
+        JSON.stringify({ iteration: request.iteration })
+      );
+    }
+  };
+
+  const result = await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher,
+    agent
+  });
+
+  expect(order).toEqual(["eval-1", "research-2", "eval-2"]);
+  expect(result.completedIterations).toBe(2);
+  expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 2 });
+});

--- a/tests/resume-orchestrator.test.ts
+++ b/tests/resume-orchestrator.test.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ModelClient, ModelCompletion, ModelEvalAgent, ModelRequest } from "../src/model-agent.js";
 import { copySkillSnapshot, orchestrateBaseline, SkillResearcher } from "../src/orchestrator.js";
+import { createResearchSnapshotManifest } from "../src/resume.js";
 import { EvalAgent } from "../src/runner.js";
 import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } from "./helpers.js";
 
@@ -43,7 +44,10 @@ async function writeCompletedResearch(root: string, iteration = 1): Promise<stri
     join(candidateSkillDir, ".autoresearch-transcript.json"),
     JSON.stringify({
       request: { phase: `research iteration ${iteration}` },
-      response: JSON.stringify({ summary: "complete", changes: [{ path: "SKILL.md", contents: "# Candidate\n" }] })
+      response: JSON.stringify({
+        summary: "complete",
+        changes: [{ path: "SKILL.md", contents: `# Candidate ${iteration}\n` }]
+      })
     })
   );
   return candidateSkillDir;
@@ -120,6 +124,119 @@ test("baseline scores survive another concurrent eval failure and are reused on 
 
   expect(resumedCalls).toEqual(["notes-002"]);
   expect(result.baselineScores.map((item) => item.total_score)).toEqual([0.6, 0.7]);
+});
+
+test("a failed concurrent run drains a slow success before resume begins", async () => {
+  const root = await tempProject();
+  const evals = {
+    evals: [syntheticEvals.evals[0], { ...syntheticEvals.evals[0], id: "notes-002", title: "Summarise another change" }]
+  };
+  await writeFixture(root, { ...syntheticConfig, max_concurrency: 2 }, evals);
+  const order: string[] = [];
+  const firstAgent: EvalAgent = {
+    async run(request) {
+      if (request.evalCase.id === "notes-001") {
+        order.push("fast-failure");
+        throw new Error("first eval interrupted");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      order.push("slow-success");
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.6);
+    }
+  };
+
+  await expect(orchestrateBaseline({ projectRoot: root, agent: firstAgent })).rejects.toThrow("first eval interrupted");
+  expect(order).toEqual(["fast-failure", "slow-success"]);
+  await expect(readFile(join(root, "workspace", "baseline", "scores-1.json"), "utf8")).resolves.toContain(
+    '"eval_id": "notes-002"'
+  );
+
+  const resumedCalls: string[] = [];
+  await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    agent: {
+      async run(request) {
+        resumedCalls.push(request.evalCase.id);
+        return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.7);
+      }
+    }
+  });
+  expect(resumedCalls).toEqual(["notes-001"]);
+});
+
+test("a failed concurrent iteration drains a slow success before resume begins", async () => {
+  const root = await tempProject();
+  const evals = {
+    evals: [syntheticEvals.evals[0], { ...syntheticEvals.evals[0], id: "notes-002", title: "Summarise another change" }]
+  };
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1, max_concurrency: 2 }, evals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  await writeScore(root, join("workspace", "baseline"), 1, score("notes-002", "summarise-changelog", "summarise", 0.2));
+  await writeCompletedResearch(root);
+
+  const order: string[] = [];
+  await expect(
+    orchestrateBaseline({
+      projectRoot: root,
+      resume: true,
+      runResearch: true,
+      seedSkillDir,
+      researcher: shouldNotResearch,
+      agent: {
+        async run(request) {
+          if (request.evalCase.id === "notes-001") {
+            order.push("fast-failure");
+            throw new Error("first iteration eval interrupted");
+          }
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          order.push("slow-success");
+          return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.6);
+        }
+      }
+    })
+  ).rejects.toThrow("first iteration eval interrupted");
+  expect(order).toEqual(["fast-failure", "slow-success"]);
+  await expect(readFile(join(root, "workspace", "iterations", "1", "scores-1.json"), "utf8")).resolves.toContain(
+    '"eval_id": "notes-002"'
+  );
+
+  const resumedCalls: string[] = [];
+  await orchestrateBaseline({
+    projectRoot: root,
+    resume: true,
+    runResearch: true,
+    seedSkillDir,
+    researcher: shouldNotResearch,
+    agent: {
+      async run(request) {
+        resumedCalls.push(request.evalCase.id);
+        return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.9);
+      }
+    }
+  });
+  expect(resumedCalls).toEqual(["notes-001"]);
+});
+
+test("resume reuses a complete generated baseline without an eval adapter", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.6));
+
+  const result = await orchestrateBaseline({ projectRoot: root, resume: true });
+
+  expect(result.baselineScores[0].total_score).toBe(0.6);
+  expect(result.events).toContainEqual({ type: "baseline-resumed", scores: 1, remaining: 0 });
+});
+
+test("resume still requires an eval adapter when recovery cannot supply a baseline score", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+
+  await expect(orchestrateBaseline({ projectRoot: root, resume: true })).rejects.toThrow(
+    "No eval agent was provided to resume the incomplete baseline run"
+  );
 });
 
 test("resume reuses completed research and scores, then rebuilds a missing iteration summary", async () => {
@@ -214,7 +331,7 @@ test("resume runs only a missing judge from validated producer output", async ()
   );
 });
 
-test("resume rebuilds a missing score from a completed judge transcript", async () => {
+test("resume rebuilds a missing score from a completed judge transcript without adapters", async () => {
   const root = await tempProject();
   await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
   const seedSkillDir = await writeSeed(root);
@@ -230,27 +347,53 @@ test("resume rebuilds a missing score from a completed judge transcript", async 
     })
   );
 
-  const agent: EvalAgent = {
-    async run() {
-      throw new Error("producer must not run");
-    },
-    async judge() {
-      throw new Error("judge must not run");
-    }
-  };
   const result = await orchestrateBaseline({
     projectRoot: root,
     resume: true,
     runResearch: true,
-    seedSkillDir,
-    researcher: shouldNotResearch,
-    agent
+    seedSkillDir
   });
 
   expect(result.events).toContainEqual({ type: "eval-judge-resumed", iteration: 1, evalId: "notes-001" });
   await expect(readFile(join(root, "workspace", "iterations", "1", "scores-0.json"), "utf8")).resolves.toContain(
     '"total_score": 0.9'
   );
+});
+
+test.each([
+  { label: "baseline", scoreDir: join("workspace", "baseline"), outputDir: join("workspace", "baseline") },
+  {
+    label: "iteration",
+    scoreDir: join("workspace", "iterations", "1"),
+    outputDir: join("workspace", "iterations", "1", "outputs")
+  }
+])("resume rejects a $label score that conflicts with its judge transcript", async ({ label, scoreDir, outputDir }) => {
+  const root = await tempProject();
+  await writeFixture(root, { ...syntheticConfig, max_iterations: 1 }, syntheticEvals);
+  const seedSkillDir = await writeSeed(root);
+  await writeScore(root, join("workspace", "baseline"), 0, score("notes-001", "summarise-changelog", "summarise", 0.2));
+  if (label === "iteration") {
+    await writeCompletedResearch(root);
+    await writeScore(root, scoreDir, 0, score("notes-001", "summarise-changelog", "summarise", 0.8));
+  }
+  const evalOutputDir = join(root, outputDir, "notes-001");
+  await mkdir(evalOutputDir, { recursive: true });
+  await writeFile(
+    join(evalOutputDir, "judge-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "judge eval notes-001" },
+      response: score("notes-001", "summarise-changelog", "summarise", 0.9)
+    })
+  );
+
+  await expect(
+    orchestrateBaseline({
+      projectRoot: root,
+      resume: true,
+      runResearch: label === "iteration",
+      seedSkillDir
+    })
+  ).rejects.toThrow("persisted score does not match judge transcript");
 });
 
 test("resume archives incomplete research before rerunning the researcher", async () => {
@@ -269,7 +412,10 @@ test("resume archives incomplete research before rerunning the researcher", asyn
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
       await writeFile(
         join(request.candidateSkillDir, ".autoresearch-iteration.json"),
-        JSON.stringify({ iteration: 1 })
+        JSON.stringify({
+          iteration: 1,
+          manifest: await createResearchSnapshotManifest(request.candidateSkillDir)
+        })
       );
     }
   };
@@ -434,7 +580,10 @@ test("resume completes the current partial iteration before researching a later 
       await copySkillSnapshot(request.previousSkillDir, request.candidateSkillDir);
       await writeFile(
         join(request.candidateSkillDir, ".autoresearch-iteration.json"),
-        JSON.stringify({ iteration: request.iteration })
+        JSON.stringify({
+          iteration: request.iteration,
+          manifest: await createResearchSnapshotManifest(request.candidateSkillDir)
+        })
       );
     }
   };

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { aggregateScores } from "../src/aggregate.js";
 import {
+  createResearchSnapshotManifest,
   findUnexpectedScoreFiles,
   inspectJudgeArtifact,
   inspectProducerArtifact,
@@ -31,6 +32,32 @@ test("inspectScoreArtifact validates the score at the configured eval position",
   const invalid = await inspectScoreArtifact({ directory: root, index: 1, evalCase, track });
   expect(invalid).toMatchObject({ status: "invalid" });
   expect(invalid.status === "invalid" && invalid.reason).toContain('expected "notes-001"');
+});
+
+test("inspectScoreArtifact requires complete, unique, rubric-compatible dimensions", async () => {
+  const root = await tempProject();
+  const valid = score(evalCase.id, evalCase.eval_type, track.id, 0.6);
+  const cases = [
+    { dimensions: [], message: "Expected >=1" },
+    { dimensions: [...valid.dimensions, valid.dimensions[0]], message: "duplicate dimensions: clarity" },
+    { dimensions: [{ ...valid.dimensions[0], max_score: 2 }], message: "max_score 2, expected 1" }
+  ];
+
+  for (const [index, candidate] of cases.entries()) {
+    await writeFile(join(root, `scores-${index}.json`), JSON.stringify({ ...valid, ...candidate }));
+    const artifact = await inspectScoreArtifact({ directory: root, index, evalCase, track });
+    expect(artifact).toMatchObject({ status: "invalid" });
+    expect(artifact.status === "invalid" && artifact.reason).toContain(candidate.message);
+  }
+
+  const twoDimensionEval = {
+    ...evalCase,
+    scoring_dimensions: [...evalCase.scoring_dimensions, { id: "risk", label: "Risk", max_score: 1 }]
+  };
+  await writeFile(join(root, "scores-3.json"), JSON.stringify(valid));
+  const missing = await inspectScoreArtifact({ directory: root, index: 3, evalCase: twoDimensionEval, track });
+  expect(missing).toMatchObject({ status: "invalid" });
+  expect(missing.status === "invalid" && missing.reason).toContain("missing dimensions: risk");
 });
 
 test("findUnexpectedScoreFiles reports positional score artifacts beyond the eval set", async () => {
@@ -79,12 +106,68 @@ test("inspectResearchArtifact supports the non-model snapshot completion marker"
   const skillDir = join(root, "skill");
   await mkdir(skillDir);
   await writeFile(join(skillDir, "SKILL.md"), "# Candidate\n");
-  await writeFile(join(skillDir, ".autoresearch-iteration.json"), JSON.stringify({ iteration: 2 }));
+  await writeFile(
+    join(skillDir, ".autoresearch-iteration.json"),
+    JSON.stringify({ iteration: 2, manifest: await createResearchSnapshotManifest(skillDir) })
+  );
 
   await expect(inspectResearchArtifact(skillDir, 2)).resolves.toMatchObject({ status: "complete" });
   const wrongIteration = await inspectResearchArtifact(skillDir, 1);
   expect(wrongIteration).toMatchObject({ status: "invalid" });
   expect(wrongIteration.status === "invalid" && wrongIteration.reason).toContain("expected 1");
+
+  await writeFile(join(skillDir, ".autoresearch-iteration.json"), JSON.stringify({ iteration: 2 }));
+  const missingManifest = await inspectResearchArtifact(skillDir, 2);
+  expect(missingManifest).toMatchObject({ status: "invalid" });
+  expect(missingManifest.status === "invalid" && missingManifest.reason).toContain("snapshot manifest");
+});
+
+test("inspectResearchArtifact rejects candidate files that differ from their marker", async () => {
+  const root = await tempProject();
+  const transcriptSkillDir = join(root, "transcript-skill");
+  await mkdir(transcriptSkillDir);
+  await writeFile(join(transcriptSkillDir, "SKILL.md"), "# Changed\n");
+  await writeFile(
+    join(transcriptSkillDir, ".autoresearch-transcript.json"),
+    JSON.stringify({
+      request: { phase: "research iteration 1" },
+      response: {
+        summary: "Candidate",
+        changes: [{ path: "SKILL.md", contents: "# Expected\n" }]
+      }
+    })
+  );
+  const transcript = await inspectResearchArtifact(transcriptSkillDir, 1);
+  expect(transcript).toMatchObject({ status: "invalid" });
+  expect(transcript.status === "invalid" && transcript.reason).toContain(
+    "declared research contents do not match candidate file"
+  );
+
+  await writeFile(
+    join(transcriptSkillDir, ".autoresearch-transcript.json"),
+    JSON.stringify({
+      request: { phase: "research iteration 1" },
+      response: {
+        summary: "Candidate",
+        changes: [{ path: "../outside.md", contents: "outside" }]
+      }
+    })
+  );
+  const escaping = await inspectResearchArtifact(transcriptSkillDir, 1);
+  expect(escaping).toMatchObject({ status: "invalid" });
+  expect(escaping.status === "invalid" && escaping.reason).toContain("outside its directory");
+
+  const snapshotSkillDir = join(root, "snapshot-skill");
+  await mkdir(snapshotSkillDir);
+  await writeFile(join(snapshotSkillDir, "SKILL.md"), "# Expected\n");
+  const manifest = await createResearchSnapshotManifest(snapshotSkillDir);
+  await writeFile(join(snapshotSkillDir, ".autoresearch-iteration.json"), JSON.stringify({ iteration: 1, manifest }));
+  await writeFile(join(snapshotSkillDir, "SKILL.md"), "# Changed\n");
+  const snapshot = await inspectResearchArtifact(snapshotSkillDir, 1);
+  expect(snapshot).toMatchObject({ status: "invalid" });
+  expect(snapshot.status === "invalid" && snapshot.reason).toContain(
+    "snapshot manifest does not match candidate files"
+  );
 });
 
 test("inspectResearchArtifact requires an exact phase, a valid patch, and a SKILL.md", async () => {
@@ -119,7 +202,7 @@ test("inspectResearchArtifact requires an exact phase, a valid patch, and a SKIL
   );
   const missingSkill = await inspectResearchArtifact(skillDir, 1);
   expect(missingSkill).toMatchObject({ status: "incomplete" });
-  expect(missingSkill.status === "incomplete" && missingSkill.reason).toContain("no SKILL.md");
+  expect(missingSkill.status === "incomplete" && missingSkill.reason).toContain("missing candidate file");
 });
 
 test.each([

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -1,0 +1,242 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { aggregateScores } from "../src/aggregate.js";
+import {
+  findUnexpectedScoreFiles,
+  inspectJudgeArtifact,
+  inspectProducerArtifact,
+  inspectResearchArtifact,
+  inspectScoreArtifact,
+  inspectSummaryArtifact
+} from "../src/resume.js";
+import { syntheticConfig, syntheticEvals, score, tempProject } from "./helpers.js";
+
+const evalCase = syntheticEvals.evals[0];
+const track = syntheticConfig.tracks[0];
+
+test("inspectScoreArtifact validates the score at the configured eval position", async () => {
+  const root = await tempProject();
+  const valid = score(evalCase.id, evalCase.eval_type, track.id, 0.6);
+  await writeFile(join(root, "scores-0.json"), JSON.stringify(valid));
+
+  await expect(inspectScoreArtifact({ directory: root, index: 0, evalCase, track })).resolves.toEqual({
+    status: "complete",
+    value: valid
+  });
+  await expect(inspectScoreArtifact({ directory: root, index: 1, evalCase, track })).resolves.toEqual({
+    status: "absent"
+  });
+
+  await writeFile(join(root, "scores-1.json"), JSON.stringify({ ...valid, eval_id: "another-eval" }));
+  const invalid = await inspectScoreArtifact({ directory: root, index: 1, evalCase, track });
+  expect(invalid).toMatchObject({ status: "invalid" });
+  expect(invalid.status === "invalid" && invalid.reason).toContain('expected "notes-001"');
+});
+
+test("findUnexpectedScoreFiles reports positional score artifacts beyond the eval set", async () => {
+  const root = await tempProject();
+  await Promise.all(
+    ["scores-0.json", "scores-3.json", "scores-2.json", "summary.json"].map((file) => writeFile(join(root, file), "{}"))
+  );
+
+  await expect(findUnexpectedScoreFiles(root, 2)).resolves.toEqual(["scores-2.json", "scores-3.json"]);
+});
+
+test("inspectResearchArtifact requires a candidate directory and a valid completion marker", async () => {
+  const root = await tempProject();
+  const skillDir = join(root, "skill");
+  await expect(inspectResearchArtifact(skillDir, 1)).resolves.toEqual({ status: "absent" });
+
+  await mkdir(skillDir);
+  const partial = await inspectResearchArtifact(skillDir, 1);
+  expect(partial).toMatchObject({ status: "incomplete" });
+  expect(partial.status === "incomplete" && partial.reason).toContain("without a research completion marker");
+
+  await mkdir(join(skillDir, "skill"));
+  await writeFile(join(skillDir, "skill", "SKILL.md"), "# Candidate\n");
+  await writeFile(
+    join(skillDir, ".autoresearch-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "research iteration 1" },
+      response: {
+        summary: "Improved candidate",
+        guidance: [],
+        changes: [{ path: "skill/SKILL.md", contents: "# Candidate\n" }]
+      }
+    })
+  );
+  await expect(inspectResearchArtifact(skillDir, 1)).resolves.toEqual({
+    status: "complete",
+    value: {
+      candidateSkillDir: skillDir,
+      markerPath: join(skillDir, ".autoresearch-flue-transcript.json")
+    }
+  });
+});
+
+test("inspectResearchArtifact supports the non-model snapshot completion marker", async () => {
+  const root = await tempProject();
+  const skillDir = join(root, "skill");
+  await mkdir(skillDir);
+  await writeFile(join(skillDir, "SKILL.md"), "# Candidate\n");
+  await writeFile(join(skillDir, ".autoresearch-iteration.json"), JSON.stringify({ iteration: 2 }));
+
+  await expect(inspectResearchArtifact(skillDir, 2)).resolves.toMatchObject({ status: "complete" });
+  const wrongIteration = await inspectResearchArtifact(skillDir, 1);
+  expect(wrongIteration).toMatchObject({ status: "invalid" });
+  expect(wrongIteration.status === "invalid" && wrongIteration.reason).toContain("expected 1");
+});
+
+test("inspectResearchArtifact requires an exact phase, a valid patch, and a SKILL.md", async () => {
+  const root = await tempProject();
+  const skillDir = join(root, "skill");
+  const markerPath = join(skillDir, ".autoresearch-flue-transcript.json");
+  await mkdir(skillDir);
+  await writeFile(
+    markerPath,
+    JSON.stringify({
+      request: { phase: "research iteration 2" },
+      response: {
+        summary: "Candidate",
+        changes: [{ path: "SKILL.md", contents: "# Candidate\n" }]
+      }
+    })
+  );
+
+  const wrongPhase = await inspectResearchArtifact(skillDir, 1);
+  expect(wrongPhase).toMatchObject({ status: "invalid" });
+  expect(wrongPhase.status === "invalid" && wrongPhase.reason).toContain('expected "research iteration 1"');
+
+  await writeFile(
+    markerPath,
+    JSON.stringify({
+      request: { phase: "research iteration 1" },
+      response: {
+        summary: "Candidate",
+        changes: [{ path: "SKILL.md", contents: "# Candidate\n" }]
+      }
+    })
+  );
+  const missingSkill = await inspectResearchArtifact(skillDir, 1);
+  expect(missingSkill).toMatchObject({ status: "incomplete" });
+  expect(missingSkill.status === "incomplete" && missingSkill.reason).toContain("no SKILL.md");
+});
+
+test.each([
+  {
+    transcript: "producer-flue-transcript.json",
+    response: { output_files: [{ path: "output/index.html", contents: "<h1>Result</h1>" }] }
+  },
+  {
+    transcript: "producer-transcript.json",
+    response: JSON.stringify({
+      output_files: [{ path: "output/index.html", contents: "<h1>Result</h1>" }]
+    })
+  }
+])("inspectProducerArtifact recovers $transcript output", async ({ transcript, response }) => {
+  const root = await tempProject();
+  await mkdir(join(root, "output"));
+  await writeFile(join(root, "output", "index.html"), "<h1>Result</h1>");
+  await writeFile(join(root, transcript), JSON.stringify({ request: { phase: "producer eval notes-001" }, response }));
+
+  await expect(inspectProducerArtifact(root, "notes-001")).resolves.toEqual({
+    status: "complete",
+    value: {
+      transcriptPath: join(root, transcript),
+      outputFiles: [{ path: "output/index.html", contents: "<h1>Result</h1>" }]
+    }
+  });
+});
+
+test("inspectProducerArtifact rejects a transcript whose output is missing or changed", async () => {
+  const root = await tempProject();
+  await writeFile(
+    join(root, "producer-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "producer eval notes-001" },
+      response: { output_files: [{ path: "RESULT.md", contents: "expected" }] }
+    })
+  );
+
+  const missing = await inspectProducerArtifact(root, "notes-001");
+  expect(missing).toMatchObject({ status: "incomplete" });
+  expect(missing.status === "incomplete" && missing.reason).toContain("missing output file");
+
+  await writeFile(join(root, "RESULT.md"), "changed");
+  const changed = await inspectProducerArtifact(root, "notes-001");
+  expect(changed).toMatchObject({ status: "invalid" });
+  expect(changed.status === "invalid" && changed.reason).toContain("does not match persisted");
+});
+
+test("inspectProducerArtifact rejects a transcript for another eval", async () => {
+  const root = await tempProject();
+  await writeFile(join(root, "RESULT.md"), "result");
+  await writeFile(
+    join(root, "producer-flue-transcript.json"),
+    JSON.stringify({
+      request: { phase: "producer eval notes-002" },
+      response: { output_files: [{ path: "RESULT.md", contents: "result" }] }
+    })
+  );
+
+  const artifact = await inspectProducerArtifact(root, "notes-001");
+  expect(artifact).toMatchObject({ status: "invalid" });
+  expect(artifact.status === "invalid" && artifact.reason).toContain('expected "producer eval notes-001"');
+});
+
+test.each([
+  {
+    transcript: "judge-flue-transcript.json",
+    response: score(evalCase.id, evalCase.eval_type, track.id, 0.8)
+  },
+  {
+    transcript: "judge-transcript.json",
+    response: JSON.stringify(score(evalCase.id, evalCase.eval_type, track.id, 0.8))
+  }
+])("inspectJudgeArtifact recovers and validates $transcript", async ({ transcript, response }) => {
+  const root = await tempProject();
+  await writeFile(join(root, transcript), JSON.stringify({ request: { phase: "judge eval notes-001" }, response }));
+
+  await expect(inspectJudgeArtifact(root, evalCase, track)).resolves.toEqual({
+    status: "complete",
+    value: {
+      transcriptPath: join(root, transcript),
+      score: score(evalCase.id, evalCase.eval_type, track.id, 0.8)
+    }
+  });
+});
+
+test("inspectJudgeArtifact rejects a mismatched phase or score identity", async () => {
+  const root = await tempProject();
+  const transcriptPath = join(root, "judge-flue-transcript.json");
+  await writeFile(
+    transcriptPath,
+    JSON.stringify({
+      request: { phase: "judge eval notes-002" },
+      response: score(evalCase.id, evalCase.eval_type, track.id)
+    })
+  );
+  const wrongPhase = await inspectJudgeArtifact(root, evalCase, track);
+  expect(wrongPhase).toMatchObject({ status: "invalid" });
+  expect(wrongPhase.status === "invalid" && wrongPhase.reason).toContain('expected "judge eval notes-001"');
+});
+
+test("inspectSummaryArtifact distinguishes missing, valid, and stale summaries", async () => {
+  const root = await tempProject();
+  const summaryPath = join(root, "summary.json");
+  const aggregate = aggregateScores(syntheticConfig, [score(evalCase.id, evalCase.eval_type, track.id, 0.6)]);
+
+  await expect(inspectSummaryArtifact(summaryPath, aggregate)).resolves.toEqual({ status: "absent" });
+  await writeFile(summaryPath, JSON.stringify(aggregate));
+  await expect(inspectSummaryArtifact(summaryPath, aggregate)).resolves.toEqual({
+    status: "complete",
+    value: aggregate
+  });
+
+  const stale = await inspectSummaryArtifact(summaryPath, {
+    ...aggregate,
+    overall: { ...aggregate.overall, normalizedScore: 0.1 }
+  });
+  expect(stale).toMatchObject({ status: "invalid" });
+  expect(stale.status === "invalid" && stale.reason).toContain("does not match the aggregate recomputed");
+});


### PR DESCRIPTION
## Summary

- add opt-in `resume` support to the CLI and Flue workflow payload
- validate and reuse completed baseline scores, candidate research, producer output, judge transcripts, and iteration scores
- persist scores as each eval completes so concurrent failures retain finished work
- archive recoverable partial research/producer artifacts before retrying, while rejecting contradictory or stale artifacts
- rebuild missing summaries and resume iterations sequentially
- document recovery behavior, assumptions, cost semantics, and fresh-run cleanup

## Verification

- `./node_modules/.bin/vitest run tests --pool=forks --maxWorkers=1` — 22 files, 133 tests passed
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc -p tsconfig.json`
- `./node_modules/.bin/eslint .`
- focused Prettier check/write on all changed files
- `git diff --check`

## Known project blocker

`flue build --target node --root . --output .flue-dist` still fails on the existing dependency mismatch tracked in #84: installed Wrangler 4.95.0 does not satisfy `@cloudflare/vite-plugin`'s `^4.98.0` peer requirement. This PR intentionally does not mix that dependency upgrade into the resume implementation.

Closes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--resume` to continue interrupted baseline and evaluation runs, reusing completed scores/artifacts and resuming only missing phases.
  * Rebuilds missing iteration summaries when required inputs are present, with backups for safely re-running incomplete artifacts.
  * Extended resume logging with distinct “resumed” events for baseline, research, and scoring steps.
* **Documentation**
  * Documented “Resume An Interrupted Run” and updated harness guidance to use `resume: true`, including validation and cost reporting behavior.
* **Bug Fixes**
  * Improved error handling in concurrent execution by surfacing the first worker failure deterministically.
* **Tests**
  * Expanded coverage for resume CLI parsing, artifact inspection/validation, and end-to-end resumed orchestration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->