### PR TITLE
Add cleanup mode for fresh autoresearch reruns

### DIFF
--- a/.flue/workflows/autoresearch.ts
+++ b/.flue/workflows/autoresearch.ts
@@ -10,6 +10,7 @@ interface AutoresearchPayload {
   runResearch?: boolean;
   forceResearch?: boolean;
   resume?: boolean;
+  withCleanup?: boolean;
   seedSkillDir?: string;
   guidanceSkillDir?: string;
   budgetUsd?: number;
@@ -33,6 +34,7 @@ export async function run({ init, payload, env }: FlueContext<AutoresearchPayloa
     runResearch: payload.runResearch,
     forceResearch: payload.forceResearch,
     resume: payload.resume,
+    withCleanup: payload.withCleanup,
     seedSkillDir: payload.seedSkillDir,
     guidanceSkillDir: payload.guidanceSkillDir,
     budgetUsd: payload.budgetUsd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,13 +220,13 @@ Run these before pushing.
 
 The harness writes many files under `workspace/`.
 
-For repeatable fixture runs, clean generated iterations before committing:
+For repeatable fixture runs, start the run with cleanup enabled:
 
 ```bash
-rm -rf fixtures/projects/release-notes-alpha/workspace/iterations
+pnpm exec skills-autoresearch --project fixtures/projects/release-notes-alpha --with-baseline --research --with-cleanup --score-dir path/to/scores
 ```
 
-Score files and summaries use exclusive writes in several paths, so rerunning against an existing iteration directory can fail intentionally instead of silently overwriting evidence.
+`--with-cleanup` removes generated iterations, resume backups, and the guidance ledger before the run while preserving the baseline and project inputs. Score files and summaries otherwise keep their conservative exclusive-write behavior.
 
 ## Contribution Guidelines
 

--- a/docs/blog-tutorial-draft.md
+++ b/docs/blog-tutorial-draft.md
@@ -354,15 +354,17 @@ The run writes `workspace/cost-summary.json`. Planned and actual call counts bot
 
 Cost preview and budget support are documented and implemented in part, but [issue #19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19) remains open. The issue should be reconciled with current behavior: call-count preview exists, while Flue token usage and reliable dollar enforcement remain incomplete.
 
-## Step 7: rerunning is deliberately awkward today
+## Step 7: rerunning from a clean slate
 
-Iteration files are written conservatively to preserve evidence. Running the same research fixture again can collide with existing artifacts. The current workaround is to remove generated iterations before starting over:
+Iteration files are written conservatively to preserve evidence. To explicitly start over, add `"withCleanup":true` to the Flue payload. Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving the baseline and project inputs.
 
 ```bash
-rm -rf fixtures/projects/release-notes-alpha/workspace/iterations
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-clean"}'
 ```
 
-That is risky tutorial ergonomics and easy to forget. A supported cleanup flag is tracked in [issue #10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10).
+Cleanup is all-or-nothing from the run's perspective: if any generated artifact cannot be removed, the run stops with the artifact path in the error instead of continuing into a partially stale workspace. It cannot be combined with resume.
+
+Adding this one option also exposed a broader maintenance problem: run options, artifact paths, provider-independent persistence steps, and command examples are repeated across the CLI, Flue workflow, orchestrator, adapters, and documentation. That makes each small feature a coordinated multi-file change with real drift risk. [Issue #96](https://github.com/schalkneethling/skills-autoresearch-flue/issues/96) scopes a compatibility-preserving consolidation around shared run contracts and a canonical generated-artifact lifecycle rather than attempting a repository-wide rewrite.
 
 More importantly, if a provider or network failure happens halfway through an expensive run, the harness cannot yet resume at the missing phase. Phase-aware recovery is the project's only current `p0` feature issue: [issue #55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55).
 

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -59,10 +59,10 @@ Compare:
 
 ## Cleanup
 
-Generated iteration artifacts are written with exclusive file creation. Remove generated iterations before rerunning the same project from scratch:
+Generated iteration artifacts are written with exclusive file creation. Use cleanup mode to rerun the same project from a clean research slate:
 
 ```bash
-rm -rf path/to/my-autoresearch-project/workspace/iterations
+pnpm exec skills-autoresearch --project path/to/my-autoresearch-project --with-baseline --with-cleanup --research --score-dir path/to/scores
 ```
 
-Only commit generated iterations when the fixture or documentation intentionally needs a recorded run.
+Cleanup preserves the baseline and removes generated iterations, resume backups, and the guidance ledger. Only commit generated iterations when the fixture or documentation intentionally needs a recorded run.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -406,6 +406,7 @@ The payload fields are:
 - `forceResearch`: optional override for research runs. When omitted or `false`, `runResearch:true` stops before the researcher if the baseline aggregate score already meets `target_score`.
 - `resume`: optional recovery mode. When `true`, the harness validates and reuses completed baseline scores, candidate research, producer output, and iteration scores before running only the missing phases.
 - `sessionId`: run/session name passed in the payload and used when writing harness artifacts.
+- `withCleanup`: remove generated research state before a fresh run. This cannot be combined with `resume`.
 
 This should return events ending with `research-loop-ready`.
 
@@ -501,12 +502,14 @@ Resume assumes that `config.json`, eval cases, input, reference material, models
 
 The cost summary and actual call counts written by a resumed invocation describe that invocation, while the call preview remains the configured maximum. Consult earlier transcripts and provider records for costs from previous failed attempts.
 
-To intentionally rerun research from an imported baseline, remove generated iterations and any prior resume backups:
+To intentionally rerun research from an imported baseline, pass `"withCleanup":true`:
 
 ```bash
-rm -rf path/to/my-autoresearch-project/workspace/iterations path/to/my-autoresearch-project/workspace/resume-backups
+varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-clean"}'
 ```
 
-If the harness generated the baseline too, also remove `workspace/baseline` before a fresh run. Do not remove an imported baseline unless you intend to regenerate or replace it.
+Cleanup removes `workspace/iterations`, `workspace/resume-backups`, and `workspace/guidance-ledger.json` as a true clean slate for research. It deliberately preserves `workspace/baseline`, configuration, evals, inputs, references, and skills. The conservative exclusive-create behavior remains the default when `withCleanup` is omitted. Do not combine cleanup with resume: cleanup discards the artifacts that resume needs.
+
+The standalone CLI uses the equivalent `--with-cleanup` flag. If the harness generated the baseline and you also intend to replace it, remove `workspace/baseline` separately before the run.
 
 Keep committed fixtures baseline-only unless you intentionally want to preserve a specific alpha run artifact.

--- a/github-issue-triage-report.html
+++ b/github-issue-triage-report.html
@@ -186,7 +186,7 @@
   <body>
     <main>
       <h1>GitHub Issue Triage Report</h1>
-      <p class="meta">Generated: 2026-07-21T15:27:08+02:00</p>
+      <p class="meta">Generated: 2026-07-21T15:46:28+02:00</p>
       <p>
         Input repositories:
         <a href="https://github.com/schalkneethling/skills-autoresearch-flue"
@@ -197,16 +197,16 @@
       <h2>Summary</h2>
       <div class="summary-grid" aria-label="Repository triage summary">
         <div class="metric"><strong>1</strong>Repository triaged</div>
-        <div class="metric"><strong>16</strong>Open issues</div>
+        <div class="metric"><strong>15</strong>Open issues</div>
         <div class="metric"><strong>0</strong>p0</div>
-        <div class="metric"><strong>4</strong>p1</div>
+        <div class="metric"><strong>3</strong>p1</div>
         <div class="metric"><strong>9</strong>p2</div>
         <div class="metric"><strong>3</strong>p3</div>
       </div>
 
       <details open>
         <summary>
-          schalkneethling/skills-autoresearch-flue - 16 open issues - p0: 0, p1: 4, p2: 9, p3: 3 - next: #10 Add rerun
+          schalkneethling/skills-autoresearch-flue - 15 open issues - p0: 0, p1: 3, p2: 9, p3: 3 - next: #10 Add rerun
           flag to clean or overwrite generated iterations
         </summary>
         <div class="details-body">
@@ -223,9 +223,10 @@
           <h3>Label Update Status</h3>
           <p class="status-ok">Verified on GitHub.</p>
           <p>
-            All canonical labels exist, and each of the 16 open issues has exactly one of <code>p0</code>,
-            <code>p1</code>, <code>p2</code>, or <code>p3</code>. Issue #64 is no longer included because it was closed
-            as completed after merged PR #88. No priority-label changes were needed for the remaining open issues.
+            All canonical labels exist, and each of the 15 open issues has exactly one of <code>p0</code>,
+            <code>p1</code>, <code>p2</code>, or <code>p3</code>. Issues #64 and #87 are no longer included because they
+            were closed as completed after merged PRs #88 and #95. No priority-label changes were needed for the
+            remaining open issues.
           </p>
 
           <h3>Next Issue Nomination</h3>
@@ -250,21 +251,6 @@
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td><span class="badge p1">p1</span></td>
-                <td>
-                  <a href="https://github.com/schalkneethling/skills-autoresearch-flue/issues/87"
-                    >#87 Add full clean-install verification workflow to CI</a
-                  >
-                </td>
-                <td>The roadmap prioritizes a dependable install and end-to-end single-skill loop before expansion.</td>
-                <td>High reliability and unblock value across all future work.</td>
-                <td><span class="label">enhancement</span><span class="label">p1</span></td>
-                <td>
-                  <strong>Implementation complete in PR #95.</strong> The issue remains open pending merge and closure,
-                  so it remains in live metrics but is excluded from the next-work nomination.
-                </td>
-              </tr>
               <tr>
                 <td><span class="badge p1">p1</span></td>
                 <td>

--- a/skill/skills-autoresearch/SKILL.md
+++ b/skill/skills-autoresearch/SKILL.md
@@ -379,10 +379,10 @@ Check that:
 
 ## Reruns
 
-Iteration artifacts are created with exclusive writes. To rerun from scratch, remove generated iterations in the autoresearch project:
+Iteration artifacts are created with exclusive writes. To rerun from a clean research slate, use `--with-cleanup` with the standalone CLI or `"withCleanup":true` in the Flue payload.
 
 ```bash
-rm -rf path/to/project-root/workspace/iterations
+pnpm exec skills-autoresearch --project path/to/project-root --with-baseline --research --with-cleanup --score-dir path/to/scores
 ```
 
-Do not remove baseline artifacts unless the user is intentionally replacing the baseline.
+Cleanup removes generated iterations, resume backups, and the guidance ledger. It preserves baseline artifacts and cannot be combined with resume.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ interface CliOptions {
   runResearch: boolean;
   forceResearch: boolean;
   resume: boolean;
+  withCleanup: boolean;
   seedSkillDir?: string;
   scoreDir?: string;
   modelClient?: "anthropic";
@@ -29,6 +30,7 @@ function usage(): string {
     "  --research            Run research iterations after baseline.",
     "  --force-research      Run research even when the baseline already reaches target_score.",
     "  --resume              Continue from validated baseline and iteration artifacts.",
+    "  --with-cleanup        Remove generated research artifacts before starting a fresh run.",
     "  --seed-skill <dir>    Seed skill directory for research iterations.",
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
@@ -47,6 +49,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       research: { type: "boolean" },
       "force-research": { type: "boolean" },
       resume: { type: "boolean" },
+      "with-cleanup": { type: "boolean" },
       "seed-skill": { type: "string" },
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
@@ -69,6 +72,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     runResearch: parsed.values.research ?? false,
     forceResearch: parsed.values["force-research"] ?? false,
     resume: parsed.values.resume ?? false,
+    withCleanup: parsed.values["with-cleanup"] ?? false,
     seedSkillDir: parsed.values["seed-skill"],
     scoreDir: parsed.values["score-dir"],
     modelClient: parseModelClient(parsed.values["model-client"]),
@@ -78,6 +82,9 @@ export function parseCliArgs(argv: string[]): CliOptions {
 
   if (options.scoreDir && options.modelClient) {
     throw new Error("Use either --score-dir or --model-client, not both.");
+  }
+  if (options.resume && options.withCleanup) {
+    throw new Error("Use either --resume or --with-cleanup, not both.");
   }
   if (!options.resume && !options.withBaseline && !options.scoreDir && !options.modelClient) {
     throw new Error("Generating a baseline requires --score-dir or --model-client anthropic.");
@@ -123,6 +130,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     runResearch: cli.runResearch,
     forceResearch: cli.forceResearch,
     resume: cli.resume,
+    withCleanup: cli.withCleanup,
     seedSkillDir: cli.seedSkillDir,
     budgetUsd: cli.budgetUsd,
     modelBacked: Boolean(modelClient),
@@ -175,6 +183,8 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
   switch (event.type) {
     case "project-loaded":
       return { level: "debug", message: `Loaded project: ${event.root}` };
+    case "cleanup-completed":
+      return { level: "log", message: `Prepared clean research workspace: ${event.removed.join(", ")}` };
     case "cost-preview":
       return {
         level: event.summary.planned.totalCalls > 20 ? "warn" : "log",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { cp, lstat, mkdir, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
@@ -200,8 +200,17 @@ async function cleanupGeneratedResearchArtifacts(projectRoot: string): Promise<s
   const removed: string[] = [];
   for (const artifact of GENERATED_RESEARCH_ARTIFACTS) {
     const relativePath = `workspace/${artifact}`;
+    const artifactPath = join(projectRoot, "workspace", artifact);
     try {
-      await rm(join(projectRoot, "workspace", artifact), { recursive: true, force: true });
+      await lstat(artifactPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw new Error(`Failed to inspect generated research artifact ${relativePath}.`, { cause: error });
+    }
+    try {
+      await rm(artifactPath, { recursive: true, force: true });
     } catch (error) {
       throw new Error(`Failed to clean generated research artifact ${relativePath}.`, { cause: error });
     }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -19,6 +19,7 @@ import { EvalScore } from "./schemas.js";
 
 export type RunEvent =
   | { type: "project-loaded"; root: string }
+  | { type: "cleanup-completed"; removed: string[] }
   | { type: "cost-preview"; summary: ModelRunCostSummary }
   | { type: "baseline-imported"; scores: number; missing: string[] }
   | { type: "baseline-started"; evals: number; countsTowardIterations: false }
@@ -105,6 +106,7 @@ export interface OrchestrateOptions {
   runResearch?: boolean;
   forceResearch?: boolean;
   resume?: boolean;
+  withCleanup?: boolean;
   seedSkillDir?: string;
   guidanceSkillDir?: string;
   budgetUsd?: number;
@@ -113,6 +115,9 @@ export interface OrchestrateOptions {
 }
 
 export async function orchestrateBaseline(options: OrchestrateOptions): Promise<OrchestratorResult> {
+  if (options.resume && options.withCleanup) {
+    throw new Error("Use either resume or withCleanup, not both.");
+  }
   const events: RunEvent[] = [];
   const emit = createEventSink(events, options.onEvent);
   const project = await loadProject(options.projectRoot);
@@ -127,6 +132,10 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
     options.budgetUsd ?? project.config.budget_usd
   );
   emit({ type: "cost-preview", summary: costTracker.summary() });
+
+  if (options.withCleanup) {
+    emit({ type: "cleanup-completed", removed: await cleanupGeneratedResearchArtifacts(project.root) });
+  }
 
   const expectedEvalIds = project.evals.evals.map((evalCase) => evalCase.id);
   const baselineScores = options.withBaseline
@@ -183,6 +192,22 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
     iterations: research.iterations,
     bestIteration: research.bestIteration
   });
+}
+
+const GENERATED_RESEARCH_ARTIFACTS = ["iterations", "resume-backups", "guidance-ledger.json"] as const;
+
+async function cleanupGeneratedResearchArtifacts(projectRoot: string): Promise<string[]> {
+  const removed: string[] = [];
+  for (const artifact of GENERATED_RESEARCH_ARTIFACTS) {
+    const relativePath = `workspace/${artifact}`;
+    try {
+      await rm(join(projectRoot, "workspace", artifact), { recursive: true, force: true });
+    } catch (error) {
+      throw new Error(`Failed to clean generated research artifact ${relativePath}.`, { cause: error });
+    }
+    removed.push(relativePath);
+  }
+  return removed;
 }
 
 async function importRequiredBaseline(

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -33,6 +33,8 @@ test("parseCliArgs validates currently required adapters", () => {
   });
   expect(parseCliArgs(["--resume"])).toMatchObject({ resume: true });
   expect(parseCliArgs(["--resume", "--research"])).toMatchObject({ resume: true, runResearch: true });
+  expect(parseCliArgs(["--with-baseline", "--with-cleanup"])).toMatchObject({ withCleanup: true });
+  expect(() => parseCliArgs(["--resume", "--with-cleanup"])).toThrow(/either --resume or --with-cleanup/);
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
     /Research iterations require --score-dir or --model-client/

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -569,6 +569,20 @@ test("orchestrator cleanup removes generated research state and preserves the ba
   });
 });
 
+test("orchestrator cleanup reports no removals when generated research state is absent", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
+    }
+  };
+
+  const result = await orchestrateBaseline({ projectRoot: root, agent, withCleanup: true });
+
+  expect(result.events).toContainEqual({ type: "cleanup-completed", removed: [] });
+});
+
 test("orchestrator rejects cleanup with resume", async () => {
   await expect(orchestrateBaseline({ projectRoot: "/unused", resume: true, withCleanup: true })).rejects.toThrow(
     /either resume or withCleanup/
@@ -581,7 +595,7 @@ test("orchestrator stops with the artifact path when cleanup fails", async () =>
   await writeFile(join(root, "workspace"), "not a directory\n");
 
   await expect(orchestrateBaseline({ projectRoot: root, withCleanup: true })).rejects.toThrow(
-    /Failed to clean generated research artifact workspace\/iterations/
+    /Failed to inspect generated research artifact workspace\/iterations/
   );
 });
 

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -540,6 +540,51 @@ test("orchestrator preserves absolute origin_skill paths", async () => {
   expect(previousSkillDir).toBe(seedSkill);
 });
 
+test("orchestrator cleanup removes generated research state and preserves the baseline", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, "iterations", "1"), { recursive: true });
+  await mkdir(join(workspace, "resume-backups", "interrupted"), { recursive: true });
+  await mkdir(join(workspace, "baseline"), { recursive: true });
+  await writeFile(join(workspace, "iterations", "1", "stale.txt"), "stale\n");
+  await writeFile(join(workspace, "resume-backups", "interrupted", "stale.txt"), "stale\n");
+  await writeFile(join(workspace, "guidance-ledger.json"), "{}\n");
+  await writeFile(join(workspace, "baseline", "keep.txt"), "baseline\n");
+
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
+    }
+  };
+  const result = await orchestrateBaseline({ projectRoot: root, agent, withCleanup: true });
+
+  for (const path of ["iterations", "resume-backups", "guidance-ledger.json"]) {
+    await expect(stat(join(workspace, path))).rejects.toMatchObject({ code: "ENOENT" });
+  }
+  await expect(readFile(join(workspace, "baseline", "keep.txt"), "utf8")).resolves.toBe("baseline\n");
+  expect(result.events).toContainEqual({
+    type: "cleanup-completed",
+    removed: ["workspace/iterations", "workspace/resume-backups", "workspace/guidance-ledger.json"]
+  });
+});
+
+test("orchestrator rejects cleanup with resume", async () => {
+  await expect(orchestrateBaseline({ projectRoot: "/unused", resume: true, withCleanup: true })).rejects.toThrow(
+    /either resume or withCleanup/
+  );
+});
+
+test("orchestrator stops with the artifact path when cleanup fails", async () => {
+  const root = await tempProject();
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  await writeFile(join(root, "workspace"), "not a directory\n");
+
+  await expect(orchestrateBaseline({ projectRoot: root, withCleanup: true })).rejects.toThrow(
+    /Failed to clean generated research artifact workspace\/iterations/
+  );
+});
+
 test("orchestrator stops research at max iterations and keeps the best candidate", async () => {
   const root = await tempProject();
   await writeFixture(root, syntheticConfig, syntheticEvals);


### PR DESCRIPTION
## Summary

- Add `--with-cleanup` CLI support and `withCleanup` Flue payload handling.
- Remove generated research artifacts while preserving baselines and project inputs.
- Reject cleanup/resume combinations and report cleanup events and failures.
- Update documentation and add orchestrator and CLI coverage.

## Testing

- Added focused CLI and orchestrator tests for cleanup behavior, preservation, conflicts, and failures.

fix #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cleanup mode for research reruns via `--with-cleanup` or `withCleanup: true` (including `withCleanup` support in autoresearch payloads).
  * Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving baseline and project inputs.
  * Added completion reporting listing removed artifacts.
  * Cleanup cannot be combined with resume mode.
* **Documentation**
  * Updated contributor, tutorial, harness, use-case, and skill docs with the new cleanup guidance and examples.
* **Chores**
  * Refreshed the generated issue triage report (counts, nominations, and timestamp).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->