### PR TITLE
Add config-driven commands for smoke and research runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Generated research output lands under `workspace/iterations/<n>/`. Do not commit
 
 ## Guardrails
 
+- Treat review feedback as a hypothesis: verify it against current code, callers, CI paths, and documented behavior before changing anything. If feedback is invalid or conflicts with a repository invariant, state that clearly and explain the evidence.
 - Keep Flue as the primary harness layer for alpha work.
 - Do not collapse producer and judge into one self-scoring model call.
 - Prefer schema-validated structured model output over ad hoc parsing.
@@ -82,6 +83,7 @@ Generated research output lands under `workspace/iterations/<n>/`. Do not commit
 - Update docs and tests when config shape, artifact layout, commands, or model flow changes.
 - Never commit `.env`, resolved API keys, provider secrets, or transcripts containing secrets.
 - Score and summary writes often use exclusive file creation; rerun failures may indicate existing artifacts rather than logic failure.
+- Keep `pnpm run check` and `alpha:smoke` credential-free. Do not route smoke runs through Varlock or require `op`; use Varlock only for model-backed commands.
 
 ## What Is Still Alpha
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm run typecheck
 pnpm run build
 pnpm run flue:build
 pnpm run autoresearch -- smoke --project path/to/project
-varlock run -- pnpm run autoresearch -- research --project path/to/project
+pnpm run autoresearch -- research --project path/to/project
 pnpm run alpha:smoke
 pnpm run alpha:research
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm run typecheck
 pnpm run build
 pnpm run flue:build
 pnpm run autoresearch -- smoke --project path/to/project
-pnpm run autoresearch -- research --project path/to/project
+varlock run -- pnpm run autoresearch -- research --project path/to/project
 pnpm run alpha:smoke
 pnpm run alpha:research
 ```

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ pnpm test
 pnpm run typecheck
 pnpm run build
 pnpm run flue:build
+pnpm run autoresearch -- smoke --project path/to/project
+varlock run -- pnpm run autoresearch -- research --project path/to/project
 pnpm run alpha:smoke
 pnpm run alpha:research
 ```
+
+The `smoke` and `research` commands derive normal Flue payload fields and the session name, use `origin_skill` and model settings from the project config, and avoid inline JSON. Direct Flue payload invocation remains available for advanced debugging.
 
 `alpha:smoke` imports a committed baseline and does not call a model.
 

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -75,21 +75,22 @@ This runs the Flue workflow with:
   "projectRoot": "fixtures/projects/release-notes-alpha",
   "withBaseline": true,
   "runResearch": true,
-  "seedSkillDir": "fixtures/projects/release-notes-alpha/seed-skill",
   "sessionId": "alpha-research"
 }
 ```
 
-If the imported baseline already meets `target_score`, the run emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1`. Add `"forceResearch": true` to the payload only when you want to spend model calls on research anyway.
+The wrapper derives the baseline/research flags from the `research` command, and the fixture's `origin_skill` config selects `seed-skill`.
+
+If the imported baseline already meets `target_score`, the run emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1`. Add `--force-research` only when you want to spend model calls on research anyway.
 
 During research, an iteration that reaches the aggregate target but lowers any eval case below its baseline score emits `target-score-blocked-by-regression` and continues until a non-regressing candidate reaches the target or `max_iterations` is exhausted.
 
 ## Resume An Interrupted Run
 
-If a model-backed run stops after writing some artifacts, rerun with the same run-defining payload and add `"resume": true`. The `sessionId` may be changed to distinguish the resumed invocation, as in this example:
+If a model-backed run stops after writing some artifacts, rerun the config-driven command with `--resume`:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-resume"}'
+varlock run -- pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --resume
 ```
 
 Resume validates and reuses completed scores, candidate research, producer output, and judge transcripts, then runs only missing phases. It rebuilds a missing iteration summary after all scores are present. Incomplete research or producer artifacts that are safe to retry are moved to `workspace/resume-backups/`; invalid or inconsistent artifacts stop the run with an actionable error rather than being overwritten.

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -90,7 +90,7 @@ During research, an iteration that reaches the aggregate target but lowers any e
 If a model-backed run stops after writing some artifacts, rerun the config-driven command with `--resume`:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --resume
+pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --resume
 ```
 
 Resume validates and reuses completed scores, candidate research, producer output, and judge transcripts, then runs only missing phases. It rebuilds a missing iteration summary after all scores are present. Incomplete research or producer artifacts that are safe to retry are moved to `workspace/resume-backups/`; invalid or inconsistent artifacts stop the run with an actionable error rather than being overwritten.

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -90,7 +90,7 @@ During research, an iteration that reaches the aggregate target but lowers any e
 If a model-backed run stops after writing some artifacts, rerun the config-driven command with `--resume`:
 
 ```bash
-pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --resume
+varlock run -- pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --resume
 ```
 
 Resume validates and reuses completed scores, candidate research, producer output, and judge transcripts, then runs only missing phases. It rebuilds a missing iteration summary after all scores are present. Incomplete research or producer artifacts that are safe to retry are moved to `workspace/resume-backups/`; invalid or inconsistent artifacts stop the run with an actionable error rather than being overwritten.

--- a/docs/blog-tutorial-draft.md
+++ b/docs/blog-tutorial-draft.md
@@ -359,7 +359,7 @@ Cost preview and budget support are documented and implemented in part, but [iss
 Iteration files are written conservatively to preserve evidence. To explicitly start over, add `--with-cleanup` to the config-driven command. Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving the baseline and project inputs.
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --with-cleanup
+pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --with-cleanup
 ```
 
 Cleanup is all-or-nothing from the run's perspective: if any generated artifact cannot be removed, the run stops with the artifact path in the error instead of continuing into a partially stale workspace. It cannot be combined with resume.

