### PR TITLE
Complete run option and artifact cleanup plumbing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ function usage(): string {
     "  --resume              Continue from validated baseline and iteration artifacts.",
     "  --with-cleanup        Remove generated research artifacts before starting a fresh run.",
     "  --seed-skill <dir>    Seed skill directory for research iterations.",
+    "  --guidance-skill <dir> Reference skill directory for research iterations.",
     "  --score-dir <dir>     Directory of file-backed EvalScore JSON files.",
     "  --model-client <name> Use a model client. Supported: anthropic.",
     "  --budget-usd <amount> Stop before additional model calls once observed cost reaches this cap.",
@@ -50,6 +51,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       resume: { type: "boolean" },
       "with-cleanup": { type: "boolean" },
       "seed-skill": { type: "string" },
+      "guidance-skill": { type: "string" },
       "score-dir": { type: "string" },
       "model-client": { type: "string" },
       "budget-usd": { type: "string" },
@@ -76,6 +78,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       resume: parsed.values.resume,
       withCleanup: parsed.values["with-cleanup"],
       seedSkillDir: parsed.values["seed-skill"],
+      guidanceSkillDir: parsed.values["guidance-skill"],
       budgetUsd: parseBudgetUsd(parsed.values["budget-usd"])
     }),
     scoreDir: parsed.values["score-dir"],
@@ -87,9 +90,6 @@ export function parseCliArgs(argv: string[]): CliOptions {
 
   if (options.scoreDir && options.modelClient) {
     throw new Error("Use either --score-dir or --model-client, not both.");
-  }
-  if (options.resume && options.withCleanup) {
-    throw new Error("Use either --resume or --with-cleanup, not both.");
   }
   if (!options.resume && !options.withBaseline && !options.scoreDir && !options.modelClient) {
     throw new Error("Generating a baseline requires --score-dir or --model-client anthropic.");
@@ -146,6 +146,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       resume: cli.resume,
       withCleanup: cli.withCleanup,
       seedSkillDir: cli.seedSkillDir,
+      guidanceSkillDir: cli.guidanceSkillDir,
       budgetUsd: cli.budgetUsd,
       modelBacked: Boolean(modelClient),
       onEvent: (event) => {

--- a/src/flue-harness.ts
+++ b/src/flue-harness.ts
@@ -3,15 +3,11 @@ import { join } from "node:path";
 import { ModelCallRole, ModelRunCostSummary } from "./cost.js";
 import {
   applyOutputFiles,
-  appendGuidanceLedger,
   buildJudgeModelRequest,
   buildProduceModelRequest,
   buildResearchModelRequest,
-  formatResearchSummary,
   parseModelJudgeResponse,
-  applySkillResearchPatch,
-  validateSkillResearchPatch,
-  validateChangedScripts
+  researchArtifactOperations
 } from "./model-agent.js";
 import { persistResearchArtifact, persistTranscript } from "./artifact-lifecycle.js";
 import { orchestrateBaseline, OrchestrateOptions, SkillResearcher } from "./orchestrator.js";
@@ -98,13 +94,14 @@ export class FlueSkillResearcher implements SkillResearcher {
       cwd: modelRequest.workspaceDir
     });
     recordFlueCall(request.costTracker, "researcher", modelRequest);
-    await persistResearchArtifact(request, modelRequest, patch, patch, ".autoresearch-flue-transcript.json", {
-      validatePatch: validateSkillResearchPatch,
-      applyPatch: applySkillResearchPatch,
-      validateScripts: validateChangedScripts,
-      appendLedger: appendGuidanceLedger,
-      formatSummary: formatResearchSummary
-    });
+    await persistResearchArtifact(
+      request,
+      modelRequest,
+      patch,
+      patch,
+      ".autoresearch-flue-transcript.json",
+      researchArtifactOperations
+    );
   }
 }
 

--- a/src/model-agent.ts
+++ b/src/model-agent.ts
@@ -651,7 +651,7 @@ function executeScriptValidator(validator: ScriptValidator, absolutePath: string
   });
 }
 
