### PR TITLE
Add quiet Flue wrapper and append-only run logs

### DIFF
--- a/.flue/workflows/autoresearch.ts
+++ b/.flue/workflows/autoresearch.ts
@@ -1,7 +1,8 @@
 import type { FlueContext } from "@flue/runtime";
 import { createAgent } from "@flue/runtime";
 import { local } from "@flue/runtime/node";
-import { runFlueAutoresearch } from "../../src/flue-harness.js";
+import { runFlueAutoresearch, type FlueWorkflowResult } from "../../src/flue-harness.js";
+import { formatEvent } from "../../src/cli.js";
 import { autoresearchProfiles } from "../profiles.js";
 
 interface AutoresearchPayload {
@@ -16,9 +17,12 @@ interface AutoresearchPayload {
   budgetUsd?: number;
   sessionId?: string;
   model?: string;
+  verbose?: boolean;
+  writeRunLog?: boolean;
+  runLogPath?: string;
 }
 
-export async function run({ init, payload, env }: FlueContext<AutoresearchPayload>) {
+export async function run({ init, payload, env, log }: FlueContext<AutoresearchPayload>): Promise<FlueWorkflowResult> {
   const model = payload.model ?? env.FLUE_MODEL ?? "anthropic/claude-sonnet-4-6";
   const autoresearch = createAgent(() => ({
     sandbox: local(),
@@ -37,13 +41,27 @@ export async function run({ init, payload, env }: FlueContext<AutoresearchPayloa
     withCleanup: payload.withCleanup,
     seedSkillDir: payload.seedSkillDir,
     guidanceSkillDir: payload.guidanceSkillDir,
-    budgetUsd: payload.budgetUsd
+    budgetUsd: payload.budgetUsd,
+    onEvent(event) {
+      const formatted = formatEvent(event);
+      if (formatted.level === "debug" && !payload.verbose) {
+        return;
+      }
+      if (formatted.level === "warn") {
+        log.warn(formatted.message);
+      } else if (formatted.level === "error") {
+        log.error(formatted.message);
+      } else {
+        log.info(formatted.message);
+      }
+    }
   });
 
   return {
     completedIterations: result.completedIterations,
     normalizedScore: result.aggregate.overall.normalizedScore,
     bestSkillDir: result.bestIteration?.skillDir,
+    runLogPath: payload.runLogPath,
     cost: result.cost,
     events: result.events.map((event) => event.type)
   };

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test-results/
 **/workspace/.phase-workspaces/
 **/workspace/iterations/
 **/workspace/cost-summary.json
+**/workspace/run-logs/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ pnpm run alpha:research
 
 `alpha:research` runs the model-backed Flue harness through `varlock run`.
 
+Flue-backed commands are quiet by default and write a complete append-only process log under the target project's `workspace/run-logs/`. Pass `-- --verbose` to expose full Flue output in the terminal, or `-- --no-run-log` to explicitly opt out of the local log.
+
 ## Using The Harness
 
 If you want to point the harness at your own skill, start with [docs/using-the-harness.md](docs/using-the-harness.md). It explains the required project layout, config fields, eval cases, baseline artifacts, run commands, and how to inspect results.

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -66,6 +66,8 @@ This requires `ANTHROPIC_API_KEY` to resolve through Varlock.
 pnpm run alpha:research
 ```
 
+Normal runs print compact phase/eval progress and write the complete Flue process stream under `fixtures/projects/release-notes-alpha/workspace/run-logs/`. Add `-- --verbose` to `alpha:smoke` or `alpha:research` to expose the full stream in the terminal, or `-- --no-run-log` to explicitly disable the local audit log.
+
 This runs the Flue workflow with:
 
 ```json
@@ -87,7 +89,7 @@ During research, an iteration that reaches the aggregate target but lowers any e
 If a model-backed run stops after writing some artifacts, rerun with the same run-defining payload and add `"resume": true`. The `sessionId` may be changed to distinguish the resumed invocation, as in this example:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-resume"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-resume"}'
 ```
 
 Resume validates and reuses completed scores, candidate research, producer output, and judge transcripts, then runs only missing phases. It rebuilds a missing iteration summary after all scores are present. Incomplete research or producer artifacts that are safe to retry are moved to `workspace/resume-backups/`; invalid or inconsistent artifacts stop the run with an actionable error rather than being overwritten.

--- a/docs/blog-tutorial-draft.md
+++ b/docs/blog-tutorial-draft.md
@@ -359,7 +359,7 @@ Cost preview and budget support are documented and implemented in part, but [iss
 Iteration files are written conservatively to preserve evidence. To explicitly start over, add `"withCleanup":true` to the Flue payload. Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving the baseline and project inputs.
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-clean"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-clean"}'
 ```
 
 Cleanup is all-or-nothing from the run's perspective: if any generated artifact cannot be removed, the run stops with the artifact path in the error instead of continuing into a partially stale workspace. It cannot be combined with resume.
@@ -386,7 +386,7 @@ The alpha can already:
 | Finding from this walkthrough                                                                  | Status                                                                             |
 | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Clean install could not run Flue because CLI/runtime and Wrangler versions were incompatible   | [#84](https://github.com/schalkneethling/skills-autoresearch-flue/issues/84)       |
-| Normal terminal output exposes long model reasoning and generated content                      | [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17)       |
+| Normal terminal output exposes long model reasoning and generated content                      | Addressed by the quiet wrapper in #17; full output moves to `workspace/run-logs/`  |
 | Common runs require long, plumbing-heavy Flue payloads outside the convenience fixture scripts | [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)       |
 | Reruns require manual cleanup                                                                  | [#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10)       |
 | Failed runs cannot resume from the latest trustworthy phase                                    | [#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55)       |
@@ -401,7 +401,7 @@ Two tracker housekeeping items are also worth noting. [Issue #65](https://github
 The issue tracker points to a coherent progression:
 
 - Reliability first: resume failed runs ([#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55)) and support safe reruns ([#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10)).
-- Make the tool pleasant to operate: shorter commands ([#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)), quiet output ([#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17)), and a richer run report ([#18](https://github.com/schalkneethling/skills-autoresearch-flue/issues/18)).
+- Make the tool pleasant to operate: build on the quiet output and durable run log from [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17), then add shorter config-driven commands ([#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)) and a richer run report ([#18](https://github.com/schalkneethling/skills-autoresearch-flue/issues/18)).
 - Improve the quality of researched skills: place durable material in references, scripts, or assets ([#64](https://github.com/schalkneethling/skills-autoresearch-flue/issues/64)); review the candidate skill itself ([#63](https://github.com/schalkneethling/skills-autoresearch-flue/issues/63)); and evaluate trigger phrasing ([#61](https://github.com/schalkneethling/skills-autoresearch-flue/issues/61)).
 - Broaden only after the loop is dependable: multi-skill runs ([#8](https://github.com/schalkneethling/skills-autoresearch-flue/issues/8)) and cross-provider judging.
 
@@ -467,7 +467,7 @@ Likely blockers to land or explicitly resolve before publication:
 
 Strong candidates for the same publication milestone:
 
-- [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17): default terminal output should be readable and should not dump long reasoning or generated content.
+- Verify [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17) against a real model-backed run: default terminal output should remain compact, `--verbose` should expose the full stream, and the append-only run log should contain the suppressed detail through success or failure.
 - [#19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19): reconcile the issue with the implemented call preview and clearly describe the remaining token-usage and dollar-budget limitations.
 - Add or update documentation for secret injection without 1Password, making the maintainer's `dev` vault convention clearly optional.
 - Fix or intentionally baseline the existing repository-wide `format:check` failures.

--- a/docs/use-cases/compare-producer-models.md
+++ b/docs/use-cases/compare-producer-models.md
@@ -24,7 +24,7 @@ This makes the comparison easier to interpret.
 For each producer model, generate a baseline:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"baseline-haiku"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"baseline-haiku"}'
 ```
 
 Record:

--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -49,7 +49,7 @@ The `seed-skill/` directory can exist even though the baseline will not mount it
 From the root of this harness checkout, run:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 Omit `withBaseline` so the harness generates a fresh model-backed baseline. Use `runResearch:false` so the run stops after baseline generation and aggregation.
@@ -98,7 +98,7 @@ If `overall.normalizedScore < target_score`, the model likely needs either:
 After generating the baseline, you can run with `withBaseline:true` and `runResearch:true` to confirm the harness will stop before research when the baseline already passes:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-check"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-check"}'
 ```
 
 When the baseline passes, the run emits:

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -30,7 +30,7 @@ workspace/baseline/
 The baseline can be imported without model calls:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"regression-smoke"}'
+pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"regression-smoke"}'
 ```
 
 This validates the project and imported score artifacts.
@@ -40,7 +40,7 @@ This validates the project and imported score artifacts.
 To evaluate an updated seed skill through the normal research loop:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"regression-research"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"regression-research"}'
 ```
 
 If the imported baseline already reaches `target_score`, the harness stops before research unless you set `forceResearch:true`.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -26,19 +26,19 @@ Use seed skill improvement when:
 If `workspace/baseline/` already exists, you can import it:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
 ```
 
 If no baseline exists yet, generate one:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 ## Step 2: Run Research
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
 ```
 
 If the imported baseline already reaches `target_score`, the run stops with `baseline-target-score-reached`.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -412,13 +412,13 @@ This should return events ending with `research-loop-ready`.
 
 The supported `flue:run` wrapper keeps terminal output concise by default. It shows run identity, phase and eval progress, tool starts/completions, scores, stop conditions, errors, and artifact paths, while suppressing streamed reasoning, full prompts, model completions, and generated file contents.
 
-Every invocation also creates an append-only NDJSON log under:
+By default, each invocation creates an append-only NDJSON log under:
 
 ```text
 <projectRoot>/workspace/run-logs/<timestamp>-<sessionId>-<id>.ndjson
 ```
 
-The log path is printed when the run starts and returned as `runLogPath`. The log captures the complete child-process stdout and stderr stream through success or failure. Phase-specific structured transcripts remain the canonical model audit artifacts.
+When run-log writing is enabled, the log path is printed when the run starts and returned as `runLogPath`. The log captures the complete child-process stdout and stderr stream through success or failure. Phase-specific structured transcripts remain the canonical model audit artifacts.
 
 Run with full terminal detail when debugging:
 
@@ -432,7 +432,13 @@ Disable the full local log only when you explicitly do not want that audit trail
 pnpm run flue:run -- --no-run-log --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-unlogged-smoke"}'
 ```
 
-Run logs can contain prompts, model output, tool arguments, errors, and generated content. Treat them as sensitive audit artifacts and do not commit them. Direct `pnpm exec flue run autoresearch ...` remains available as an advanced debugging path and retains Flue's unfiltered event stream.
+Run logs can contain prompts, model output, tool arguments, errors, and generated content. Treat them as sensitive audit artifacts and do not commit them. This repository ignores `**/workspace/run-logs/`, but that rule does not protect a separate external `projectRoot` repository. Add the following rule to the external project's `.gitignore`:
+
+```gitignore
+workspace/run-logs/
+```
+
+Direct `pnpm exec flue run autoresearch ...` remains available as an advanced debugging path and retains Flue's unfiltered event stream.
 
 The standalone `skills-autoresearch` CLI supports the same `--verbose` and `--no-run-log` flags.
 

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -172,7 +172,7 @@ Imported baseline smoke runs with `withBaseline:true` plan no baseline producer 
 Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pass `--budget-usd <amount>` to the CLI for a one-off override. Flue payloads accept `budgetUsd`:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"budgetUsd":0.5,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"budgetUsd":0.5,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
 ```
 
 The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue runs currently record call counts, but they do not expose token usage to this harness, so dollar-cost caps only take effect when usage and known pricing are available. Treat the dollar estimate as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
@@ -386,16 +386,14 @@ pnpm run alpha:smoke
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
 ```
 
-This command uses `pnpm exec` to run the `flue` binary from this repository's installed dependencies. It does not require a globally installed `flue` CLI.
+This command uses the repository's wrapper around its project-local `flue` dependency. It does not require a globally installed `flue` CLI.
 
 The command parts are:
 
-- `pnpm exec flue run autoresearch`: runs the `autoresearch` Flue workflow through the project-local `flue` dependency.
-- `--target node`: uses the Node.js target for the run.
-- `--root .`: tells Flue to run from this harness checkout root. Flue reads source files from `<root>/.flue/` when that directory exists.
+- `pnpm run flue:run`: runs the project wrapper, which invokes the project-local Flue dependency with the Node target and this checkout as its root.
 - `--payload '...'`: passes harness-specific options as JSON.
 
 The payload fields are:
@@ -410,12 +408,40 @@ The payload fields are:
 
 This should return events ending with `research-loop-ready`.
 
+## Terminal Output And Run Logs
+
+The supported `flue:run` wrapper keeps terminal output concise by default. It shows run identity, phase and eval progress, tool starts/completions, scores, stop conditions, errors, and artifact paths, while suppressing streamed reasoning, full prompts, model completions, and generated file contents.
+
+Every invocation also creates an append-only NDJSON log under:
+
+```text
+<projectRoot>/workspace/run-logs/<timestamp>-<sessionId>-<id>.ndjson
+```
+
+The log path is printed when the run starts and returned as `runLogPath`. The log captures the complete child-process stdout and stderr stream through success or failure. Phase-specific structured transcripts remain the canonical model audit artifacts.
+
+Run with full terminal detail when debugging:
+
+```bash
+pnpm run flue:run -- --verbose --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-verbose-smoke"}'
+```
+
+Disable the full local log only when you explicitly do not want that audit trail:
+
+```bash
+pnpm run flue:run -- --no-run-log --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-unlogged-smoke"}'
+```
+
+Run logs can contain prompts, model output, tool arguments, errors, and generated content. Treat them as sensitive audit artifacts and do not commit them. Direct `pnpm exec flue run autoresearch ...` remains available as an advanced debugging path and retains Flue's unfiltered event stream.
+
+The standalone `skills-autoresearch` CLI supports the same `--verbose` and `--no-run-log` flags.
+
 ## Generate An Initial Baseline
 
 If your project does not have `workspace/baseline/` yet, run a model-backed baseline generation pass without `withBaseline` and with `runResearch:false`:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 This should return events including `baseline-started`, `baseline-generated`, `aggregated`, and `research-loop-ready`. The generated score files and transcripts are written under:
@@ -435,7 +461,7 @@ pnpm run alpha:research
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
 ```
 
 This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run --` wraps the command so model credentials are available during the run.
@@ -443,7 +469,7 @@ This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run 
 For a multi-skill project, point `seedSkillDir` at the specific skill you want that run to improve:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
 ```
 
 The run first scores the baseline. If the baseline aggregate `normalizedScore` is already greater than or equal to `target_score`, the harness emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1` or calling the researcher. To intentionally run improvements anyway, add `"forceResearch": true` to the payload.
@@ -482,7 +508,7 @@ Key questions:
 Use resume mode after a provider error, network failure, quota limit, or interrupted process:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-resume"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-resume"}'
 ```
 
 Resume walks the run in order and validates artifacts before trusting them:
@@ -505,7 +531,7 @@ The cost summary and actual call counts written by a resumed invocation describe
 To intentionally rerun research from an imported baseline, pass `"withCleanup":true`:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-clean"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-clean"}'
 ```
 
 Cleanup removes `workspace/iterations`, `workspace/resume-backups`, and `workspace/guidance-ledger.json` as a true clean slate for research. It deliberately preserves `workspace/baseline`, configuration, evals, inputs, references, and skills. The conservative exclusive-create behavior remains the default when `withCleanup` is omitted. Do not combine cleanup with resume: cleanup discards the artifacts that resume needs.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Flue agent harness for autoresearching and evaluating agent skills.",
   "bin": {
-    "skills-autoresearch": "./dist/src/cli.js"
+    "skills-autoresearch": "./dist/src/cli.js",
+    "skills-autoresearch-flue": "./dist/src/flue-runner.js"
   },
   "type": "module",
   "scripts": {
@@ -16,10 +17,10 @@
     "typecheck": "tsc --noEmit",
     "check": "pnpm run format:check && pnpm run lint && pnpm run knip && pnpm run typecheck && pnpm test && pnpm run build && pnpm run flue:build && pnpm run alpha:smoke",
     "build": "tsc -p tsconfig.json",
-    "flue:run": "flue run autoresearch --target node --root .",
+    "flue:run": "pnpm run build && node dist/src/flue-runner.js",
     "flue:build": "flue build --target node --root . --output .flue-dist",
-    "alpha:smoke": "flue run autoresearch --target node --root . --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
-    "alpha:research": "varlock run -- flue run autoresearch --target node --root . --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
+    "alpha:smoke": "pnpm run build && node dist/src/flue-runner.js --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
+    "alpha:research": "pnpm run build && varlock run -- node dist/src/flue-runner.js --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
     "env:check": "varlock load"
   },
   "dependencies": {

--- a/skill/skills-autoresearch/SKILL.md
+++ b/skill/skills-autoresearch/SKILL.md
@@ -292,7 +292,7 @@ pnpm run build
 Run a baseline smoke without model calls:
 
 ```bash
-pnpm exec flue run autoresearch --target node --root . --id my-smoke --payload '{"projectRoot":"path/to/project-root","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm run flue:run -- --payload '{"projectRoot":"path/to/project-root","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
 ```
 
 Expected smoke events should end with `research-loop-ready`.
@@ -306,7 +306,7 @@ pnpm run env:check
 Then run without `withBaseline`:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-baseline --payload '{"projectRoot":"path/to/project-root","runResearch":false,"sessionId":"my-baseline"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/project-root","runResearch":false,"sessionId":"my-baseline"}'
 ```
 
 Expected generated-baseline events include `baseline-started` and `baseline-generated`.
@@ -314,8 +314,10 @@ Expected generated-baseline events include `baseline-started` and `baseline-gene
 For model-backed research after a baseline exists, run:
 
 ```bash
-varlock run -- pnpm exec flue run autoresearch --target node --root . --id my-research --payload '{"projectRoot":"path/to/project-root","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/project-root/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/project-root","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/project-root/seed-skill","sessionId":"my-research"}'
 ```
+
+The wrapper keeps terminal output compact and writes the complete process stream under `workspace/run-logs/`. Add `--verbose` before `--payload` for full terminal detail, or `--no-run-log` only when the user explicitly opts out of the audit log. Never commit run logs; they may contain prompts, model output, tool arguments, and generated content.
 
 For a multi-skill project, point `seedSkillDir` at the specific skill directory for this run, for example `path/to/project-root/skills/security-audit`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,7 +134,9 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   const logger = createLogger(console, { verbose: cli.verbose });
   const runLog = cli.writeRunLog ? createRunLog(cli.projectRoot, "standalone-cli") : undefined;
   if (runLog) {
-    logger.write("log", `Run log: ${runLog.path}`);
+    if (!cli.json) {
+      logger.write("log", `Run log: ${runLog.path}`);
+    }
     runLog.append("run-start", { argv, projectRoot: cli.projectRoot });
   }
 
@@ -172,7 +174,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     const result = await orchestrateBaseline(options);
     runLog?.append("run-result", result);
     if (cli.json) {
-      logger.write("log", JSON.stringify({ ...result, runLogPath: runLog?.path }, null, 2));
+      logger.write("log", JSON.stringify({ ...result, ...(runLog ? { runLogPath: runLog.path } : {}) }, null, 2));
       return;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { formatCallCounts } from "./cost.js";
 import { createLogger, Logger, LogLevel } from "./logger.js";
 import { AnthropicMessagesClient, ModelEvalAgent, ModelSkillResearcher } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, RunEvent } from "./orchestrator.js";
+import { createRunLog } from "./run-log.js";
 
 interface CliOptions {
   projectRoot: string;
@@ -18,6 +19,8 @@ interface CliOptions {
   modelClient?: "anthropic";
   budgetUsd?: number;
   json: boolean;
+  verbose: boolean;
+  writeRunLog: boolean;
 }
 
 function usage(): string {
@@ -35,6 +38,8 @@ function usage(): string {
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
     "  --budget-usd <amount> Stop before additional model calls once observed cost reaches this cap.",
+    "  --verbose             Print debug-level run events.",
+    "  --no-run-log          Do not write the complete local run log.",
     "  --json                Print the full orchestrator result as JSON.",
     "  -h, --help            Show this help."
   ].join("\n");
@@ -54,6 +59,8 @@ export function parseCliArgs(argv: string[]): CliOptions {
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
       "budget-usd": { type: "string" },
+      verbose: { type: "boolean" },
+      "no-run-log": { type: "boolean" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" }
     },
@@ -77,7 +84,9 @@ export function parseCliArgs(argv: string[]): CliOptions {
     scoreDir: parsed.values["score-dir"],
     modelClient: parseModelClient(parsed.values["model-client"]),
     budgetUsd: parseBudgetUsd(parsed.values["budget-usd"]),
-    json: parsed.values.json ?? false
+    json: parsed.values.json ?? false,
+    verbose: parsed.values.verbose ?? false,
+    writeRunLog: !(parsed.values["no-run-log"] ?? false)
   };
 
   if (options.scoreDir && options.modelClient) {
@@ -121,54 +130,69 @@ function parseModelClient(value: string | boolean | undefined): "anthropic" | un
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
-  const logger = createLogger();
   const cli = parseCliArgs(argv);
-  const modelClient = cli.modelClient === "anthropic" ? new AnthropicMessagesClient() : undefined;
-  const options: OrchestrateOptions = {
-    projectRoot: cli.projectRoot,
-    withBaseline: cli.withBaseline,
-    runResearch: cli.runResearch,
-    forceResearch: cli.forceResearch,
-    resume: cli.resume,
-    withCleanup: cli.withCleanup,
-    seedSkillDir: cli.seedSkillDir,
-    budgetUsd: cli.budgetUsd,
-    modelBacked: Boolean(modelClient),
-    onEvent: cli.json
-      ? undefined
-      : (event) => {
+  const logger = createLogger(console, { verbose: cli.verbose });
+  const runLog = cli.writeRunLog ? createRunLog(cli.projectRoot, "standalone-cli") : undefined;
+  if (runLog) {
+    logger.write("log", `Run log: ${runLog.path}`);
+    runLog.append("run-start", { argv, projectRoot: cli.projectRoot });
+  }
+
+  try {
+    const modelClient = cli.modelClient === "anthropic" ? new AnthropicMessagesClient() : undefined;
+    const options: OrchestrateOptions = {
+      projectRoot: cli.projectRoot,
+      withBaseline: cli.withBaseline,
+      runResearch: cli.runResearch,
+      forceResearch: cli.forceResearch,
+      resume: cli.resume,
+      withCleanup: cli.withCleanup,
+      seedSkillDir: cli.seedSkillDir,
+      budgetUsd: cli.budgetUsd,
+      modelBacked: Boolean(modelClient),
+      onEvent: (event) => {
+        runLog?.append("run-event", event);
+        if (!cli.json) {
           const formatted = formatEvent(event);
           logger.write(formatted.level, formatted.message);
-        },
-    agent: modelClient
-      ? new ModelEvalAgent(modelClient)
-      : cli.scoreDir
-        ? new FileScoreAgent({ scoreDir: cli.scoreDir })
-        : undefined,
-    researcher: modelClient
-      ? new ModelSkillResearcher(modelClient)
-      : cli.runResearch
-        ? new SnapshotResearcher()
-        : undefined
-  };
+        }
+      },
+      agent: modelClient
+        ? new ModelEvalAgent(modelClient)
+        : cli.scoreDir
+          ? new FileScoreAgent({ scoreDir: cli.scoreDir })
+          : undefined,
+      researcher: modelClient
+        ? new ModelSkillResearcher(modelClient)
+        : cli.runResearch
+          ? new SnapshotResearcher()
+          : undefined
+    };
 
-  const result = await orchestrateBaseline(options);
-  if (cli.json) {
-    logger.write("log", JSON.stringify(result, null, 2));
-    return;
-  }
+    const result = await orchestrateBaseline(options);
+    runLog?.append("run-result", result);
+    if (cli.json) {
+      logger.write("log", JSON.stringify({ ...result, runLogPath: runLog?.path }, null, 2));
+      return;
+    }
 
-  logger.write(
-    "log",
-    `Final score: ${result.aggregate.overall.normalizedScore.toFixed(3)} ` +
-      `(${result.aggregate.overall.score}/${result.aggregate.overall.maxScore})`
-  );
-  logger.write("log", `Model calls: ${formatCallCounts(result.cost.actual.calls)}`);
-  if (result.cost.actual.costUsd !== undefined) {
-    logger.write("log", `Observed model cost: $${result.cost.actual.costUsd.toFixed(4)}`);
-  }
-  if (result.bestIteration) {
-    logger.write("log", `Best skill: ${result.bestIteration.skillDir}`);
+    logger.write(
+      "log",
+      `Final score: ${result.aggregate.overall.normalizedScore.toFixed(3)} ` +
+        `(${result.aggregate.overall.score}/${result.aggregate.overall.maxScore})`
+    );
+    logger.write("log", `Model calls: ${formatCallCounts(result.cost.actual.calls)}`);
+    if (result.cost.actual.costUsd !== undefined) {
+      logger.write("log", `Observed model cost: $${result.cost.actual.costUsd.toFixed(4)}`);
+    }
+    if (result.bestIteration) {
+      logger.write("log", `Best skill: ${result.bestIteration.skillDir}`);
+    }
+  } catch (error) {
+    runLog?.append("run-error", { message: (error as Error).message, stack: (error as Error).stack });
+    throw error;
+  } finally {
+    runLog?.close();
   }
 }
 
@@ -207,6 +231,17 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
         level: "log",
         message: `Resumed baseline: reused ${event.scores} score(s), ${event.remaining} remaining`
       };
+    case "eval-started": {
+      const phase = event.phase === "baseline" ? "Baseline" : `Iteration ${event.iteration}`;
+      return { level: "log", message: `${phase}: eval ${event.index}/${event.total} started (${event.evalId})` };
+    }
+    case "eval-completed": {
+      const phase = event.phase === "baseline" ? "Baseline" : `Iteration ${event.iteration}`;
+      return {
+        level: "log",
+        message: `${phase}: eval ${event.index}/${event.total} complete (${event.evalId}) → ${event.outputDir}`
+      };
+    }
     case "aggregated":
       return {
         level: "log",

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -1,5 +1,5 @@
 import type { FlueSession } from "@flue/runtime";
-import { ModelCallRole } from "./cost.js";
+import { ModelCallRole, ModelRunCostSummary } from "./cost.js";
 import {
   applyOutputFiles,
   appendGuidanceLedger,
@@ -28,6 +28,15 @@ import { join } from "node:path";
 export interface FlueAutoresearchOptions extends Omit<OrchestrateOptions, "agent" | "researcher"> {
   session: FlueSession;
 }
+
+export type FlueWorkflowResult = {
+  completedIterations: number;
+  normalizedScore: number;
+  bestSkillDir?: string;
+  runLogPath?: string;
+  cost: ModelRunCostSummary;
+  events: string[];
+};
 
 const PRODUCER_AGENT = "producer";
 const JUDGE_AGENT = "judge";

--- a/src/flue-runner.ts
+++ b/src/flue-runner.ts
@@ -11,6 +11,8 @@ type RunnerOptions = {
   payload: Record<string, unknown>;
 };
 
+const QUIET_STDOUT_MAX_CHARS = 1_048_576;
+
 export async function runFlueCommand(argv = process.argv.slice(2)): Promise<number> {
   const options = parseRunnerArgs(argv);
   const projectRoot = resolve(String(options.payload.projectRoot ?? process.cwd()));
@@ -18,6 +20,7 @@ export async function runFlueCommand(argv = process.argv.slice(2)): Promise<numb
   const runLog = options.writeRunLog ? createRunLog(projectRoot, sessionId) : undefined;
   const payload = {
     ...options.payload,
+    projectRoot,
     verbose: options.verbose,
     writeRunLog: options.writeRunLog,
     ...(runLog ? { runLogPath: runLog.path } : {})
@@ -73,6 +76,7 @@ function spawnFlue(args: string[], verbose: boolean, runLog: RunLog | undefined)
   return new Promise((resolveExit) => {
     const child = spawn("pnpm", args, { stdio: ["inherit", "pipe", "pipe"] });
     let quietStdout = "";
+    let quietStdoutTruncated = false;
     let quietStderrBuffer = "";
 
     child.stdout.on("data", (chunk: Buffer) => {
@@ -82,7 +86,9 @@ function spawnFlue(args: string[], verbose: boolean, runLog: RunLog | undefined)
         process.stdout.write(text);
         return;
       }
-      quietStdout += text;
+      const buffered = appendQuietStdout(quietStdout, text);
+      quietStdout = buffered.output;
+      quietStdoutTruncated ||= buffered.truncated;
     });
     child.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString();
@@ -107,7 +113,7 @@ function spawnFlue(args: string[], verbose: boolean, runLog: RunLog | undefined)
     });
     child.on("close", (code) => {
       if (!verbose) {
-        const summary = formatQuietResult(quietStdout);
+        const summary = formatQuietResult(quietStdout, quietStdoutTruncated);
         if (summary) {
           process.stdout.write(`${summary}\n`);
         }
@@ -120,10 +126,23 @@ function spawnFlue(args: string[], verbose: boolean, runLog: RunLog | undefined)
   });
 }
 
-export function formatQuietResult(output: string): string | undefined {
+export function appendQuietStdout(current: string, chunk: string): { output: string; truncated: boolean } {
+  if (chunk.length >= QUIET_STDOUT_MAX_CHARS) {
+    return { output: chunk.slice(-QUIET_STDOUT_MAX_CHARS), truncated: true };
+  }
+  const combined = current + chunk;
+  if (combined.length <= QUIET_STDOUT_MAX_CHARS) {
+    return { output: combined, truncated: false };
+  }
+  return { output: combined.slice(-QUIET_STDOUT_MAX_CHARS), truncated: true };
+}
+
+export function formatQuietResult(output: string, truncated = false): string | undefined {
   const jsonStart = output.indexOf("{");
   if (jsonStart === -1) {
-    return undefined;
+    return truncated
+      ? "Run completed, but its structured result exceeded the 1 MiB quiet-mode buffer; inspect the run log or rerun with --verbose."
+      : undefined;
   }
   try {
     const result = JSON.parse(output.slice(jsonStart)) as Partial<FlueWorkflowResult>;
@@ -135,7 +154,9 @@ export function formatQuietResult(output: string): string | undefined {
       (result.bestSkillDir ? `; best skill ${result.bestSkillDir}` : "")
     );
   } catch {
-    return undefined;
+    return truncated
+      ? "Run completed, but its structured result exceeded the 1 MiB quiet-mode buffer; inspect the run log or rerun with --verbose."
+      : undefined;
   }
 }
 

--- a/src/flue-runner.ts
+++ b/src/flue-runner.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+import type { FlueWorkflowResult } from "./flue-harness.js";
+import { createRunLog, RunLog } from "./run-log.js";
+
+type RunnerOptions = {
+  verbose: boolean;
+  writeRunLog: boolean;
+  payload: Record<string, unknown>;
+};
+
+export async function runFlueCommand(argv = process.argv.slice(2)): Promise<number> {
+  const options = parseRunnerArgs(argv);
+  const projectRoot = resolve(String(options.payload.projectRoot ?? process.cwd()));
+  const sessionId = String(options.payload.sessionId ?? "autoresearch");
+  const runLog = options.writeRunLog ? createRunLog(projectRoot, sessionId) : undefined;
+  const payload = {
+    ...options.payload,
+    verbose: options.verbose,
+    writeRunLog: options.writeRunLog,
+    ...(runLog ? { runLogPath: runLog.path } : {})
+  };
+  const flueArgs = buildFlueArgs(payload);
+
+  runLog?.append("run-start", { command: "flue", args: flueArgs, projectRoot, sessionId });
+  if (runLog) {
+    process.stderr.write(`Run log: ${runLog.path}\n`);
+  }
+
+  const exitCode = await spawnFlue(flueArgs, options.verbose, runLog);
+  runLog?.append("run-end", { exitCode });
+  runLog?.close();
+  return exitCode;
+}
+
+export function parseRunnerArgs(argv: string[]): RunnerOptions {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      verbose: { type: "boolean" },
+      "no-run-log": { type: "boolean" },
+      payload: { type: "string" }
+    },
+    strict: true,
+    allowPositionals: false
+  });
+
+  return {
+    verbose: values.verbose ?? false,
+    writeRunLog: !(values["no-run-log"] ?? false),
+    payload: JSON.parse(values.payload ?? "{}") as Record<string, unknown>
+  };
+}
+
+export function buildFlueArgs(payload: Record<string, unknown>): string[] {
+  return [
+    "exec",
+    "flue",
+    "run",
+    "autoresearch",
+    "--target",
+    "node",
+    "--root",
+    ".",
+    "--payload",
+    JSON.stringify(payload)
+  ];
+}
+
+function spawnFlue(args: string[], verbose: boolean, runLog: RunLog | undefined): Promise<number> {
+  return new Promise((resolveExit) => {
+    const child = spawn("pnpm", args, { stdio: ["inherit", "pipe", "pipe"] });
+    let quietStdout = "";
+    let quietStderrBuffer = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      runLog?.append("process-output", { stream: "stdout", text });
+      if (verbose) {
+        process.stdout.write(text);
+        return;
+      }
+      quietStdout += text;
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      runLog?.append("process-output", { stream: "stderr", text });
+      if (verbose) {
+        process.stderr.write(text);
+        return;
+      }
+      quietStderrBuffer += text;
+      const lines = quietStderrBuffer.split("\n");
+      quietStderrBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (shouldPrintQuietLine(line)) {
+          process.stderr.write(`${line}\n`);
+        }
+      }
+    });
+    child.on("error", (error) => {
+      runLog?.append("process-error", { message: error.message });
+      process.stderr.write(`Unable to start Flue: ${error.message}\n`);
+      resolveExit(1);
+    });
+    child.on("close", (code) => {
+      if (!verbose) {
+        const summary = formatQuietResult(quietStdout);
+        if (summary) {
+          process.stdout.write(`${summary}\n`);
+        }
+      }
+      if (!verbose && quietStderrBuffer && shouldPrintQuietLine(quietStderrBuffer)) {
+        process.stderr.write(`${quietStderrBuffer}\n`);
+      }
+      resolveExit(code ?? 1);
+    });
+  });
+}
+
+export function formatQuietResult(output: string): string | undefined {
+  const jsonStart = output.indexOf("{");
+  if (jsonStart === -1) {
+    return undefined;
+  }
+  try {
+    const result = JSON.parse(output.slice(jsonStart)) as Partial<FlueWorkflowResult>;
+    const score = result.normalizedScore?.toFixed(3) ?? "unknown";
+    const iterations = result.completedIterations ?? "unknown";
+    const calls = result.cost?.actual?.totalCalls ?? "unknown";
+    return (
+      `Run complete: score ${score}; iterations ${iterations}; model calls ${calls}` +
+      (result.bestSkillDir ? `; best skill ${result.bestSkillDir}` : "")
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export function shouldPrintQuietLine(line: string): boolean {
+  return (
+    line.startsWith("[flue] Running workflow:") ||
+    line.startsWith("[flue] Run ID:") ||
+    line.startsWith("[flue] tool:") ||
+    line.startsWith("[flue] info:") ||
+    line.startsWith("[flue] warn:") ||
+    line.startsWith("[flue] error:") ||
+    line.startsWith("[flue] ERROR") ||
+    line.startsWith("[flue] Workflow error:") ||
+    line === "[flue] Done."
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runFlueCommand()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error: unknown) => {
+      process.stderr.write(`${(error as Error).message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,9 +13,16 @@ export interface Logger {
   write(level: LogLevel, message: string): void;
 }
 
-export function createLogger(sink: LogSink = console): Logger {
+export type LoggerOptions = {
+  verbose?: boolean;
+};
+
+export function createLogger(sink: LogSink = console, options: LoggerOptions = {}): Logger {
   return {
     write(level, message) {
+      if (level === "debug" && !options.verbose) {
+        return;
+      }
       sink[level](message);
     }
   };

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -26,6 +26,23 @@ export type RunEvent =
   | { type: "baseline-generated"; scores: number }
   | { type: "baseline-resumed"; scores: number; remaining: number }
   | {
+      type: "eval-started";
+      phase: "baseline" | "iteration";
+      iteration?: number;
+      evalId: string;
+      index: number;
+      total: number;
+    }
+  | {
+      type: "eval-completed";
+      phase: "baseline" | "iteration";
+      iteration?: number;
+      evalId: string;
+      index: number;
+      total: number;
+      outputDir: string;
+    }
+  | {
       type: "iteration-started";
       iteration: number;
       previousSkillDir: string;
@@ -271,6 +288,13 @@ async function generateInitialBaseline(
     project.evals.evals,
     project.config.max_concurrency,
     async (evalCase, index) => {
+      emit({
+        type: "eval-started",
+        phase: "baseline",
+        evalId: evalCase.id,
+        index: index + 1,
+        total: project.evals.evals.length
+      });
       const score = await runEval(
         {
           config: project.config,
@@ -283,6 +307,14 @@ async function generateInitialBaseline(
         agent
       );
       await persistEvalScore(outputRoot, index, score);
+      emit({
+        type: "eval-completed",
+        phase: "baseline",
+        evalId: evalCase.id,
+        index: index + 1,
+        total: project.evals.evals.length,
+        outputDir: join(outputRoot, evalCase.id)
+      });
       return score;
     }
   );
@@ -452,9 +484,11 @@ async function runResearchIterations(
       ? await resumeIterationScores(project, iteration, iterationDir, candidateSkillDir, agent, emit, costTracker)
       : await runFreshIterationScores(
           project,
+          iteration,
           iterationDir,
           candidateSkillDir,
           requireEvalAgent(agent, "run research iterations"),
+          emit,
           costTracker
         );
 
@@ -555,12 +589,22 @@ async function improveSkill(
 
 async function runFreshIterationScores(
   project: ProjectInputs,
+  iteration: number,
   iterationDir: string,
   candidateSkillDir: string,
   agent: EvalAgent,
+  emit: (event: RunEvent) => void,
   costTracker: ModelRunCostTracker
 ): Promise<EvalScore[]> {
   return runWithConcurrency(project.evals.evals, project.config.max_concurrency, async (evalCase, index) => {
+    emit({
+      type: "eval-started",
+      phase: "iteration",
+      iteration,
+      evalId: evalCase.id,
+      index: index + 1,
+      total: project.evals.evals.length
+    });
     const score = await runEval(
       {
         config: project.config,
@@ -574,6 +618,15 @@ async function runFreshIterationScores(
       agent
     );
     await persistEvalScore(iterationDir, index, score);
+    emit({
+      type: "eval-completed",
+      phase: "iteration",
+      iteration,
+      evalId: evalCase.id,
+      index: index + 1,
+      total: project.evals.evals.length,
+      outputDir: join(iterationDir, "outputs", evalCase.id)
+    });
     return score;
   });
 }

--- a/src/run-log.ts
+++ b/src/run-log.ts
@@ -1,0 +1,35 @@
+import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join, resolve } from "node:path";
+
+export type RunLog = {
+  path: string;
+  append(type: string, data: unknown): void;
+  close(): void;
+};
+
+export function createRunLog(projectRoot: string, sessionId = "autoresearch"): RunLog {
+  const directory = join(resolve(projectRoot), "workspace", "run-logs");
+  mkdirSync(directory, { recursive: true });
+  const timestamp = new Date().toISOString().replaceAll(":", "-");
+  const safeSessionId = sessionId.replaceAll(/[^a-zA-Z0-9._-]/g, "-") || "autoresearch";
+  const path = join(directory, `${timestamp}-${safeSessionId}-${randomUUID()}.ndjson`);
+  const descriptor = openSync(path, "wx");
+  let closed = false;
+
+  return {
+    path,
+    append(type, data) {
+      if (closed) {
+        return;
+      }
+      writeSync(descriptor, `${JSON.stringify({ timestamp: new Date().toISOString(), type, data })}\n`);
+    },
+    close() {
+      if (!closed) {
+        closeSync(descriptor);
+        closed = true;
+      }
+    }
+  };
+}

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -1,9 +1,17 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { FileScoreAgent, SnapshotResearcher } from "../src/adapters.js";
-import { parseCliArgs } from "../src/cli.js";
+import { main, parseCliArgs } from "../src/cli.js";
 import { trackForEval } from "../src/project.js";
-import { securityConfig, securityEvals, score, syntheticConfig, tempProject } from "./helpers.js";
+import {
+  securityConfig,
+  securityEvals,
+  score,
+  syntheticConfig,
+  syntheticEvals,
+  tempProject,
+  writeFixture
+} from "./helpers.js";
 
 test("parseCliArgs validates currently required adapters", () => {
   expect(parseCliArgs(["--project", "/tmp/project", "--with-baseline"])).toMatchObject({
@@ -48,6 +56,33 @@ test("parseCliArgs validates currently required adapters", () => {
   expect(() => parseCliArgs(["--model-client", "anthropic", "--budget-usd=-1"])).toThrow(/non-negative/);
   expect(() => parseCliArgs(["--model-client", "anthropic", "--budget-usd", "nope"])).toThrow(/non-negative/);
   expect(() => parseCliArgs(["--project"])).toThrow(/argument missing/);
+});
+
+test("JSON mode emits only JSON and includes the run-log path conditionally", async () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  try {
+    const root = await tempProject();
+    await writeFixture(root, syntheticConfig, syntheticEvals);
+    const scoreDir = join(root, "scores");
+    await mkdir(scoreDir, { recursive: true });
+    await writeFile(
+      join(scoreDir, "notes-001.json"),
+      JSON.stringify(score("notes-001", "summarise-changelog", "summarise"))
+    );
+
+    await main(["--project", root, "--score-dir", scoreDir, "--json"]);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(log.mock.calls[0][0]))).toMatchObject({ runLogPath: expect.any(String) });
+
+    log.mockClear();
+    const unloggedRoot = await tempProject();
+    await writeFixture(unloggedRoot, syntheticConfig, syntheticEvals);
+    await main(["--project", unloggedRoot, "--score-dir", scoreDir, "--json", "--no-run-log"]);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(log.mock.calls[0][0]))).not.toHaveProperty("runLogPath");
+  } finally {
+    log.mockRestore();
+  }
 });
 
 test("FileScoreAgent returns eval scores from explicit files", async () => {

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -34,6 +34,10 @@ test("parseCliArgs validates currently required adapters", () => {
   expect(parseCliArgs(["--resume"])).toMatchObject({ resume: true });
   expect(parseCliArgs(["--resume", "--research"])).toMatchObject({ resume: true, runResearch: true });
   expect(parseCliArgs(["--with-baseline", "--with-cleanup"])).toMatchObject({ withCleanup: true });
+  expect(parseCliArgs(["--with-baseline", "--verbose", "--no-run-log"])).toMatchObject({
+    verbose: true,
+    writeRunLog: false
+  });
   expect(() => parseCliArgs(["--resume", "--with-cleanup"])).toThrow(/either --resume or --with-cleanup/);
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(

--- a/tests/e2e-dry-run.test.ts
+++ b/tests/e2e-dry-run.test.ts
@@ -83,6 +83,22 @@ test("dry run executes baseline, applies a candidate skill patch, and scores one
   expect(result.completedIterations).toBe(1);
   expect(result.aggregate.overall.normalizedScore).toBe(0.9);
   expect(result.events.at(-1)).toMatchObject({ type: "target-score-reached", iteration: 1 });
+  expect(result.events).toContainEqual({
+    type: "eval-started",
+    phase: "baseline",
+    evalId: evalCase.id,
+    index: 1,
+    total: 1
+  });
+  expect(result.events).toContainEqual({
+    type: "eval-completed",
+    phase: "iteration",
+    iteration: 1,
+    evalId: evalCase.id,
+    index: 1,
+    total: 1,
+    outputDir: join(root, "workspace", "iterations", "1", "outputs", evalCase.id)
+  });
   expect(client.requests.map((request) => request.system)).toEqual(
     [
       ["baseline producer", "task-producer"],

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -1,4 +1,10 @@
-import { buildFlueArgs, formatQuietResult, parseRunnerArgs, shouldPrintQuietLine } from "../src/flue-runner.js";
+import {
+  appendQuietStdout,
+  buildFlueArgs,
+  formatQuietResult,
+  parseRunnerArgs,
+  shouldPrintQuietLine
+} from "../src/flue-runner.js";
 
 test("Flue runner parses verbose and run-log opt-out flags without forwarding them", () => {
   expect(
@@ -39,5 +45,26 @@ test("quiet Flue output replaces the full result with a compact summary", () => 
     )
   ).toBe(
     "Run complete: score 0.900; iterations 2; model calls 8; best skill /tmp/project/workspace/iterations/2/skill"
+  );
+});
+
+test("quiet Flue output keeps a fixed-size tail that can still contain the final result", () => {
+  const resultJson = JSON.stringify({
+    completedIterations: 1,
+    normalizedScore: 0.8,
+    cost: { actual: { totalCalls: 5 } }
+  });
+  const buffered = appendQuietStdout("x".repeat(1_048_570), resultJson);
+
+  expect(buffered.truncated).toBe(true);
+  expect(buffered.output.length).toBeLessThanOrEqual(1_048_576);
+  expect(formatQuietResult(buffered.output, buffered.truncated)).toBe(
+    "Run complete: score 0.800; iterations 1; model calls 5"
+  );
+});
+
+test("quiet Flue output explains when a truncated result cannot be parsed", () => {
+  expect(formatQuietResult("result tail without JSON", true)).toBe(
+    "Run completed, but its structured result exceeded the 1 MiB quiet-mode buffer; inspect the run log or rerun with --verbose."
   );
 });

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -1,0 +1,43 @@
+import { buildFlueArgs, formatQuietResult, parseRunnerArgs, shouldPrintQuietLine } from "../src/flue-runner.js";
+
+test("Flue runner parses verbose and run-log opt-out flags without forwarding them", () => {
+  expect(
+    parseRunnerArgs(["--verbose", "--no-run-log", "--payload", '{"projectRoot":"/tmp/project","sessionId":"test"}'])
+  ).toEqual({
+    verbose: true,
+    writeRunLog: false,
+    payload: { projectRoot: "/tmp/project", sessionId: "test" }
+  });
+});
+
+test("Flue runner emits exactly one canonical payload argument", () => {
+  const args = buildFlueArgs({ projectRoot: "/tmp/project", verbose: true });
+  expect(args.filter((arg) => arg === "--payload")).toHaveLength(1);
+  expect(JSON.parse(args.at(-1) ?? "")).toEqual({ projectRoot: "/tmp/project", verbose: true });
+});
+
+test.each([
+  ["[flue] tool:start  write  /tmp/result.md", true],
+  ["[flue] info: Iteration 1: eval 1/2 started", true],
+  ["[flue] Run ID: workflow:autoresearch:123", true],
+  ["[flue] thinking:start", false],
+  ["  full generated output contents", false],
+  ["  hidden chain of thought", false]
+])("quiet Flue output filters content-bearing lines", (line, expected) => {
+  expect(shouldPrintQuietLine(line)).toBe(expected);
+});
+
+test("quiet Flue output replaces the full result with a compact summary", () => {
+  expect(
+    formatQuietResult(
+      `[flue] build output\n${JSON.stringify({
+        completedIterations: 2,
+        normalizedScore: 0.9,
+        bestSkillDir: "/tmp/project/workspace/iterations/2/skill",
+        cost: { actual: { totalCalls: 8 } }
+      })}\n`
+    )
+  ).toBe(
+    "Run complete: score 0.900; iterations 2; model calls 8; best skill /tmp/project/workspace/iterations/2/skill"
+  );
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,5 +1,8 @@
+import { readFile } from "node:fs/promises";
 import { createLogger, LogLevel, LogSink } from "../src/logger.js";
 import { formatEvent, writeEvents } from "../src/cli.js";
+import { createRunLog } from "../src/run-log.js";
+import { tempProject } from "./helpers.js";
 
 function sink() {
   const calls: Array<{ level: LogLevel; message: unknown }> = [];
@@ -20,7 +23,7 @@ function sink() {
   return { calls, target };
 }
 
-test("createLogger routes messages by constant log level", () => {
+test("createLogger keeps default output quiet and verbose output includes debug messages", () => {
   const { calls, target } = sink();
   const logger = createLogger(target);
 
@@ -32,14 +35,16 @@ test("createLogger routes messages by constant log level", () => {
   expect(calls).toEqual([
     { level: "log", message: "info" },
     { level: "warn", message: "careful" },
-    { level: "debug", message: "trace" },
     { level: "error", message: "broken" }
   ]);
+
+  createLogger(target, { verbose: true }).write("debug", "verbose trace");
+  expect(calls.at(-1)).toEqual({ level: "debug", message: "verbose trace" });
 });
 
 test("writeEvents uses the severity returned by formatEvent", () => {
   const { calls, target } = sink();
-  const logger = createLogger(target);
+  const logger = createLogger(target, { verbose: true });
 
   writeEvents(
     [
@@ -74,4 +79,42 @@ test("formatEvent explains baseline target completion", () => {
       targetScore: 0.8
     })
   ).toEqual({ level: "log", message: "Baseline reached target: 0.950 >= 0.800" });
+});
+
+test("formatEvent reports compact eval progress and artifact paths", () => {
+  expect(
+    formatEvent({
+      type: "eval-completed",
+      phase: "iteration",
+      iteration: 2,
+      evalId: "notes-001",
+      index: 1,
+      total: 3,
+      outputDir: "/tmp/project/workspace/iterations/2/outputs/notes-001"
+    })
+  ).toEqual({
+    level: "log",
+    message: "Iteration 2: eval 1/3 complete (notes-001) → /tmp/project/workspace/iterations/2/outputs/notes-001"
+  });
+});
+
+test("run logs append structured records without overwriting earlier entries", async () => {
+  const root = await tempProject();
+  const runLog = createRunLog(root, "test run");
+  runLog.append("run-start", { value: 1 });
+  const firstRecord = await readFile(runLog.path, "utf8");
+  runLog.append("run-event", { value: 2 });
+  runLog.close();
+
+  const completedLog = await readFile(runLog.path, "utf8");
+  expect(completedLog.startsWith(firstRecord)).toBe(true);
+  expect(completedLog.length).toBeGreaterThan(firstRecord.length);
+  const records = completedLog
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { type: string; data: { value: number } });
+  expect(records.map(({ type, data }) => [type, data.value])).toEqual([
+    ["run-start", 1],
+    ["run-event", 2]
+  ]);
 });

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -219,7 +219,7 @@ test("orchestrator generates initial baseline by default without counting it as 
     type: "baseline-started",
     countsTowardIterations: false
   });
-  expect(generated.events[3]).toMatchObject({ type: "baseline-generated", scores: 1 });
+  expect(generated.events).toContainEqual({ type: "baseline-generated", scores: 1 });
   expect(generated.completedIterations).toBe(0);
   expect(generated.events.at(-1)).toMatchObject({
     type: "research-loop-ready",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    environment: "node"
+    environment: "node",
+    exclude: ["dist/**", ".flue-dist/**", "node_modules/**"]
   }
 });


### PR DESCRIPTION
## Summary

- Add a project-local Flue runner with concise output by default
- Support `--verbose` and `--no-run-log` options
- Persist complete append-only run logs and expose their paths
- Add eval progress events and update usage documentation

## Testing

- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs now show compact progress by default while writing detailed append-only NDJSON logs under `workspace/run-logs/`.
  * Added `--verbose` for full terminal streaming and `--no-run-log` to disable local logging.
  * Run results can include the generated `runLogPath`, and evaluation progress is reported with clearer per-phase completion details.
* **Documentation**
  * Updated commands and examples to use the streamlined Flue runner workflow and document terminal output/run-log behavior.
* **Tests**
  * Expanded CLI, quiet-mode, logging, and evaluation event assertions.
* **Chores**
  * Updated ignore rules and test configuration to avoid running built artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->