--- a/docs/blog-tutorial-draft.md
+++ b/docs/blog-tutorial-draft.md
@@ -356,10 +356,10 @@ Cost preview and budget support are documented and implemented in part, but [iss
 
 ## Step 7: rerunning from a clean slate
 
-Iteration files are written conservatively to preserve evidence. To explicitly start over, add `"withCleanup":true` to the Flue payload. Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving the baseline and project inputs.
+Iteration files are written conservatively to preserve evidence. To explicitly start over, add `--with-cleanup` to the config-driven command. Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving the baseline and project inputs.
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"fixtures/projects/release-notes-alpha","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"fixtures/projects/release-notes-alpha/seed-skill","sessionId":"alpha-research-clean"}'
+varlock run -- pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --with-cleanup
 ```
 
 Cleanup is all-or-nothing from the run's perspective: if any generated artifact cannot be removed, the run stops with the artifact path in the error instead of continuing into a partially stale workspace. It cannot be combined with resume.
@@ -387,7 +387,7 @@ The alpha can already:
 | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Clean install could not run Flue because CLI/runtime and Wrangler versions were incompatible   | [#84](https://github.com/schalkneethling/skills-autoresearch-flue/issues/84)       |
 | Normal terminal output exposes long model reasoning and generated content                      | Addressed by the quiet wrapper in #17; full output moves to `workspace/run-logs/`  |
-| Common runs require long, plumbing-heavy Flue payloads outside the convenience fixture scripts | [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)       |
+| Common runs require long, plumbing-heavy Flue payloads outside the convenience fixture scripts | Addressed by config-driven `smoke` and `research` commands in #12                  |
 | Reruns require manual cleanup                                                                  | [#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10)       |
 | Failed runs cannot resume from the latest trustworthy phase                                    | [#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55)       |
 | Flue call counts are captured, but this run exposed no token usage or dollar estimate          | [#19](https://github.com/schalkneethling/skills-autoresearch-flue/issues/19)       |
@@ -401,7 +401,7 @@ Two tracker housekeeping items are also worth noting. [Issue #65](https://github
 The issue tracker points to a coherent progression:
 
 - Reliability first: resume failed runs ([#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55)) and support safe reruns ([#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10)).
-- Make the tool pleasant to operate: build on the quiet output and durable run log from [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17), then add shorter config-driven commands ([#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12)) and a richer run report ([#18](https://github.com/schalkneethling/skills-autoresearch-flue/issues/18)).
+- Make the tool pleasant to operate: build on the quiet output and durable run log from [#17](https://github.com/schalkneethling/skills-autoresearch-flue/issues/17), the config-driven commands from [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12), and a richer run report ([#18](https://github.com/schalkneethling/skills-autoresearch-flue/issues/18)).
 - Improve the quality of researched skills: place durable material in references, scripts, or assets ([#64](https://github.com/schalkneethling/skills-autoresearch-flue/issues/64)); review the candidate skill itself ([#63](https://github.com/schalkneethling/skills-autoresearch-flue/issues/63)); and evaluate trigger phrasing ([#61](https://github.com/schalkneethling/skills-autoresearch-flue/issues/61)).
 - Broaden only after the loop is dependable: multi-skill runs ([#8](https://github.com/schalkneethling/skills-autoresearch-flue/issues/8)) and cross-provider judging.
 
@@ -432,7 +432,7 @@ The final tutorial should start with two separate directories:
 /path/to/the-user-project/          # the skill project being researched
 ```
 
-The user should run the harness against an external, absolute `projectRoot` and point `seedSkillDir` at a skill in that project. The walkthrough must verify path resolution from the harness working directory, where config and eval artifacts are written, which files remain in the external repository, and how the generated candidate is adopted after a successful run.
+The user should run the harness against an external, absolute project path and configure `origin_skill` for the skill in that project. The walkthrough must verify path resolution from the harness working directory, where config and eval artifacts are written, which files remain in the external repository, and how the generated candidate is adopted after a successful run.
 
 Use a realistic project and skill rather than moving the release-notes fixture elsewhere merely to demonstrate an absolute path. The scenario should begin with a recognizable user problem, exercise more than one representative eval if affordable, and finish with an artifact the reader would plausibly keep or ship.
 
@@ -441,7 +441,7 @@ The revised article should answer these questions explicitly:
 - What must be installed in the harness checkout versus the user's project?
 - Which command is run from which directory?
 - Which paths in `config.json` resolve relative to the external project root?
-- Which payload paths resolve relative to the shell working directory?
+- Which command-line override paths resolve relative to the shell working directory?
 - Does the user's repository need Flue, Varlock, or harness dependencies installed locally?
 - Where do baseline, iteration, transcript, and cost artifacts land?
 - How does the user review and adopt the winning candidate skill?
@@ -461,7 +461,7 @@ Do not publish the final tutorial until the path it recommends works from a clea
 Likely blockers to land or explicitly resolve before publication:
 
 - [#84](https://github.com/schalkneethling/skills-autoresearch-flue/issues/84): a clean install must produce a compatible Flue CLI/runtime/Wrangler dependency graph.
-- [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12): a normal external-project run needs a short, config-driven command instead of a long inline Flue payload.
+- Verify [#12](https://github.com/schalkneethling/skills-autoresearch-flue/issues/12) against a separate external project using the short config-driven command.
 - [#55](https://github.com/schalkneethling/skills-autoresearch-flue/issues/55): failed model-backed work should resume from the latest trustworthy phase.
 - [#10](https://github.com/schalkneethling/skills-autoresearch-flue/issues/10): rerunning should not require a tutorial to recommend manual recursive deletion.
 

--- a/docs/blog-tutorial-draft.md
+++ b/docs/blog-tutorial-draft.md
@@ -359,7 +359,7 @@ Cost preview and budget support are documented and implemented in part, but [iss
 Iteration files are written conservatively to preserve evidence. To explicitly start over, add `--with-cleanup` to the config-driven command. Cleanup removes generated iterations, resume backups, and the guidance ledger while preserving the baseline and project inputs.
 
 ```bash
-pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --with-cleanup
+varlock run -- pnpm run autoresearch -- research --project fixtures/projects/release-notes-alpha --with-cleanup
 ```
 
 Cleanup is all-or-nothing from the run's perspective: if any generated artifact cannot be removed, the run stops with the artifact path in the error instead of continuing into a partially stale workspace. It cannot be combined with resume.

--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -95,10 +95,10 @@ If `overall.normalizedScore < target_score`, the model likely needs either:
 
 ## Step 4: Optional Early-Exit Check
 
-After generating the baseline, you can run with `withBaseline:true` and `runResearch:true` to confirm the harness will stop before research when the baseline already passes:
+After generating the baseline, inspect `workspace/baseline/summary.json` before running this check. When `overall.normalizedScore >= target_score`, the command confirms that the harness stops before research:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 When the baseline passes, the run emits:
@@ -108,6 +108,8 @@ baseline-target-score-reached
 ```
 
 and does not create `workspace/iterations/1`.
+
+If the baseline score is below `target_score`, this same command does not stop early: it proceeds into model-backed research, requires a valid `origin_skill`, and can incur researcher, producer, and judge calls. Use it only when that fallback behavior is intended.
 
 ## Seed-As-Reference Research
 

--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -98,7 +98,7 @@ If `overall.normalizedScore < target_score`, the model likely needs either:
 After generating the baseline, you can run with `withBaseline:true` and `runResearch:true` to confirm the harness will stop before research when the baseline already passes:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-check"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 When the baseline passes, the run emits:

--- a/docs/use-cases/no-skill-baseline-guidance-check.md
+++ b/docs/use-cases/no-skill-baseline-guidance-check.md
@@ -98,7 +98,7 @@ If `overall.normalizedScore < target_score`, the model likely needs either:
 After generating the baseline, inspect `workspace/baseline/summary.json` before running this check. When `overall.normalizedScore >= target_score`, the command confirms that the harness stops before research:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 When the baseline passes, the run emits:

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -40,7 +40,7 @@ This validates the project and imported score artifacts.
 To evaluate an updated seed skill through the normal research loop:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 If the imported baseline already reaches `target_score`, the harness stops before research unless you pass `--force-research`.
@@ -62,7 +62,7 @@ Compare:
 Generated iteration artifacts are written with exclusive file creation. Use cleanup mode to rerun the same project from a clean research slate:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
 ```
 
 Cleanup preserves the baseline and removes generated iterations, resume backups, and the guidance ledger. Only commit generated iterations when the fixture or documentation intentionally needs a recorded run.

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -30,7 +30,7 @@ workspace/baseline/
 The baseline can be imported without model calls:
 
 ```bash
-pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"regression-smoke"}'
+pnpm run autoresearch -- smoke --project path/to/my-autoresearch-project
 ```
 
 This validates the project and imported score artifacts.
@@ -40,12 +40,12 @@ This validates the project and imported score artifacts.
 To evaluate an updated seed skill through the normal research loop:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"regression-research"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
-If the imported baseline already reaches `target_score`, the harness stops before research unless you set `forceResearch:true`.
+If the imported baseline already reaches `target_score`, the harness stops before research unless you pass `--force-research`.
 
-Use `forceResearch:true` only when you intentionally want a fresh candidate despite a passing baseline.
+Use `--force-research` only when you intentionally want a fresh candidate despite a passing baseline.
 
 ## Step 3: Review The Difference
 
@@ -62,7 +62,7 @@ Compare:
 Generated iteration artifacts are written with exclusive file creation. Use cleanup mode to rerun the same project from a clean research slate:
 
 ```bash
-pnpm exec skills-autoresearch --project path/to/my-autoresearch-project --with-baseline --with-cleanup --research --score-dir path/to/scores
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
 ```
 
 Cleanup preserves the baseline and removes generated iterations, resume backups, and the guidance ledger. Only commit generated iterations when the fixture or documentation intentionally needs a recorded run.

--- a/docs/use-cases/regression-test-existing-skill.md
+++ b/docs/use-cases/regression-test-existing-skill.md
@@ -40,7 +40,7 @@ This validates the project and imported score artifacts.
 To evaluate an updated seed skill through the normal research loop:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 If the imported baseline already reaches `target_score`, the harness stops before research unless you pass `--force-research`.
@@ -62,7 +62,7 @@ Compare:
 Generated iteration artifacts are written with exclusive file creation. Use cleanup mode to rerun the same project from a clean research slate:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
 ```
 
 Cleanup preserves the baseline and removes generated iterations, resume backups, and the guidance ledger. Only commit generated iterations when the fixture or documentation intentionally needs a recorded run.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -26,7 +26,7 @@ Use seed skill improvement when:
 If `workspace/baseline/` already exists, you can import it:
 
 ```bash
-pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm run autoresearch -- smoke --project path/to/my-autoresearch-project
 ```
 
 If no baseline exists yet, generate one:
@@ -38,7 +38,7 @@ varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autore
 ## Step 2: Run Research
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 If the imported baseline already reaches `target_score`, the run stops with `baseline-target-score-reached`.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -38,7 +38,7 @@ varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autore
 ## Step 2: Run Research
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 If the imported baseline already reaches `target_score`, the run stops with `baseline-target-score-reached`.

--- a/docs/use-cases/seed-skill-improvement.md
+++ b/docs/use-cases/seed-skill-improvement.md
@@ -38,7 +38,7 @@ varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autore
 ## Step 2: Run Research
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
 If the imported baseline already reaches `target_score`, the run stops with `baseline-target-score-reached`.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -30,7 +30,7 @@ The default alpha fixture uses:
 
 When this guide says "project layout", it means an autoresearch project root: a repository or directory that contains the config, evals, reference material, candidate skill files, and workspace artifacts for one bounded improvement effort.
 
-For example, a dedicated repository such as [`skills-autoresearch-security/`](https://github.com/schalkneethling/skills-autoresearch-security/tree/main) is a project root. The harness does not require the project root to live inside this repository; the `projectRoot` payload value points Flue at the project you want to run.
+For example, a dedicated repository such as [`skills-autoresearch-security/`](https://github.com/schalkneethling/skills-autoresearch-security/tree/main) is a project root. The harness does not require the project root to live inside this repository; pass its path with `--project`, or run from that directory and omit the flag.
 
 ## Terminology
 
@@ -86,7 +86,7 @@ skills-autoresearch-security/
       ...
 ```
 
-The important parts are not the exact directory names for every project, but that `config.json` and the run payload point at the correct project root and seed skill directory.
+The important parts are not the exact directory names for every project, but that `config.json` and the run command point at the correct project root. `origin_skill` selects the default seed skill.
 
 ## Config
 
@@ -169,10 +169,10 @@ iteration judge calls = eval count * max_iterations when runResearch is true
 
 Imported baseline smoke runs with `withBaseline:true` plan no baseline producer or judge calls. `max_concurrency` controls how many evals can run at once; it does not reduce the number of producer or judge calls.
 
-Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pass `--budget-usd <amount>` to the CLI for a one-off override. Flue payloads accept `budgetUsd`:
+Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pass `--budget-usd <amount>` for a one-off override:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"budgetUsd":0.5,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --budget-usd 0.5
 ```
 
 The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue runs currently record call counts, but they do not expose token usage to this harness, so dollar-cost caps only take effect when usage and known pricing are available. Treat the dollar estimate as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
@@ -187,9 +187,9 @@ That file includes planned calls, observed calls by role, token usage when avail
 
 ## Seed Skill Selection
 
-`origin_skill` is the `config.json` field for the default seed skill. The harness uses this path when a run payload does not provide a skill override.
+`origin_skill` is the `config.json` field for the default seed skill. Normal runs use it automatically.
 
-`seedSkillDir` is the run payload override for one invocation. Payload overrides resolve relative to the shell working directory unless absolute. Do not add it to `config.json`; pass it in the JSON payload you send to the project-local Flue autoresearch command when you want that specific run to improve a different skill directory.
+Use `--seed-skill <dir>` to override `origin_skill` for one invocation. Overrides resolve relative to the shell working directory unless absolute.
 
 For example, this config default improves the audit skill:
 
@@ -199,16 +199,12 @@ For example, this config default improves the audit skill:
 }
 ```
 
-To improve the authoring skill without editing `config.json`, keep the config default as-is and pass `seedSkillDir` in that run's payload:
+To improve the authoring skill without editing `config.json`, keep the config default as-is and pass a concise override:
 
-```json
-{
-  "projectRoot": "path/to/skills-autoresearch-security",
-  "withBaseline": true,
-  "runResearch": true,
-  "seedSkillDir": "path/to/skills-autoresearch-security/skills/secure-authoring",
-  "sessionId": "security-authoring-research"
-}
+```bash
+varlock run -- pnpm run autoresearch -- research \
+  --project path/to/skills-autoresearch-security \
+  --seed-skill path/to/skills-autoresearch-security/skills/secure-authoring
 ```
 
 Current alpha behavior improves one seed skill per run. For multi-skill projects, run the harness once per target skill.
@@ -386,31 +382,24 @@ pnpm run alpha:smoke
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-smoke"}'
+pnpm run autoresearch -- smoke --project path/to/my-autoresearch-project
 ```
 
-This command uses the repository's wrapper around its project-local `flue` dependency. It does not require a globally installed `flue` CLI.
+This command imports and validates `workspace/baseline/`, then stops before research. It uses the repository's project-local Flue dependency and does not require a global `flue` CLI.
 
-The command parts are:
+The simple commands derive common payload fields for you:
 
-- `pnpm run flue:run`: runs the project wrapper, which invokes the project-local Flue dependency with the Node target and this checkout as its root.
-- `--payload '...'`: passes harness-specific options as JSON.
-
-The payload fields are:
-
-- `projectRoot`: path to the autoresearch project you want the harness to load. Relative paths are resolved from the directory where you run the command, so in this guide they are relative to the local `skills-autoresearch-flue` checkout root. Use an absolute path if the project lives somewhere else and you want to avoid ambiguity.
-- `withBaseline`: tells the harness to load or validate the baseline artifacts for the project.
-- `runResearch`: controls whether the researcher should patch the skill. `false` makes this a smoke run that stops before model-backed research.
-- `forceResearch`: optional override for research runs. When omitted or `false`, `runResearch:true` stops before the researcher if the baseline aggregate score already meets `target_score`.
-- `resume`: optional recovery mode. When `true`, the harness validates and reuses completed baseline scores, candidate research, producer output, and iteration scores before running only the missing phases.
-- `sessionId`: run/session name passed in the payload and used when writing harness artifacts.
-- `withCleanup`: remove generated research state before a fresh run. This cannot be combined with `resume`.
+- `--project` defaults to the current directory.
+- `smoke` sets `withBaseline:true` and `runResearch:false`.
+- `research` sets `withBaseline:true` and `runResearch:true`.
+- The session name is derived from the project directory and command.
+- Research uses `origin_skill`, model assignments, iteration limits, target score, concurrency, and budget from `config.json`.
 
 This should return events ending with `research-loop-ready`.
 
 ## Terminal Output And Run Logs
 
-The supported `flue:run` wrapper keeps terminal output concise by default. It shows run identity, phase and eval progress, tool starts/completions, scores, stop conditions, errors, and artifact paths, while suppressing streamed reasoning, full prompts, model completions, and generated file contents.
+The supported `autoresearch` wrapper keeps terminal output concise by default. It shows run identity, phase and eval progress, tool starts/completions, scores, stop conditions, errors, and artifact paths, while suppressing streamed reasoning, full prompts, model completions, and generated file contents.
 
 By default, each invocation creates an append-only NDJSON log under:
 
@@ -423,13 +412,13 @@ When run-log writing is enabled, the log path is printed when the run starts and
 Run with full terminal detail when debugging:
 
 ```bash
-pnpm run flue:run -- --verbose --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-verbose-smoke"}'
+pnpm run autoresearch -- smoke --project path/to/my-autoresearch-project --verbose
 ```
 
 Disable the full local log only when you explicitly do not want that audit trail:
 
 ```bash
-pnpm run flue:run -- --no-run-log --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":false,"sessionId":"my-unlogged-smoke"}'
+pnpm run autoresearch -- smoke --project path/to/my-autoresearch-project --no-run-log
 ```
 
 Run logs can contain prompts, model output, tool arguments, errors, and generated content. Treat them as sensitive audit artifacts and do not commit them. This repository ignores `**/workspace/run-logs/`, but that rule does not protect a separate external `projectRoot` repository. Add the following rule to the external project's `.gitignore`:
@@ -438,13 +427,9 @@ Run logs can contain prompts, model output, tool arguments, errors, and generate
 workspace/run-logs/
 ```
 
-Direct `pnpm exec flue run autoresearch ...` remains available as an advanced debugging path and retains Flue's unfiltered event stream.
-
-The standalone `skills-autoresearch` CLI supports the same `--verbose` and `--no-run-log` flags.
-
 ## Generate An Initial Baseline
 
-If your project does not have `workspace/baseline/` yet, run a model-backed baseline generation pass without `withBaseline` and with `runResearch:false`:
+The config-driven `smoke` and `research` commands expect an imported baseline. If your project does not have `workspace/baseline/` yet, use the advanced payload form for a model-backed baseline generation pass:
 
 ```bash
 varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","runResearch":false,"sessionId":"my-baseline"}'
@@ -467,18 +452,20 @@ pnpm run alpha:research
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
-This also uses `pnpm exec` to run the project-local `flue` binary. `varlock run --` wraps the command so model credentials are available during the run.
+`varlock run --` makes model credentials available. The command reads the default seed skill from `origin_skill` and all model assignments and limits from `config.json`.
 
-For a multi-skill project, point `seedSkillDir` at the specific skill you want that run to improve:
+For a multi-skill project, use the concise seed override:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/skills-autoresearch-security","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/skills-autoresearch-security/skills/security-audit","sessionId":"security-audit-research"}'
+varlock run -- pnpm run autoresearch -- research \
+  --project path/to/skills-autoresearch-security \
+  --seed-skill path/to/skills-autoresearch-security/skills/security-audit
 ```
 
-The run first scores the baseline. If the baseline aggregate `normalizedScore` is already greater than or equal to `target_score`, the harness emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1` or calling the researcher. To intentionally run improvements anyway, add `"forceResearch": true` to the payload.
+The run first scores the baseline. If the baseline aggregate `normalizedScore` is already greater than or equal to `target_score`, the harness emits `baseline-target-score-reached` and stops before creating `workspace/iterations/1` or calling the researcher. To intentionally run improvements anyway, add `--force-research`.
 
 When research proceeds, the run stops when either:
 
@@ -514,7 +501,7 @@ Key questions:
 Use resume mode after a provider error, network failure, quota limit, or interrupted process:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"resume":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-resume"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --resume
 ```
 
 Resume walks the run in order and validates artifacts before trusting them:
@@ -528,20 +515,30 @@ Resume walks the run in order and validates artifacts before trusting them:
 
 Incomplete candidate research and producer output directories that are safe to retry are moved under `workspace/resume-backups/` before that phase runs again, preserving the interrupted artifacts for audit.
 
-`resume:true` without `withBaseline` recovers a baseline that the harness was generating when it failed. `resume:true` with `withBaseline:true` keeps the strict imported-baseline behavior, then recovers research iterations.
+The config-driven resume command keeps the strict imported-baseline behavior, then recovers research iterations. Recovering an interrupted initial baseline remains available through the advanced payload form with `resume:true` and without `withBaseline`.
 
 Resume assumes that `config.json`, eval cases, input, reference material, models, and seed skill have not changed since the interrupted run. There is not yet a run manifest that fingerprints those inputs. Start a fresh run after changing them.
 
 The cost summary and actual call counts written by a resumed invocation describe that invocation, while the call preview remains the configured maximum. Consult earlier transcripts and provider records for costs from previous failed attempts.
 
-To intentionally rerun research from an imported baseline, pass `"withCleanup":true`:
+To intentionally rerun research from an imported baseline, pass `--with-cleanup`:
 
 ```bash
-varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"withCleanup":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research-clean"}'
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
 ```
 
 Cleanup removes `workspace/iterations`, `workspace/resume-backups`, and `workspace/guidance-ledger.json` as a true clean slate for research. It deliberately preserves `workspace/baseline`, configuration, evals, inputs, references, and skills. The conservative exclusive-create behavior remains the default when `withCleanup` is omitted. Do not combine cleanup with resume: cleanup discards the artifacts that resume needs.
 
-The standalone CLI uses the equivalent `--with-cleanup` flag. If the harness generated the baseline and you also intend to replace it, remove `workspace/baseline` separately before the run.
+If the harness generated the baseline and you also intend to replace it, remove `workspace/baseline` separately before the run.
 
 Keep committed fixtures baseline-only unless you intentionally want to preserve a specific alpha run artifact.
+
+## Advanced Direct Flue Invocation
+
+The wrapper still accepts a complete payload when you need uncommon workflow fields or are debugging:
+
+```bash
+varlock run -- pnpm run flue:run -- --payload '{"projectRoot":"path/to/my-autoresearch-project","withBaseline":true,"runResearch":true,"seedSkillDir":"path/to/my-autoresearch-project/seed-skill","sessionId":"my-research"}'
+```
+
+Direct `pnpm exec flue run autoresearch --target node --root . --payload '...'` also remains available and retains Flue's unfiltered event stream. Payload fields use the camel-case names accepted by `.flue/workflows/autoresearch.ts`, including `projectRoot`, `withBaseline`, `runResearch`, `forceResearch`, `resume`, `withCleanup`, `seedSkillDir`, `guidanceSkillDir`, `budgetUsd`, and `sessionId`.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -172,7 +172,7 @@ Imported baseline smoke runs with `withBaseline:true` plan no baseline producer 
 Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pass `--budget-usd <amount>` for a one-off override:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --budget-usd 0.5
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project --budget-usd 0.5
 ```
 
 The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue runs currently record call counts, but they do not expose token usage to this harness, so dollar-cost caps only take effect when usage and known pricing are available. Treat the dollar estimate as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
@@ -202,7 +202,7 @@ For example, this config default improves the audit skill:
 To improve the authoring skill without editing `config.json`, keep the config default as-is and pass a concise override:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research \
+pnpm run autoresearch -- research \
   --project path/to/skills-autoresearch-security \
   --seed-skill path/to/skills-autoresearch-security/skills/secure-authoring
 ```
@@ -452,15 +452,15 @@ pnpm run alpha:research
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
-`varlock run --` makes model credentials available. The command reads the default seed skill from `origin_skill` and all model assignments and limits from `config.json`.
+The `autoresearch` script loads model credentials through Varlock. The command reads the default seed skill from `origin_skill` and all model assignments and limits from `config.json`.
 
 For a multi-skill project, use the concise seed override:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research \
+pnpm run autoresearch -- research \
   --project path/to/skills-autoresearch-security \
   --seed-skill path/to/skills-autoresearch-security/skills/security-audit
 ```
@@ -501,7 +501,7 @@ Key questions:
 Use resume mode after a provider error, network failure, quota limit, or interrupted process:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --resume
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project --resume
 ```
 
 Resume walks the run in order and validates artifacts before trusting them:
@@ -524,7 +524,7 @@ The cost summary and actual call counts written by a resumed invocation describe
 To intentionally rerun research from an imported baseline, pass `--with-cleanup`:
 
 ```bash
-varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
+pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
 ```
 
 Cleanup removes `workspace/iterations`, `workspace/resume-backups`, and `workspace/guidance-ledger.json` as a true clean slate for research. It deliberately preserves `workspace/baseline`, configuration, evals, inputs, references, and skills. The conservative exclusive-create behavior remains the default when `withCleanup` is omitted. Do not combine cleanup with resume: cleanup discards the artifacts that resume needs.

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -172,7 +172,7 @@ Imported baseline smoke runs with `withBaseline:true` plan no baseline producer 
 Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pass `--budget-usd <amount>` for a one-off override:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project --budget-usd 0.5
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --budget-usd 0.5
 ```
 
 The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue runs currently record call counts, but they do not expose token usage to this harness, so dollar-cost caps only take effect when usage and known pricing are available. Treat the dollar estimate as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
@@ -202,7 +202,7 @@ For example, this config default improves the audit skill:
 To improve the authoring skill without editing `config.json`, keep the config default as-is and pass a concise override:
 
 ```bash
-pnpm run autoresearch -- research \
+varlock run -- pnpm run autoresearch -- research \
   --project path/to/skills-autoresearch-security \
   --seed-skill path/to/skills-autoresearch-security/skills/secure-authoring
 ```
@@ -452,15 +452,15 @@ pnpm run alpha:research
 For your own project, run the following from the root of a local `skills-autoresearch-flue` checkout:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project
 ```
 
-The `autoresearch` script loads model credentials through Varlock. The command reads the default seed skill from `origin_skill` and all model assignments and limits from `config.json`.
+`varlock run --` makes model credentials available. The command reads the default seed skill from `origin_skill` and all model assignments and limits from `config.json`.
 
 For a multi-skill project, use the concise seed override:
 
 ```bash
-pnpm run autoresearch -- research \
+varlock run -- pnpm run autoresearch -- research \
   --project path/to/skills-autoresearch-security \
   --seed-skill path/to/skills-autoresearch-security/skills/security-audit
 ```
@@ -501,7 +501,7 @@ Key questions:
 Use resume mode after a provider error, network failure, quota limit, or interrupted process:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project --resume
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --resume
 ```
 
 Resume walks the run in order and validates artifacts before trusting them:
@@ -524,7 +524,7 @@ The cost summary and actual call counts written by a resumed invocation describe
 To intentionally rerun research from an imported baseline, pass `--with-cleanup`:
 
 ```bash
-pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
+varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --with-cleanup
 ```
 
 Cleanup removes `workspace/iterations`, `workspace/resume-backups`, and `workspace/guidance-ledger.json` as a true clean slate for research. It deliberately preserves `workspace/baseline`, configuration, evals, inputs, references, and skills. The conservative exclusive-create behavior remains the default when `withCleanup` is omitted. Do not combine cleanup with resume: cleanup discards the artifacts that resume needs.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "check": "pnpm run format:check && pnpm run lint && pnpm run knip && pnpm run typecheck && pnpm test && pnpm run build && pnpm run flue:build && pnpm run alpha:smoke",
     "build": "tsc -p tsconfig.json",
-    "autoresearch": "pnpm run build && node dist/src/flue-runner.js",
+    "autoresearch": "pnpm run build && varlock run -- node dist/src/flue-runner.js",
     "flue:run": "pnpm run build && node dist/src/flue-runner.js",
     "flue:build": "flue build --target node --root . --output .flue-dist",
     "alpha:smoke": "pnpm run autoresearch -- smoke --project fixtures/projects/release-notes-alpha --session alpha-smoke",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "check": "pnpm run format:check && pnpm run lint && pnpm run knip && pnpm run typecheck && pnpm test && pnpm run build && pnpm run flue:build && pnpm run alpha:smoke",
     "build": "tsc -p tsconfig.json",
-    "autoresearch": "pnpm run build && varlock run -- node dist/src/flue-runner.js",
+    "autoresearch": "pnpm run build && node dist/src/flue-runner.js",
     "flue:run": "pnpm run build && node dist/src/flue-runner.js",
     "flue:build": "flue build --target node --root . --output .flue-dist",
     "alpha:smoke": "pnpm run autoresearch -- smoke --project fixtures/projects/release-notes-alpha --session alpha-smoke",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "typecheck": "tsc --noEmit",
     "check": "pnpm run format:check && pnpm run lint && pnpm run knip && pnpm run typecheck && pnpm test && pnpm run build && pnpm run flue:build && pnpm run alpha:smoke",
     "build": "tsc -p tsconfig.json",
+    "autoresearch": "pnpm run build && node dist/src/flue-runner.js",
     "flue:run": "pnpm run build && node dist/src/flue-runner.js",
     "flue:build": "flue build --target node --root . --output .flue-dist",
-    "alpha:smoke": "pnpm run build && node dist/src/flue-runner.js --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":false,\"sessionId\":\"alpha-smoke\"}'",
-    "alpha:research": "pnpm run build && varlock run -- node dist/src/flue-runner.js --payload '{\"projectRoot\":\"fixtures/projects/release-notes-alpha\",\"withBaseline\":true,\"runResearch\":true,\"seedSkillDir\":\"fixtures/projects/release-notes-alpha/seed-skill\",\"sessionId\":\"alpha-research\"}'",
+    "alpha:smoke": "pnpm run autoresearch -- smoke --project fixtures/projects/release-notes-alpha --session alpha-smoke",
+    "alpha:research": "pnpm run build && varlock run -- node dist/src/flue-runner.js research --project fixtures/projects/release-notes-alpha --session alpha-research",
     "env:check": "varlock load"
   },
   "dependencies": {

--- a/src/flue-runner.ts
+++ b/src/flue-runner.ts
@@ -1,20 +1,52 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import type { FlueWorkflowResult } from "./flue-harness.js";
 import { createRunLog, RunLog } from "./run-log.js";
 
-type RunnerOptions = {
+export type RunnerMode = "smoke" | "research";
+
+export type RunnerOptions = {
   verbose: boolean;
   writeRunLog: boolean;
   payload: Record<string, unknown>;
+  help?: boolean;
 };
 
 const QUIET_STDOUT_MAX_CHARS = 1_048_576;
 
+function usage(): string {
+  return [
+    "Usage:",
+    "  skills-autoresearch-flue smoke [options]",
+    "  skills-autoresearch-flue research [options]",
+    "  skills-autoresearch-flue --payload <json> [options]",
+    "",
+    "Config-driven options:",
+    "  --project <dir>         Project root. Defaults to current directory.",
+    "  --seed-skill <dir>      Override config.json origin_skill for this run.",
+    "  --guidance-skill <dir>  Override config.json guidance_skill for this run.",
+    "  --session <name>        Override the derived project-mode session name.",
+    "  --resume                Resume validated artifacts from an interrupted run.",
+    "  --with-cleanup          Remove generated research artifacts before a fresh run.",
+    "  --force-research        Research even when the baseline reaches target_score.",
+    "  --budget-usd <amount>   Override config.json budget_usd for this run.",
+    "",
+    "General options:",
+    "  --payload <json>        Advanced: pass a complete Flue payload directly.",
+    "  --verbose               Print the complete Flue event stream.",
+    "  --no-run-log            Do not write the complete local run log.",
+    "  -h, --help              Show this help."
+  ].join("\n");
+}
+
 export async function runFlueCommand(argv = process.argv.slice(2)): Promise<number> {
   const options = parseRunnerArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
   const projectRoot = resolve(String(options.payload.projectRoot ?? process.cwd()));
   const sessionId = String(options.payload.sessionId ?? "autoresearch");
   const runLog = options.writeRunLog ? createRunLog(projectRoot, sessionId) : undefined;
@@ -39,22 +71,128 @@ export async function runFlueCommand(argv = process.argv.slice(2)): Promise<numb
 }
 
 export function parseRunnerArgs(argv: string[]): RunnerOptions {
-  const { values } = parseArgs({
-    args: argv,
+  const runnerArgv = argv[0] === "--" ? argv.slice(1) : argv;
+  const { values, positionals } = parseArgs({
+    args: runnerArgv,
     options: {
       verbose: { type: "boolean" },
       "no-run-log": { type: "boolean" },
-      payload: { type: "string" }
+      payload: { type: "string" },
+      project: { type: "string" },
+      "seed-skill": { type: "string" },
+      "guidance-skill": { type: "string" },
+      session: { type: "string" },
+      resume: { type: "boolean" },
+      "with-cleanup": { type: "boolean" },
+      "force-research": { type: "boolean" },
+      "budget-usd": { type: "string" },
+      help: { type: "boolean", short: "h" }
     },
     strict: true,
-    allowPositionals: false
+    allowPositionals: true
   });
 
+  if (values.help) {
+    return {
+      verbose: values.verbose ?? false,
+      writeRunLog: !(values["no-run-log"] ?? false),
+      payload: {},
+      help: true
+    };
+  }
+
+  const configOptionsUsed = [
+    values.project,
+    values["seed-skill"],
+    values["guidance-skill"],
+    values.session,
+    values.resume,
+    values["with-cleanup"],
+    values["force-research"],
+    values["budget-usd"]
+  ].some((value) => value !== undefined);
+
+  if (values.payload !== undefined) {
+    if (positionals.length > 0 || configOptionsUsed) {
+      throw new Error("Use either a smoke/research command or --payload, not both.");
+    }
+    return {
+      verbose: values.verbose ?? false,
+      writeRunLog: !(values["no-run-log"] ?? false),
+      payload: parsePayload(values.payload)
+    };
+  }
+
+  if (positionals.length !== 1 || !isRunnerMode(positionals[0])) {
+    throw new Error("Choose a config-driven command: smoke or research. Use --help for usage.");
+  }
+
+  const mode = positionals[0];
   return {
     verbose: values.verbose ?? false,
     writeRunLog: !(values["no-run-log"] ?? false),
-    payload: JSON.parse(values.payload ?? "{}") as Record<string, unknown>
+    payload: buildConfigDrivenPayload(mode, {
+      projectRoot: values.project,
+      seedSkillDir: values["seed-skill"],
+      guidanceSkillDir: values["guidance-skill"],
+      sessionId: values.session,
+      resume: values.resume,
+      withCleanup: values["with-cleanup"],
+      forceResearch: values["force-research"],
+      budgetUsd: parseBudgetUsd(values["budget-usd"])
+    })
   };
+}
+
+export function buildConfigDrivenPayload(
+  mode: RunnerMode,
+  options: {
+    projectRoot?: string;
+    seedSkillDir?: string;
+    guidanceSkillDir?: string;
+    sessionId?: string;
+    resume?: boolean;
+    withCleanup?: boolean;
+    forceResearch?: boolean;
+    budgetUsd?: number;
+  } = {}
+): Record<string, unknown> {
+  const projectRoot = resolve(options.projectRoot ?? process.cwd());
+  return {
+    projectRoot,
+    withBaseline: true,
+    runResearch: mode === "research",
+    sessionId: options.sessionId ?? `${basename(projectRoot)}-${mode}`,
+    ...(options.seedSkillDir ? { seedSkillDir: options.seedSkillDir } : {}),
+    ...(options.guidanceSkillDir ? { guidanceSkillDir: options.guidanceSkillDir } : {}),
+    ...(options.resume ? { resume: true } : {}),
+    ...(options.withCleanup ? { withCleanup: true } : {}),
+    ...(options.forceResearch ? { forceResearch: true } : {}),
+    ...(options.budgetUsd === undefined ? {} : { budgetUsd: options.budgetUsd })
+  };
+}
+
+function isRunnerMode(value: string): value is RunnerMode {
+  return value === "smoke" || value === "research";
+}
+
+function parsePayload(value: string): Record<string, unknown> {
+  const payload = JSON.parse(value) as unknown;
+  if (payload === null || Array.isArray(payload) || typeof payload !== "object") {
+    throw new Error("--payload must be a JSON object.");
+  }
+  return payload as Record<string, unknown>;
+}
+
+function parseBudgetUsd(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error("--budget-usd must be a non-negative number.");
+  }
+  return parsed;
 }
 
 export function buildFlueArgs(payload: Record<string, unknown>): string[] {

--- a/src/flue-runner.ts
+++ b/src/flue-runner.ts
@@ -188,6 +188,9 @@ function parseBudgetUsd(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
   }
+  if (value.trim() === "") {
+    throw new Error("--budget-usd must be a non-negative number.");
+  }
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) {
     throw new Error("--budget-usd must be a non-negative number.");

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import {
   appendQuietStdout,
@@ -16,6 +17,16 @@ test("Flue runner parses verbose and run-log opt-out flags without forwarding th
     writeRunLog: false,
     payload: { projectRoot: "/tmp/project", sessionId: "test" }
   });
+});
+
+test("package scripts keep model-free smoke credential-free", () => {
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+    scripts: Record<string, string>;
+  };
+
+  expect(packageJson.scripts.autoresearch).toBe("pnpm run build && node dist/src/flue-runner.js");
+  expect(packageJson.scripts["alpha:smoke"]).toContain("pnpm run autoresearch");
+  expect(packageJson.scripts["alpha:research"]).toContain("varlock run --");
 });
 
 test("Flue runner builds a config-driven baseline smoke command", () => {

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import {
   appendQuietStdout,
   buildConfigDrivenPayload,
@@ -69,7 +70,7 @@ test("config-driven commands default to the current project and derive a stable 
     projectRoot: process.cwd(),
     withBaseline: true,
     runResearch: true,
-    sessionId: `${process.cwd().split("/").at(-1)}-research`
+    sessionId: `${basename(process.cwd())}-research`
   });
 });
 
@@ -84,6 +85,8 @@ test("Flue runner rejects ambiguous modes and invalid concise overrides", () => 
   expect(() => parseRunnerArgs(["unknown"])).toThrow(/smoke or research/);
   expect(() => parseRunnerArgs(["research", "--payload", "{}"])).toThrow(/either/);
   expect(() => parseRunnerArgs(["research", "--budget-usd=-1"])).toThrow(/non-negative/);
+  expect(() => parseRunnerArgs(["research", "--budget-usd", ""])).toThrow(/non-negative/);
+  expect(() => parseRunnerArgs(["research", "--budget-usd", "   "])).toThrow(/non-negative/);
   expect(() => parseRunnerArgs(["--payload", "[]"])).toThrow(/JSON object/);
 });
 

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -1,5 +1,6 @@
 import {
   appendQuietStdout,
+  buildConfigDrivenPayload,
   buildFlueArgs,
   formatQuietResult,
   parseRunnerArgs,
@@ -14,6 +15,76 @@ test("Flue runner parses verbose and run-log opt-out flags without forwarding th
     writeRunLog: false,
     payload: { projectRoot: "/tmp/project", sessionId: "test" }
   });
+});
+
+test("Flue runner builds a config-driven baseline smoke command", () => {
+  expect(parseRunnerArgs(["--", "smoke", "--project", "/tmp/project"])).toEqual({
+    verbose: false,
+    writeRunLog: true,
+    payload: {
+      projectRoot: "/tmp/project",
+      withBaseline: true,
+      runResearch: false,
+      sessionId: "project-smoke"
+    }
+  });
+});
+
+test("Flue runner builds a config-driven research command with concise overrides", () => {
+  expect(
+    parseRunnerArgs([
+      "research",
+      "--project",
+      "/tmp/project",
+      "--seed-skill",
+      "/tmp/alternate-skill",
+      "--guidance-skill",
+      "/tmp/guidance",
+      "--session",
+      "retry",
+      "--resume",
+      "--force-research",
+      "--budget-usd",
+      "0.25"
+    ])
+  ).toEqual({
+    verbose: false,
+    writeRunLog: true,
+    payload: {
+      projectRoot: "/tmp/project",
+      withBaseline: true,
+      runResearch: true,
+      sessionId: "retry",
+      seedSkillDir: "/tmp/alternate-skill",
+      guidanceSkillDir: "/tmp/guidance",
+      resume: true,
+      forceResearch: true,
+      budgetUsd: 0.25
+    }
+  });
+});
+
+test("config-driven commands default to the current project and derive a stable session", () => {
+  expect(buildConfigDrivenPayload("research")).toMatchObject({
+    projectRoot: process.cwd(),
+    withBaseline: true,
+    runResearch: true,
+    sessionId: `${process.cwd().split("/").at(-1)}-research`
+  });
+});
+
+test("Flue runner keeps direct payload invocation as an advanced path", () => {
+  expect(parseRunnerArgs(["--payload", '{"projectRoot":"/tmp/project","runResearch":false}'])).toMatchObject({
+    payload: { projectRoot: "/tmp/project", runResearch: false }
+  });
+});
+
+test("Flue runner rejects ambiguous modes and invalid concise overrides", () => {
+  expect(() => parseRunnerArgs([])).toThrow(/smoke or research/);
+  expect(() => parseRunnerArgs(["unknown"])).toThrow(/smoke or research/);
+  expect(() => parseRunnerArgs(["research", "--payload", "{}"])).toThrow(/either/);
+  expect(() => parseRunnerArgs(["research", "--budget-usd=-1"])).toThrow(/non-negative/);
+  expect(() => parseRunnerArgs(["--payload", "[]"])).toThrow(/JSON object/);
 });
 
 test("Flue runner emits exactly one canonical payload argument", () => {


### PR DESCRIPTION
## Summary

- Add concise `smoke` and `research` runner commands driven by project configuration.
- Support project, skill, session, resume, cleanup, force-research, and budget overrides.
- Update README and usage documentation while preserving advanced payload invocation.

## Testing

- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `autoresearch` entry point that runs model-free smoke and model-backed research in config-driven phases (with session-based runs).
  * Enhanced the CLI with `--project`, `--seed-skill`, `--budget-usd`, `--resume`, `--with-cleanup`, `--force-research`, and unified help/usage output.
  * Continued to support advanced `--payload` execution for expert use.

* **Documentation**
  * Updated README and harness/use-case guides to prefer the wrapper-first `pnpm run autoresearch` flow and revised stop/force/resume/cleanup instructions.

* **Tests**
  * Expanded parsing and payload/validation test coverage, including script wiring for credential-free smoke.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->