-const researchArtifactOperations = {
+export const researchArtifactOperations = {
   validatePatch: validateSkillResearchPatch,
   applyPatch: applySkillResearchPatch,
   validateScripts: validateChangedScripts,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,5 @@
 import { cp, lstat, mkdir, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { aggregateScores, AggregateReport } from "./aggregate.js";
 import { importBaselineArtefacts } from "./baseline.js";
@@ -213,8 +213,8 @@ async function cleanupGeneratedResearchArtifacts(projectRoot: string): Promise<s
   const layout = projectLayout(projectRoot);
   const removed: string[] = [];
   for (const artifact of GENERATED_RESEARCH_ARTIFACTS) {
-    const relativePath = `workspace/${artifact}`;
     const artifactPath = join(layout.workspaceDir, artifact);
+    const relativePath = relative(projectRoot, artifactPath);
     try {
       await lstat(artifactPath);
     } catch (error) {

--- a/src/project-layout.ts
+++ b/src/project-layout.ts
@@ -13,7 +13,7 @@ export const RESEARCH_TRANSCRIPTS = [
 ] as const;
 export const PRODUCER_TRANSCRIPTS = ["producer-flue-transcript.json", "producer-transcript.json"] as const;
 export const JUDGE_TRANSCRIPTS = ["judge-flue-transcript.json", "judge-transcript.json"] as const;
-export const GENERATED_SKILL_FILES = ["RESEARCH.md", ...RESEARCH_TRANSCRIPTS.slice(0, 2)] as const;
+export const GENERATED_SKILL_FILES = ["RESEARCH.md", ...RESEARCH_TRANSCRIPTS] as const;
 
 export interface ProjectLayout {
   root: string;

--- a/src/run-options.ts
+++ b/src/run-options.ts
@@ -24,9 +24,6 @@ export function normalizeRunOptions(input: RunOptionInput, defaultProjectRoot = 
     guidanceSkillDir: input.guidanceSkillDir,
     budgetUsd: input.budgetUsd
   };
-  if (options.resume && options.withCleanup) {
-    throw new Error("Use either --resume or --with-cleanup (either resume or withCleanup), not both.");
-  }
   if (options.budgetUsd !== undefined && (!Number.isFinite(options.budgetUsd) || options.budgetUsd < 0)) {
     throw new Error("budgetUsd must be a non-negative number.");
   }

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -51,7 +51,7 @@ test("parseCliArgs validates currently required adapters", () => {
     verbose: true,
     writeRunLog: false
   });
-  expect(() => parseCliArgs(["--resume", "--with-cleanup"])).toThrow(/either --resume or --with-cleanup/);
+  expect(parseCliArgs(["--resume", "--with-cleanup"])).toMatchObject({ resume: true, withCleanup: true });
   expect(() => parseCliArgs([])).toThrow(/--score-dir or --model-client/);
   expect(() => parseCliArgs(["--with-baseline", "--research"])).toThrow(
     /Research iterations require --score-dir or --model-client/
@@ -87,6 +87,47 @@ test("JSON mode emits only JSON and includes the run-log path conditionally", as
     expect(JSON.parse(String(log.mock.calls[0][0]))).not.toHaveProperty("runLogPath");
   } finally {
     log.mockRestore();
+  }
+});
+
+test("main forwards guidance-skill to the researcher", async () => {
+  const root = await tempProject();
+  const scoreDir = join(root, "scores");
+  const seedSkillDir = join(root, "seed-skill");
+  const guidanceSkillDir = join(root, "guidance-skill");
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  await mkdir(scoreDir, { recursive: true });
+  await mkdir(seedSkillDir, { recursive: true });
+  await mkdir(guidanceSkillDir, { recursive: true });
+  await writeFile(join(seedSkillDir, "SKILL.md"), "# Seed\n");
+  await writeFile(join(guidanceSkillDir, "SKILL.md"), "# Guidance\n");
+  await writeFile(
+    join(scoreDir, "notes-001-0.json"),
+    JSON.stringify(score("notes-001", "summarise-changelog", "summarise", 0))
+  );
+  await writeFile(
+    join(scoreDir, "notes-001-1.json"),
+    JSON.stringify(score("notes-001", "summarise-changelog", "summarise"))
+  );
+  const improve = vi.spyOn(SnapshotResearcher.prototype, "improve");
+
+  try {
+    await main([
+      "--project",
+      root,
+      "--score-dir",
+      scoreDir,
+      "--research",
+      "--force-research",
+      "--seed-skill",
+      seedSkillDir,
+      "--guidance-skill",
+      guidanceSkillDir,
+      "--no-run-log"
+    ]);
+    expect(improve).toHaveBeenCalledWith(expect.objectContaining({ guidanceSkillDir }));
+  } finally {
+    improve.mockRestore();
   }
 });
 

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -24,6 +24,11 @@ test("parseCliArgs validates currently required adapters", () => {
     runResearch: true,
     seedSkillDir: "/tmp/skill"
   });
+  expect(parseCliArgs(["--score-dir", "/tmp/scores", "--research", "--guidance-skill", "/tmp/guidance"])).toMatchObject(
+    {
+      guidanceSkillDir: "/tmp/guidance"
+    }
+  );
   expect(parseCliArgs(["--model-client", "anthropic", "--research"])).toMatchObject({
     modelClient: "anthropic",
     runResearch: true

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -222,6 +222,8 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
   await writeFile(join(previousSkillDir, "SKILL.md"), "# Previous\n");
   await writeFile(join(previousSkillDir, "RESEARCH.md"), "# Old research\n");
   await writeFile(join(previousSkillDir, ".autoresearch-transcript.json"), "{}\n");
+  await writeFile(join(previousSkillDir, ".autoresearch-flue-transcript.json"), "{}\n");
+  await writeFile(join(previousSkillDir, ".autoresearch-iteration.json"), "{}\n");
   const patch = {
     summary: "Improve the examples.",
     resource_decisions: [
@@ -298,6 +300,10 @@ test("ModelSkillResearcher snapshots the skill, applies patch changes, and recor
   await expect(readFile(join(candidateSkillDir, ".autoresearch-transcript.json"), "utf8")).resolves.toContain(
     "SKILL.md"
   );
+  await expect(stat(join(candidateSkillDir, ".autoresearch-flue-transcript.json"))).rejects.toMatchObject({
+    code: "ENOENT"
+  });
+  await expect(stat(join(candidateSkillDir, ".autoresearch-iteration.json"))).rejects.toMatchObject({ code: "ENOENT" });
   await expect(readFile(join(candidateSkillDir, "RESEARCH.md"), "utf8")).resolves.not.toContain("Old research");
 });
 

--- a/tests/run-contract.test.ts
+++ b/tests/run-contract.test.ts
@@ -28,7 +28,10 @@ test("run options normalize both adapter payload shapes into one contract", () =
     withCleanup: false
   });
   expect(flue).toEqual({ ...cli, budgetUsd: 0.25 });
-  expect(() => normalizeRunOptions({ resume: true, withCleanup: true })).toThrow(/either --resume or --with-cleanup/);
+  expect(normalizeRunOptions({ resume: true, withCleanup: true })).toMatchObject({
+    resume: true,
+    withCleanup: true
+  });
 });
 
 test("project layout identifies only generated research state for cleanup", () => {

--- a/tests/run-contract.test.ts
+++ b/tests/run-contract.test.ts
@@ -1,35 +1,44 @@
 import { normalizeRunOptions } from "../src/run-options.js";
 import { GENERATED_RESEARCH_ARTIFACTS, projectLayout } from "../src/project-layout.js";
 import { persistResearchArtifact } from "../src/artifact-lifecycle.js";
+import { join } from "node:path";
 
 test("run options normalize both adapter payload shapes into one contract", () => {
   const cli = normalizeRunOptions({
     projectRoot: "/tmp/project",
     withBaseline: true,
-    runResearch: true,
-    withCleanup: false,
-    budgetUsd: 0.25
+    runResearch: true
   });
   const flue = normalizeRunOptions({
     projectRoot: "/tmp/project",
     withBaseline: true,
     runResearch: true,
+    forceResearch: false,
+    resume: false,
     withCleanup: false,
     budgetUsd: 0.25
   });
 
-  expect(cli).toEqual(flue);
+  expect(cli).toEqual({
+    projectRoot: "/tmp/project",
+    withBaseline: true,
+    runResearch: true,
+    forceResearch: false,
+    resume: false,
+    withCleanup: false
+  });
+  expect(flue).toEqual({ ...cli, budgetUsd: 0.25 });
   expect(() => normalizeRunOptions({ resume: true, withCleanup: true })).toThrow(/either --resume or --with-cleanup/);
 });
 
 test("project layout identifies only generated research state for cleanup", () => {
   const layout = projectLayout("/tmp/project");
-  expect(GENERATED_RESEARCH_ARTIFACTS.map((artifact) => `${layout.workspaceDir}/${artifact}`)).toEqual([
-    "/tmp/project/workspace/iterations",
-    "/tmp/project/workspace/resume-backups",
-    "/tmp/project/workspace/guidance-ledger.json"
+  expect(GENERATED_RESEARCH_ARTIFACTS.map((artifact) => join(layout.workspaceDir, artifact))).toEqual([
+    join("/tmp/project", "workspace", "iterations"),
+    join("/tmp/project", "workspace", "resume-backups"),
+    join("/tmp/project", "workspace", "guidance-ledger.json")
   ]);
-  expect(layout.baselineDir).toBe("/tmp/project/workspace/baseline");
+  expect(layout.baselineDir).toBe(join("/tmp/project", "workspace", "baseline"));
 });
 
 test("research artifact lifecycle identifies the failed stage and preserves its cause", async () => {

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -583,10 +583,22 @@ test("orchestrator cleanup reports no removals when generated research state is 
   expect(result.events).toContainEqual({ type: "cleanup-completed", removed: [] });
 });
 
-test("orchestrator rejects cleanup with resume", async () => {
-  await expect(orchestrateBaseline({ projectRoot: "/unused", resume: true, withCleanup: true })).rejects.toThrow(
-    /either resume or withCleanup/
-  );
+test("orchestrator cleans generated research state before resuming", async () => {
+  const root = await tempProject();
+  const workspace = join(root, "workspace");
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  await mkdir(join(workspace, "iterations", "1"), { recursive: true });
+  await writeFile(join(workspace, "iterations", "1", "stale.txt"), "stale\n");
+
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id, 0.2);
+    }
+  };
+  const result = await orchestrateBaseline({ projectRoot: root, agent, resume: true, withCleanup: true });
+
+  await expect(stat(join(workspace, "iterations"))).rejects.toMatchObject({ code: "ENOENT" });
+  expect(result.events).toContainEqual({ type: "cleanup-completed", removed: ["workspace/iterations"] });
 });
 
 test("orchestrator stops with the artifact path when cleanup fails", async () => {


### PR DESCRIPTION
## Summary

- expose the guidance-skill option through the CLI run contract
- reuse shared research-artifact operations in the Flue adapter
- clean up all generated research transcript variants consistently
- make generated-artifact cleanup paths portable

## Why

This publishes follow-up plumbing that was left local after #105 merged, keeping CLI and Flue execution paths aligned.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm test` (105 tests passed)
- `pnpm run typecheck` was attempted but stalled without output and was stopped after approximately 90 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--guidance-skill <dir>` option for specifying a guidance skill directory during research runs.
  - Research workflows now recognize and manage the complete set of generated research transcript artifacts.

- **Bug Fixes**
  - `--resume` can now be used together with `--with-cleanup`.
  - Cleanup results now report accurate paths for removed generated artifacts.
  - Existing research artifacts are preserved correctly during subsequent skill improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->