### PR TITLE
Add deterministic analysis artifacts

### DIFF
--- a/src/determinization/analyzer.ts
+++ b/src/determinization/analyzer.ts
@@ -1,0 +1,206 @@
+import type { DeterministicAssetCatalog } from "./catalog.js";
+import { validateCatalogReferences } from "./catalog.js";
+import { compareCodePoints } from "./canonical.js";
+import { createOpportunityId, createRecommendationId } from "./ids.js";
+import {
+  DETERMINIZATION_SCHEMA_VERSION,
+  parseAnalysisOpportunities,
+  type AnalysisOpportunitiesDocument
+} from "./schemas.js";
+
+type JsonObject = Record<string, unknown>;
+
+const OPPORTUNITY_KEYS = new Set([
+  "source_refs",
+  "normalized_requirement",
+  "origin",
+  "classification",
+  "current_automation_potential",
+  "remaining_human_judgment",
+  "recommendations",
+  "confidence",
+  "expected_improvement",
+  "supporting_evidence",
+  "limitations"
+]);
+const RECOMMENDATION_KEYS = new Set([
+  "relationship",
+  "asset_kind",
+  "catalog_asset_id",
+  "proposed_name",
+  "contribution",
+  "confidence",
+  "expected_improvement",
+  "supporting_evidence",
+  "limitations",
+  "alternative_assessments",
+  "insufficiency_justification"
+]);
+const SOURCE_REFERENCE_KEYS = new Set(["path", "locator", "evidence_kind"]);
+
+function object(value: unknown, label: string): JsonObject {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
+  return value as JsonObject;
+}
+
+function exactKeys(value: JsonObject, allowed: Set<string>, label: string): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unknown.length > 0) throw new Error(`${label} contains unsupported fields: ${unknown.sort().join(", ")}`);
+}
+
+function unverifiedText(value: unknown, label: string): unknown {
+  return typeof value === "string" ? `${label}: ${value}` : value;
+}
+
+function unverifiedList(value: unknown, label: string): unknown {
+  return Array.isArray(value) ? value.map((item) => unverifiedText(item, label)) : value;
+}
+
+function normalizeSourceReferences(value: unknown[], opportunityIndex: number) {
+  return value
+    .map((rawReference, referenceIndex) => {
+      const reference = object(rawReference, `Source reference ${opportunityIndex}.${referenceIndex}`);
+      exactKeys(reference, SOURCE_REFERENCE_KEYS, `Source reference ${opportunityIndex}.${referenceIndex}`);
+      if (
+        typeof reference.path !== "string" ||
+        typeof reference.evidence_kind !== "string" ||
+        (reference.locator !== undefined && typeof reference.locator !== "string")
+      ) {
+        throw new Error(`Source reference ${opportunityIndex}.${referenceIndex} has invalid field types`);
+      }
+      return {
+        path: reference.path,
+        ...(reference.locator !== undefined && { locator: reference.locator }),
+        evidence_kind: reference.evidence_kind
+      };
+    })
+    .sort((left, right) =>
+      compareCodePoints(
+        `${left.path}\u0000${left.locator ?? ""}\u0000${left.evidence_kind}`,
+        `${right.path}\u0000${right.locator ?? ""}\u0000${right.evidence_kind}`
+      )
+    );
+}
+
+function assertOpportunityProvenance(document: AnalysisOpportunitiesDocument): void {
+  for (const opportunity of document.opportunities) {
+    for (const reference of opportunity.source_refs) {
+      const namespace = reference.path.split("/", 1)[0];
+      if (namespace !== reference.evidence_kind) {
+        throw new Error(
+          `Source reference namespace ${namespace} does not match evidence kind ${reference.evidence_kind}`
+        );
+      }
+    }
+    const hasSkill = opportunity.source_refs.some(({ evidence_kind }) => evidence_kind === "skill");
+    const hasEvaluation = opportunity.source_refs.some(({ evidence_kind }) => evidence_kind === "evaluation");
+    const validOrigin =
+      (opportunity.origin === "skill_guidance" && hasSkill && !hasEvaluation) ||
+      (opportunity.origin === "evaluation_evidence" && hasEvaluation && !hasSkill) ||
+      (opportunity.origin === "both" && hasSkill && hasEvaluation);
+    if (!validOrigin) {
+      throw new Error(`Opportunity ${opportunity.id} origin is inconsistent with skill/evaluation provenance`);
+    }
+  }
+}
+
+/** Converts untrusted transport output into the sole PR1A canonical analysis contract. */
+export function normalizeAnalysisResponse(
+  response: unknown,
+  catalog: DeterministicAssetCatalog
+): AnalysisOpportunitiesDocument {
+  const root = object(response, "Analysis response");
+  exactKeys(root, new Set(["schema_version", "opportunities"]), "Analysis response");
+  if (root.schema_version !== DETERMINIZATION_SCHEMA_VERSION)
+    throw new Error("Unsupported analysis response schema version");
+  if (!Array.isArray(root.opportunities)) throw new Error("Analysis response opportunities must be an array");
+  const catalogAssets = new Map(catalog.assets.map((asset) => [asset.id, asset]));
+
+  const opportunities = root.opportunities.map((rawOpportunity, opportunityIndex) => {
+    const opportunity = object(rawOpportunity, `Opportunity ${opportunityIndex}`);
+    exactKeys(opportunity, OPPORTUNITY_KEYS, `Opportunity ${opportunityIndex}`);
+    if (!Array.isArray(opportunity.source_refs))
+      throw new Error(`Opportunity ${opportunityIndex} source_refs must be an array`);
+    const sourceRefs = normalizeSourceReferences(opportunity.source_refs, opportunityIndex);
+    if (typeof opportunity.normalized_requirement !== "string") {
+      throw new Error(`Opportunity ${opportunityIndex} normalized_requirement must be text`);
+    }
+    const id = createOpportunityId({
+      normalized_requirement: opportunity.normalized_requirement,
+      source_refs: sourceRefs
+    });
+    if (!Array.isArray(opportunity.recommendations)) {
+      throw new Error(`Opportunity ${opportunityIndex} recommendations must be an array`);
+    }
+    const recommendations = opportunity.recommendations.map((rawRecommendation, recommendationIndex) => {
+      const recommendation = object(rawRecommendation, `Recommendation ${opportunityIndex}.${recommendationIndex}`);
+      exactKeys(recommendation, RECOMMENDATION_KEYS, `Recommendation ${opportunityIndex}.${recommendationIndex}`);
+      const catalogAsset =
+        typeof recommendation.catalog_asset_id === "string"
+          ? catalogAssets.get(recommendation.catalog_asset_id)
+          : undefined;
+      const alternativeAssessments = Array.isArray(recommendation.alternative_assessments)
+        ? recommendation.alternative_assessments.map((rawAssessment) => {
+            const assessment = object(
+              rawAssessment,
+              `Alternative assessment ${opportunityIndex}.${recommendationIndex}`
+            );
+            return {
+              ...assessment,
+              rationale: unverifiedText(assessment.rationale, "Unverified analyzer rationale")
+            };
+          })
+        : recommendation.alternative_assessments;
+      return {
+        ...recommendation,
+        id: createRecommendationId({
+          asset_kind: String(recommendation.asset_kind),
+          catalog_asset_id:
+            recommendation.catalog_asset_id === undefined ? undefined : String(recommendation.catalog_asset_id),
+          opportunity_id: id,
+          proposed_name: recommendation.proposed_name === undefined ? undefined : String(recommendation.proposed_name),
+          relationship: String(recommendation.relationship)
+        }),
+        ...(catalogAsset
+          ? {
+              proposed_name: catalogAsset.name,
+              contribution: catalogAsset.contribution,
+              expected_improvement:
+                "Potential improvement requires later evidence and verification; catalog metadata establishes only the stated capability contribution.",
+              supporting_evidence: [`Catalog capability evidence basis: ${catalogAsset.evidence_basis}`],
+              limitations: catalogAsset.limitations.map((limitation) => `Catalog capability limitation: ${limitation}`)
+            }
+          : {
+              contribution: unverifiedText(recommendation.contribution, "Unverified analyzer hypothesis"),
+              expected_improvement: unverifiedText(recommendation.expected_improvement, "Unverified analyzer estimate"),
+              supporting_evidence: unverifiedList(recommendation.supporting_evidence, "Unverified analyzer rationale"),
+              limitations: unverifiedList(recommendation.limitations, "Unverified analyzer limitation")
+            }),
+        alternative_assessments: alternativeAssessments,
+        ...(recommendation.insufficiency_justification !== undefined && {
+          insufficiency_justification: unverifiedText(
+            recommendation.insufficiency_justification,
+            "Unverified analyzer justification"
+          )
+        }),
+        lifecycle_status: "suggested"
+      };
+    });
+    return {
+      ...opportunity,
+      id,
+      source_refs: sourceRefs,
+      remaining_human_judgment: unverifiedText(opportunity.remaining_human_judgment, "Unverified analyzer judgment"),
+      expected_improvement: unverifiedText(opportunity.expected_improvement, "Unverified analyzer estimate"),
+      supporting_evidence: unverifiedList(opportunity.supporting_evidence, "Unverified analyzer rationale"),
+      limitations: unverifiedList(opportunity.limitations, "Unverified analyzer limitation"),
+      recommendations,
+      lifecycle_status: "suggested"
+    };
+  });
+  const document = parseAnalysisOpportunities({ schema_version: DETERMINIZATION_SCHEMA_VERSION, opportunities });
+  validateCatalogReferences(document, catalog);
+  assertOpportunityProvenance(document);
+  return document;
+}

--- a/src/determinization/analyzer.ts
+++ b/src/determinization/analyzer.ts
@@ -36,9 +36,10 @@ const RECOMMENDATION_KEYS = new Set([
   "alternative_assessments",
   "insufficiency_justification"
 ]);
+const ALTERNATIVE_ASSESSMENT_KEYS = new Set(["relationship", "catalog_asset_ids", "conclusion", "rationale"]);
 const SOURCE_REFERENCE_KEYS = new Set(["path", "locator", "evidence_kind"]);
 
-function object(value: unknown, label: string): JsonObject {
+function requireJsonObject(value: unknown, label: string): JsonObject {
   if (value === null || typeof value !== "object" || Array.isArray(value))
     throw new Error(`${label} must be an object`);
   return value as JsonObject;
@@ -60,7 +61,7 @@ function unverifiedList(value: unknown, label: string): unknown {
 function normalizeSourceReferences(value: unknown[], opportunityIndex: number) {
   return value
     .map((rawReference, referenceIndex) => {
-      const reference = object(rawReference, `Source reference ${opportunityIndex}.${referenceIndex}`);
+      const reference = requireJsonObject(rawReference, `Source reference ${opportunityIndex}.${referenceIndex}`);
       exactKeys(reference, SOURCE_REFERENCE_KEYS, `Source reference ${opportunityIndex}.${referenceIndex}`);
       if (
         typeof reference.path !== "string" ||
@@ -70,7 +71,7 @@ function normalizeSourceReferences(value: unknown[], opportunityIndex: number) {
         throw new Error(`Source reference ${opportunityIndex}.${referenceIndex} has invalid field types`);
       }
       return {
-        path: reference.path,
+        path: reference.path.normalize("NFC"),
         ...(reference.locator !== undefined && { locator: reference.locator }),
         evidence_kind: reference.evidence_kind
       };
@@ -110,7 +111,7 @@ export function normalizeAnalysisResponse(
   response: unknown,
   catalog: DeterministicAssetCatalog
 ): AnalysisOpportunitiesDocument {
-  const root = object(response, "Analysis response");
+  const root = requireJsonObject(response, "Analysis response");
   exactKeys(root, new Set(["schema_version", "opportunities"]), "Analysis response");
   if (root.schema_version !== DETERMINIZATION_SCHEMA_VERSION)
     throw new Error("Unsupported analysis response schema version");
@@ -118,7 +119,7 @@ export function normalizeAnalysisResponse(
   const catalogAssets = new Map(catalog.assets.map((asset) => [asset.id, asset]));
 
   const opportunities = root.opportunities.map((rawOpportunity, opportunityIndex) => {
-    const opportunity = object(rawOpportunity, `Opportunity ${opportunityIndex}`);
+    const opportunity = requireJsonObject(rawOpportunity, `Opportunity ${opportunityIndex}`);
     exactKeys(opportunity, OPPORTUNITY_KEYS, `Opportunity ${opportunityIndex}`);
     if (!Array.isArray(opportunity.source_refs))
       throw new Error(`Opportunity ${opportunityIndex} source_refs must be an array`);
@@ -134,33 +135,54 @@ export function normalizeAnalysisResponse(
       throw new Error(`Opportunity ${opportunityIndex} recommendations must be an array`);
     }
     const recommendations = opportunity.recommendations.map((rawRecommendation, recommendationIndex) => {
-      const recommendation = object(rawRecommendation, `Recommendation ${opportunityIndex}.${recommendationIndex}`);
+      const recommendation = requireJsonObject(
+        rawRecommendation,
+        `Recommendation ${opportunityIndex}.${recommendationIndex}`
+      );
       exactKeys(recommendation, RECOMMENDATION_KEYS, `Recommendation ${opportunityIndex}.${recommendationIndex}`);
-      const catalogAsset =
-        typeof recommendation.catalog_asset_id === "string"
-          ? catalogAssets.get(recommendation.catalog_asset_id)
-          : undefined;
+      const relationship = recommendation.relationship;
+      const assetKind = recommendation.asset_kind;
+      const catalogAssetId = recommendation.catalog_asset_id;
+      const proposedName = recommendation.proposed_name;
+      if (typeof relationship !== "string" || typeof assetKind !== "string") {
+        throw new Error(
+          `Recommendation ${opportunityIndex}.${recommendationIndex} relationship and asset_kind must be text`
+        );
+      }
+      if (catalogAssetId !== undefined && typeof catalogAssetId !== "string") {
+        throw new Error(`Recommendation ${opportunityIndex}.${recommendationIndex} catalog_asset_id must be text`);
+      }
+      if (proposedName !== undefined && typeof proposedName !== "string") {
+        throw new Error(`Recommendation ${opportunityIndex}.${recommendationIndex} proposed_name must be text`);
+      }
+      const catalogAsset = catalogAssetId === undefined ? undefined : catalogAssets.get(catalogAssetId);
       const alternativeAssessments = Array.isArray(recommendation.alternative_assessments)
         ? recommendation.alternative_assessments.map((rawAssessment) => {
-            const assessment = object(
+            const assessment = requireJsonObject(
               rawAssessment,
+              `Alternative assessment ${opportunityIndex}.${recommendationIndex}`
+            );
+            exactKeys(
+              assessment,
+              ALTERNATIVE_ASSESSMENT_KEYS,
               `Alternative assessment ${opportunityIndex}.${recommendationIndex}`
             );
             return {
               ...assessment,
-              rationale: unverifiedText(assessment.rationale, "Unverified analyzer rationale")
+              ...(assessment.rationale !== undefined && {
+                rationale: unverifiedText(assessment.rationale, "Unverified analyzer rationale")
+              })
             };
           })
         : recommendation.alternative_assessments;
       return {
         ...recommendation,
         id: createRecommendationId({
-          asset_kind: String(recommendation.asset_kind),
-          catalog_asset_id:
-            recommendation.catalog_asset_id === undefined ? undefined : String(recommendation.catalog_asset_id),
+          asset_kind: assetKind,
+          catalog_asset_id: catalogAssetId,
           opportunity_id: id,
-          proposed_name: recommendation.proposed_name === undefined ? undefined : String(recommendation.proposed_name),
-          relationship: String(recommendation.relationship)
+          proposed_name: proposedName,
+          relationship
         }),
         ...(catalogAsset
           ? {

--- a/src/determinization/artifacts.ts
+++ b/src/determinization/artifacts.ts
@@ -1,0 +1,253 @@
+import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { normalizeAnalysisResponse } from "./analyzer.js";
+import { serializeCanonical, sha256 } from "./canonical.js";
+import { loadDeterministicAssetCatalog } from "./catalog.js";
+import { renderDeterminizationReport } from "./report.js";
+import { renderResearchPrompt } from "./research-prompt.js";
+import { createResearchRequest, serializeResearchRequest, type DerivativeLineage } from "./research-request.js";
+import { withReadOnlyInputs } from "./read-only-snapshot.js";
+import { canonicalAnalysisSha256, orderAnalysisOpportunities, serializeAnalysisOpportunities } from "./schemas.js";
+import {
+  assertSourceManifestCurrent,
+  createSourceManifest,
+  serializeSourceManifest,
+  type AnalysisIdentity,
+  type SourceManifest,
+  type SourceSelection
+} from "./source.js";
+
+export interface DeterminizationArtifactPaths {
+  root: string;
+  source: string;
+  opportunities: string;
+  report: string;
+  researchRequest: string;
+  researchPrompt: string;
+  transcript: string;
+}
+
+export interface WriteAnalysisArtifactsOptions {
+  outputRoot: string;
+  selections: SourceSelection[];
+  catalogIndexPath: string;
+  analysis?: AnalysisIdentity;
+  analysisResponse: unknown;
+  transcript?: { request: unknown; response: unknown };
+}
+
+const REQUIRED_CATALOG_PATHS = [
+  "catalog.json",
+  "javascript-typescript.json",
+  "language.json",
+  "markdown.json"
+] as const;
+
+function assertSelectedCatalogIndex(catalogIndexPath: string, selections: SourceSelection[]): void {
+  const index = resolve(catalogIndexPath);
+  const catalogSelections = selections.filter(({ namespace }) => namespace === "catalog");
+  if (catalogSelections.length !== 1) {
+    throw new Error("Exactly one complete catalog selection is required");
+  }
+  const selection = catalogSelections[0];
+  if (resolve(selection.root, "catalog.json") !== index) {
+    throw new Error("Catalog index must be catalog.json in the selected catalog root");
+  }
+  if (
+    selection.paths.length !== REQUIRED_CATALOG_PATHS.length ||
+    new Set(selection.paths).size !== selection.paths.length ||
+    REQUIRED_CATALOG_PATHS.some((path) => !selection.paths.includes(path))
+  ) {
+    throw new Error(
+      "Catalog selection must contain exactly catalog.json and every schema 1.0.0 domain file without duplicates"
+    );
+  }
+}
+
+export interface AnalysisArtifactResult {
+  paths: DeterminizationArtifactPaths;
+  opportunityCount: number;
+  recommendationCount: number;
+  sourceOpportunitiesSha256: string;
+  resumedFiles: string[];
+  createdFiles: string[];
+}
+
+function paths(outputRoot: string): DeterminizationArtifactPaths {
+  const root = resolve(outputRoot);
+  return {
+    root,
+    source: join(root, "source.json"),
+    opportunities: join(root, "opportunities.json"),
+    report: join(root, "report.md"),
+    researchRequest: join(root, "research-request.json"),
+    researchPrompt: join(root, "prompts", "research.md"),
+    transcript: join(root, "transcript.json")
+  };
+}
+
+async function projectedRealPath(path: string): Promise<string> {
+  let cursor = resolve(path);
+  const missingSegments: string[] = [];
+  for (;;) {
+    try {
+      return join(await realpath(cursor), ...missingSegments.reverse());
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+      const parent = dirname(cursor);
+      if (parent === cursor) throw error;
+      missingSegments.push(basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+async function assertOutputSeparate(outputRoot: string, selections: SourceSelection[]): Promise<void> {
+  const output = await projectedRealPath(outputRoot);
+  for (const selection of selections) {
+    const root = await realpath(selection.root);
+    const rel = relative(root, output);
+    if (!rel || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`))) {
+      throw new Error(`Artifact output root must not be inside a selected read-only root: ${selection.namespace}`);
+    }
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+async function assertSafeDirectoryChain(outputRoot: string, parent: string, requireExisting: boolean): Promise<void> {
+  const root = resolve(outputRoot);
+  const targetParent = resolve(parent);
+  const rel = relative(root, targetParent);
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`Artifact path escapes the caller-supplied output root: ${targetParent}`);
+  }
+  const components = [
+    root,
+    ...rel
+      .split(sep)
+      .filter(Boolean)
+      .map((_, index, parts) => join(root, ...parts.slice(0, index + 1)))
+  ];
+  for (const component of components) {
+    try {
+      const metadata = await lstat(component);
+      if (metadata.isSymbolicLink())
+        throw new Error(`Artifact directory component must not be a symlink: ${component}`);
+      if (!metadata.isDirectory()) throw new Error(`Artifact directory component must be a directory: ${component}`);
+    } catch (error) {
+      if (!requireExisting && isMissing(error)) return;
+      throw error;
+    }
+  }
+  const realRoot = await realpath(root);
+  const realParent = await realpath(targetParent);
+  const realRelative = relative(realRoot, realParent);
+  if (realRelative === ".." || realRelative.startsWith(`..${sep}`) || isAbsolute(realRelative)) {
+    throw new Error(`Artifact directory resolves outside the caller-supplied output root: ${targetParent}`);
+  }
+}
+
+async function assertSafeArtifactFile(path: string): Promise<void> {
+  try {
+    const metadata = await lstat(path);
+    if (metadata.isSymbolicLink()) throw new Error(`Artifact file must not be a symlink: ${path}`);
+    if (!metadata.isFile()) throw new Error(`Artifact path must be a regular file: ${path}`);
+  } catch (error) {
+    if (isMissing(error)) return;
+    throw error;
+  }
+}
+
+function assertKnownSourceReferences(
+  document: ReturnType<typeof orderAnalysisOpportunities>,
+  manifest: SourceManifest
+): void {
+  const selected = new Set(manifest.inputs.map(({ path }) => path));
+  for (const opportunity of document.opportunities) {
+    for (const reference of opportunity.source_refs) {
+      if (!selected.has(reference.path)) throw new Error(`Unknown selected source reference: ${reference.path}`);
+    }
+  }
+}
+
+async function ensureExactFile(outputRoot: string, path: string, contents: string): Promise<"created" | "resumed"> {
+  const parent = dirname(path);
+  await assertSafeDirectoryChain(outputRoot, parent, false);
+  await mkdir(parent, { recursive: true });
+  await assertSafeDirectoryChain(outputRoot, parent, true);
+  await assertSafeArtifactFile(path);
+  try {
+    await writeFile(path, contents, { encoding: "utf8", flag: "wx" });
+    return "created";
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+    await assertSafeDirectoryChain(outputRoot, parent, true);
+    await assertSafeArtifactFile(path);
+    const existing = await readFile(path, "utf8");
+    if (existing !== contents) {
+      throw new Error(`Existing determinization artifact does not match canonical bytes: ${path}`, { cause: error });
+    }
+    return "resumed";
+  }
+}
+
+function transcriptContents(lineage: DerivativeLineage, transcript: { request: unknown; response: unknown }): string {
+  const jsonCompatible = JSON.parse(JSON.stringify(transcript)) as { request: unknown; response: unknown };
+  return serializeCanonical({
+    ...lineage,
+    authority: "audit_only",
+    request: jsonCompatible.request,
+    response: jsonCompatible.response
+  });
+}
+
+/** Writes only hash-linked Stage A artifacts and safely resumes only byte-identical files. */
+export async function writeAnalysisArtifacts(options: WriteAnalysisArtifactsOptions): Promise<AnalysisArtifactResult> {
+  assertSelectedCatalogIndex(options.catalogIndexPath, options.selections);
+  await assertOutputSeparate(options.outputRoot, options.selections);
+  return withReadOnlyInputs(options.selections, async () => {
+    const artifactPaths = paths(options.outputRoot);
+    const manifest = await createSourceManifest(options.selections, options.analysis);
+    const catalog = await loadDeterministicAssetCatalog(options.catalogIndexPath);
+    const analysis = orderAnalysisOpportunities(normalizeAnalysisResponse(options.analysisResponse, catalog));
+    assertKnownSourceReferences(analysis, manifest);
+    const opportunitiesContents = serializeAnalysisOpportunities(analysis);
+    const opportunitiesHash = canonicalAnalysisSha256(analysis);
+    if (sha256(opportunitiesContents) !== opportunitiesHash)
+      throw new Error("Canonical opportunities byte hash mismatch");
+    const lineage: DerivativeLineage = {
+      schema_version: "1.0.0",
+      source_opportunities_sha256: opportunitiesHash,
+      opportunity_ids: analysis.opportunities.map(({ id }) => id)
+    };
+    const request = createResearchRequest(analysis, lineage);
+    const planned: Array<[string, string]> = [
+      [artifactPaths.source, serializeSourceManifest(manifest)],
+      [artifactPaths.opportunities, opportunitiesContents],
+      [artifactPaths.report, renderDeterminizationReport(analysis, lineage)],
+      [artifactPaths.researchRequest, serializeResearchRequest(request)],
+      [artifactPaths.researchPrompt, renderResearchPrompt(request)]
+    ];
+    if (options.transcript) planned.push([artifactPaths.transcript, transcriptContents(lineage, options.transcript)]);
+
+    const createdFiles: string[] = [];
+    const resumedFiles: string[] = [];
+    for (const [path, contents] of planned) {
+      await assertSourceManifestCurrent(manifest, options.selections);
+      const disposition = await ensureExactFile(artifactPaths.root, path, contents);
+      (disposition === "created" ? createdFiles : resumedFiles).push(path);
+    }
+    await assertSourceManifestCurrent(manifest, options.selections);
+    return {
+      paths: artifactPaths,
+      opportunityCount: analysis.opportunities.length,
+      recommendationCount: analysis.opportunities.reduce((count, item) => count + item.recommendations.length, 0),
+      sourceOpportunitiesSha256: opportunitiesHash,
+      resumedFiles,
+      createdFiles
+    };
+  });
+}

--- a/src/determinization/artifacts.ts
+++ b/src/determinization/artifacts.ts
@@ -8,6 +8,7 @@ import { renderResearchPrompt } from "./research-prompt.js";
 import { createResearchRequest, serializeResearchRequest, type DerivativeLineage } from "./research-request.js";
 import { withReadOnlyInputs } from "./read-only-snapshot.js";
 import { canonicalAnalysisSha256, orderAnalysisOpportunities, serializeAnalysisOpportunities } from "./schemas.js";
+import { validateCanonicalAnalysis } from "./validation.js";
 import {
   assertSourceManifestCurrent,
   createSourceManifest,
@@ -33,7 +34,16 @@ export interface WriteAnalysisArtifactsOptions {
   catalogIndexPath: string;
   analysis?: AnalysisIdentity;
   analysisResponse: unknown;
+  expectedAnalysisRequest?: unknown;
   transcript?: { request: unknown; response: unknown };
+}
+
+export interface ResumeAnalysisArtifactsOptions {
+  outputRoot: string;
+  selections: SourceSelection[];
+  catalogIndexPath: string;
+  expectedModel?: { provider: string; name: string };
+  expectedAnalysisRequest: unknown;
 }
 
 const REQUIRED_CATALOG_PATHS = [
@@ -109,6 +119,27 @@ async function assertOutputSeparate(outputRoot: string, selections: SourceSelect
     const rel = relative(root, output);
     if (!rel || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`))) {
       throw new Error(`Artifact output root must not be inside a selected read-only root: ${selection.namespace}`);
+    }
+  }
+}
+
+/** Read-only preflight for callers that must reject unsafe output placement before invoking a transport. */
+export async function assertAnalysisArtifactBoundary(outputRoot: string, selections: SourceSelection[]): Promise<void> {
+  await assertOutputSeparate(outputRoot, selections);
+  let cursor = resolve(outputRoot);
+  for (;;) {
+    try {
+      const metadata = await lstat(cursor);
+      if (metadata.isSymbolicLink()) {
+        throw new Error(`Artifact output root or nearest existing parent must not be a symlink: ${cursor}`);
+      }
+      if (!metadata.isDirectory()) throw new Error(`Artifact output root parent must be a directory: ${cursor}`);
+      break;
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+      const parent = dirname(cursor);
+      if (parent === cursor) throw error;
+      cursor = parent;
     }
   }
 }
@@ -194,14 +225,126 @@ async function ensureExactFile(outputRoot: string, path: string, contents: strin
   }
 }
 
-function transcriptContents(lineage: DerivativeLineage, transcript: { request: unknown; response: unknown }): string {
+function transcriptContents(
+  lineage: DerivativeLineage,
+  transcript: { request: unknown; response: unknown },
+  manifest: SourceManifest,
+  analysisResponse: unknown,
+  expectedAnalysisRequest: unknown
+): string {
   const jsonCompatible = JSON.parse(JSON.stringify(transcript)) as { request: unknown; response: unknown };
+  const response = JSON.parse(JSON.stringify(analysisResponse)) as unknown;
+  const expectedRequest = JSON.parse(JSON.stringify(expectedAnalysisRequest)) as unknown;
+  if (serializeCanonical(jsonCompatible.request) !== serializeCanonical(expectedRequest)) {
+    throw new Error("Determinization transcript request does not match the expected analysis request");
+  }
+  assertTranscriptRequestIdentity({ request: jsonCompatible.request }, manifest);
+  if (serializeCanonical(jsonCompatible.response) !== serializeCanonical(response)) {
+    throw new Error("Determinization transcript response does not match the analyzed response");
+  }
+  const requestBytes = serializeCanonical(jsonCompatible.request);
+  const responseBytes = serializeCanonical(jsonCompatible.response);
   return serializeCanonical({
     ...lineage,
     authority: "audit_only",
+    source_manifest_sha256: sha256(serializeSourceManifest(manifest)),
+    request_sha256: sha256(requestBytes),
+    response_sha256: sha256(responseBytes),
     request: jsonCompatible.request,
     response: jsonCompatible.response
   });
+}
+
+function analysisIdentityWithRawHashes(options: WriteAnalysisArtifactsOptions): AnalysisIdentity | undefined {
+  if (!options.transcript) return options.analysis;
+  if (options.expectedAnalysisRequest === undefined) {
+    throw new Error("An independently constructed expected analysis request is required with a transcript");
+  }
+  if (!options.analysis) {
+    throw new Error("A source analysis identity is required with a transcript");
+  }
+  const request = JSON.parse(JSON.stringify(options.expectedAnalysisRequest)) as unknown;
+  const response = JSON.parse(JSON.stringify(options.analysisResponse)) as unknown;
+  return {
+    ...options.analysis,
+    request_sha256: sha256(serializeCanonical(request)),
+    response_sha256: sha256(serializeCanonical(response))
+  };
+}
+
+function strictTranscriptObject(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Cannot resume determinization: transcript must be an object");
+  }
+  const transcript = value as Record<string, unknown>;
+  const expectedKeys = new Set([
+    "schema_version",
+    "source_opportunities_sha256",
+    "opportunity_ids",
+    "authority",
+    "source_manifest_sha256",
+    "request_sha256",
+    "response_sha256",
+    "request",
+    "response"
+  ]);
+  const unknown = Object.keys(transcript).filter((key) => !expectedKeys.has(key));
+  const missing = [...expectedKeys].filter((key) => !(key in transcript));
+  if (unknown.length || missing.length) {
+    throw new Error("Cannot resume determinization: transcript shape is invalid");
+  }
+  return transcript;
+}
+
+function assertTranscriptRequestIdentity(transcript: Record<string, unknown>, manifest: SourceManifest): void {
+  const request = transcript.request;
+  if (request === null || typeof request !== "object" || Array.isArray(request)) {
+    throw new Error("Cannot resume determinization: transcript request identity is invalid");
+  }
+  const model = (request as Record<string, unknown>).model;
+  if (model === null || typeof model !== "object" || Array.isArray(model)) {
+    throw new Error("Cannot resume determinization: transcript request model identity is missing");
+  }
+  const sourceModel = manifest.analysis?.model;
+  const requestModel = model as Record<string, unknown>;
+  if (
+    sourceModel?.provider === undefined ||
+    sourceModel.name === undefined ||
+    requestModel.provider !== sourceModel.provider ||
+    requestModel.name !== sourceModel.name
+  ) {
+    throw new Error("Cannot resume determinization: transcript request does not match source model identity");
+  }
+}
+
+function derivativePlan(
+  artifactPaths: DeterminizationArtifactPaths,
+  analysis: ReturnType<typeof orderAnalysisOpportunities>,
+  lineage: DerivativeLineage
+): Array<[string, string]> {
+  const request = createResearchRequest(analysis, lineage);
+  return [
+    [artifactPaths.report, renderDeterminizationReport(analysis, lineage)],
+    [artifactPaths.researchRequest, serializeResearchRequest(request)],
+    [artifactPaths.researchPrompt, renderResearchPrompt(request)]
+  ];
+}
+
+async function persistPlan(
+  artifactPaths: DeterminizationArtifactPaths,
+  manifest: SourceManifest,
+  selections: SourceSelection[],
+  planned: Array<[string, string]>
+): Promise<{ createdFiles: string[]; resumedFiles: string[] }> {
+  const createdFiles: string[] = [];
+  const resumedFiles: string[] = [];
+  for (const [path, contents] of planned) {
+    await assertSourceManifestCurrent(manifest, selections);
+    const disposition = await ensureExactFile(artifactPaths.root, path, contents);
+    (disposition === "created" ? createdFiles : resumedFiles).push(path);
+  }
+  await assertSourceManifestCurrent(manifest, selections);
+  return { createdFiles, resumedFiles };
 }
 
 /** Writes only hash-linked Stage A artifacts and safely resumes only byte-identical files. */
@@ -210,7 +353,7 @@ export async function writeAnalysisArtifacts(options: WriteAnalysisArtifactsOpti
   await assertOutputSeparate(options.outputRoot, options.selections);
   return withReadOnlyInputs(options.selections, async () => {
     const artifactPaths = paths(options.outputRoot);
-    const manifest = await createSourceManifest(options.selections, options.analysis);
+    const manifest = await createSourceManifest(options.selections, analysisIdentityWithRawHashes(options));
     const catalog = await loadDeterministicAssetCatalog(options.catalogIndexPath);
     const analysis = orderAnalysisOpportunities(normalizeAnalysisResponse(options.analysisResponse, catalog));
     assertKnownSourceReferences(analysis, manifest);
@@ -223,24 +366,24 @@ export async function writeAnalysisArtifacts(options: WriteAnalysisArtifactsOpti
       source_opportunities_sha256: opportunitiesHash,
       opportunity_ids: analysis.opportunities.map(({ id }) => id)
     };
-    const request = createResearchRequest(analysis, lineage);
     const planned: Array<[string, string]> = [
       [artifactPaths.source, serializeSourceManifest(manifest)],
       [artifactPaths.opportunities, opportunitiesContents],
-      [artifactPaths.report, renderDeterminizationReport(analysis, lineage)],
-      [artifactPaths.researchRequest, serializeResearchRequest(request)],
-      [artifactPaths.researchPrompt, renderResearchPrompt(request)]
+      ...derivativePlan(artifactPaths, analysis, lineage)
     ];
-    if (options.transcript) planned.push([artifactPaths.transcript, transcriptContents(lineage, options.transcript)]);
-
-    const createdFiles: string[] = [];
-    const resumedFiles: string[] = [];
-    for (const [path, contents] of planned) {
-      await assertSourceManifestCurrent(manifest, options.selections);
-      const disposition = await ensureExactFile(artifactPaths.root, path, contents);
-      (disposition === "created" ? createdFiles : resumedFiles).push(path);
+    if (options.transcript) {
+      planned.push([
+        artifactPaths.transcript,
+        transcriptContents(
+          lineage,
+          options.transcript,
+          manifest,
+          options.analysisResponse,
+          options.expectedAnalysisRequest
+        )
+      ]);
     }
-    await assertSourceManifestCurrent(manifest, options.selections);
+    const { createdFiles, resumedFiles } = await persistPlan(artifactPaths, manifest, options.selections, planned);
     return {
       paths: artifactPaths,
       opportunityCount: analysis.opportunities.length,
@@ -248,6 +391,81 @@ export async function writeAnalysisArtifacts(options: WriteAnalysisArtifactsOpti
       sourceOpportunitiesSha256: opportunitiesHash,
       resumedFiles,
       createdFiles
+    };
+  });
+}
+
+/** Reuses immutable canonical analysis without making another model call. */
+export async function resumeAnalysisArtifacts(
+  options: ResumeAnalysisArtifactsOptions
+): Promise<AnalysisArtifactResult> {
+  assertSelectedCatalogIndex(options.catalogIndexPath, options.selections);
+  await assertOutputSeparate(options.outputRoot, options.selections);
+  return withReadOnlyInputs(options.selections, async () => {
+    const artifactPaths = paths(options.outputRoot);
+    const existingSource = await readFile(artifactPaths.source, "utf8");
+    const recordedSource = JSON.parse(existingSource) as { analysis?: AnalysisIdentity };
+    if (
+      options.expectedModel &&
+      (recordedSource.analysis?.model?.provider !== options.expectedModel.provider ||
+        recordedSource.analysis.model.name !== options.expectedModel.name)
+    ) {
+      throw new Error("Cannot resume determinization: configured determinizer model changed");
+    }
+    const manifest = await createSourceManifest(options.selections, recordedSource.analysis);
+    if (existingSource !== serializeSourceManifest(manifest)) {
+      throw new Error("Cannot resume determinization: source or catalog manifest is stale");
+    }
+    const catalog = await loadDeterministicAssetCatalog(options.catalogIndexPath);
+    const opportunitiesBytes = await readFile(artifactPaths.opportunities, "utf8");
+    const analysis = orderAnalysisOpportunities(
+      validateCanonicalAnalysis(JSON.parse(opportunitiesBytes) as unknown, catalog)
+    );
+    if (serializeAnalysisOpportunities(analysis) !== opportunitiesBytes) {
+      throw new Error("Cannot resume determinization: opportunities.json is not canonical or was modified");
+    }
+    const opportunitiesHash = canonicalAnalysisSha256(analysis);
+    const lineage: DerivativeLineage = {
+      schema_version: "1.0.0",
+      source_opportunities_sha256: opportunitiesHash,
+      opportunity_ids: analysis.opportunities.map(({ id }) => id)
+    };
+    const transcriptBytes = await readFile(artifactPaths.transcript, "utf8");
+    const transcript = strictTranscriptObject(JSON.parse(transcriptBytes) as unknown);
+    const expectedRequest = JSON.parse(JSON.stringify(options.expectedAnalysisRequest)) as unknown;
+    if (
+      transcript.schema_version !== "1.0.0" ||
+      transcript.authority !== "audit_only" ||
+      transcript.source_manifest_sha256 !== sha256(existingSource) ||
+      transcript.source_opportunities_sha256 !== opportunitiesHash ||
+      JSON.stringify(transcript.opportunity_ids) !== JSON.stringify(lineage.opportunity_ids) ||
+      transcript.request_sha256 !== manifest.analysis?.request_sha256 ||
+      transcript.request_sha256 !== sha256(serializeCanonical(expectedRequest)) ||
+      serializeCanonical(transcript.request) !== serializeCanonical(expectedRequest) ||
+      transcript.response_sha256 !== manifest.analysis?.response_sha256 ||
+      transcript.response_sha256 !== sha256(serializeCanonical(transcript.response)) ||
+      serializeCanonical(transcript) !== transcriptBytes
+    ) {
+      throw new Error("Cannot resume determinization: transcript provenance is missing, stale, or non-canonical");
+    }
+    assertTranscriptRequestIdentity(transcript, manifest);
+    const transcriptAnalysis = orderAnalysisOpportunities(normalizeAnalysisResponse(transcript.response, catalog));
+    if (serializeAnalysisOpportunities(transcriptAnalysis) !== opportunitiesBytes) {
+      throw new Error("Cannot resume determinization: transcript response does not match canonical opportunities");
+    }
+    const planned: Array<[string, string]> = [
+      [artifactPaths.source, existingSource],
+      [artifactPaths.opportunities, opportunitiesBytes],
+      ...derivativePlan(artifactPaths, analysis, lineage)
+    ];
+    const { createdFiles, resumedFiles } = await persistPlan(artifactPaths, manifest, options.selections, planned);
+    return {
+      paths: artifactPaths,
+      opportunityCount: analysis.opportunities.length,
+      recommendationCount: analysis.opportunities.reduce((count, item) => count + item.recommendations.length, 0),
+      sourceOpportunitiesSha256: opportunitiesHash,
+      createdFiles,
+      resumedFiles: [...resumedFiles, artifactPaths.transcript]
     };
   });
 }

--- a/src/determinization/artifacts.ts
+++ b/src/determinization/artifacts.ts
@@ -1,5 +1,6 @@
 import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import * as v from "valibot";
 import { normalizeAnalysisResponse } from "./analyzer.js";
 import { serializeCanonical, sha256 } from "./canonical.js";
 import { loadDeterministicAssetCatalog } from "./catalog.js";
@@ -7,7 +8,12 @@ import { renderDeterminizationReport } from "./report.js";
 import { renderResearchPrompt } from "./research-prompt.js";
 import { createResearchRequest, serializeResearchRequest, type DerivativeLineage } from "./research-request.js";
 import { withReadOnlyInputs } from "./read-only-snapshot.js";
-import { canonicalAnalysisSha256, orderAnalysisOpportunities, serializeAnalysisOpportunities } from "./schemas.js";
+import {
+  DETERMINIZATION_SCHEMA_VERSION,
+  canonicalAnalysisSha256,
+  orderAnalysisOpportunities,
+  serializeAnalysisOpportunities
+} from "./schemas.js";
 import { validateCanonicalAnalysis } from "./validation.js";
 import {
   assertSourceManifestCurrent,
@@ -52,6 +58,25 @@ const REQUIRED_CATALOG_PATHS = [
   "language.json",
   "markdown.json"
 ] as const;
+
+const Sha256Schema = v.pipe(v.string(), v.regex(/^[a-f0-9]{64}$/u));
+const RequiredUnknownSchema = v.pipe(
+  v.unknown(),
+  v.check((value) => value !== undefined, "Expected a required transcript value")
+);
+const AnalysisTranscriptSchema = v.strictObject({
+  schema_version: v.literal(DETERMINIZATION_SCHEMA_VERSION),
+  source_opportunities_sha256: Sha256Schema,
+  opportunity_ids: v.array(v.pipe(v.string(), v.regex(/^opp_[a-f0-9]{20}$/u))),
+  authority: v.literal("audit_only"),
+  source_manifest_sha256: Sha256Schema,
+  request_sha256: Sha256Schema,
+  response_sha256: Sha256Schema,
+  request: RequiredUnknownSchema,
+  response: RequiredUnknownSchema
+});
+
+type AnalysisTranscript = v.InferOutput<typeof AnalysisTranscriptSchema>;
 
 function assertSelectedCatalogIndex(catalogIndexPath: string, selections: SourceSelection[]): void {
   const index = resolve(catalogIndexPath);
@@ -272,31 +297,16 @@ function analysisIdentityWithRawHashes(options: WriteAnalysisArtifactsOptions): 
   };
 }
 
-function strictTranscriptObject(value: unknown): Record<string, unknown> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Cannot resume determinization: transcript must be an object");
-  }
-  const transcript = value as Record<string, unknown>;
-  const expectedKeys = new Set([
-    "schema_version",
-    "source_opportunities_sha256",
-    "opportunity_ids",
-    "authority",
-    "source_manifest_sha256",
-    "request_sha256",
-    "response_sha256",
-    "request",
-    "response"
-  ]);
-  const unknown = Object.keys(transcript).filter((key) => !expectedKeys.has(key));
-  const missing = [...expectedKeys].filter((key) => !(key in transcript));
-  if (unknown.length || missing.length) {
-    throw new Error("Cannot resume determinization: transcript shape is invalid");
-  }
-  return transcript;
+function parseAnalysisTranscript(value: unknown): AnalysisTranscript {
+  const result = v.safeParse(AnalysisTranscriptSchema, value);
+  if (!result.success) throw new Error("Cannot resume determinization: transcript shape is invalid");
+  return result.output;
 }
 
-function assertTranscriptRequestIdentity(transcript: Record<string, unknown>, manifest: SourceManifest): void {
+function assertTranscriptRequestIdentity(
+  transcript: Pick<AnalysisTranscript, "request">,
+  manifest: SourceManifest
+): void {
   const request = transcript.request;
   if (request === null || typeof request !== "object" || Array.isArray(request)) {
     throw new Error("Cannot resume determinization: transcript request identity is invalid");
@@ -362,7 +372,7 @@ export async function writeAnalysisArtifacts(options: WriteAnalysisArtifactsOpti
     if (sha256(opportunitiesContents) !== opportunitiesHash)
       throw new Error("Canonical opportunities byte hash mismatch");
     const lineage: DerivativeLineage = {
-      schema_version: "1.0.0",
+      schema_version: DETERMINIZATION_SCHEMA_VERSION,
       source_opportunities_sha256: opportunitiesHash,
       opportunity_ids: analysis.opportunities.map(({ id }) => id)
     };
@@ -424,17 +434,18 @@ export async function resumeAnalysisArtifacts(
     if (serializeAnalysisOpportunities(analysis) !== opportunitiesBytes) {
       throw new Error("Cannot resume determinization: opportunities.json is not canonical or was modified");
     }
+    assertKnownSourceReferences(analysis, manifest);
     const opportunitiesHash = canonicalAnalysisSha256(analysis);
     const lineage: DerivativeLineage = {
-      schema_version: "1.0.0",
+      schema_version: DETERMINIZATION_SCHEMA_VERSION,
       source_opportunities_sha256: opportunitiesHash,
       opportunity_ids: analysis.opportunities.map(({ id }) => id)
     };
     const transcriptBytes = await readFile(artifactPaths.transcript, "utf8");
-    const transcript = strictTranscriptObject(JSON.parse(transcriptBytes) as unknown);
+    const transcript = parseAnalysisTranscript(JSON.parse(transcriptBytes) as unknown);
     const expectedRequest = JSON.parse(JSON.stringify(options.expectedAnalysisRequest)) as unknown;
     if (
-      transcript.schema_version !== "1.0.0" ||
+      transcript.schema_version !== DETERMINIZATION_SCHEMA_VERSION ||
       transcript.authority !== "audit_only" ||
       transcript.source_manifest_sha256 !== sha256(existingSource) ||
       transcript.source_opportunities_sha256 !== opportunitiesHash ||
@@ -465,7 +476,7 @@ export async function resumeAnalysisArtifacts(
       recommendationCount: analysis.opportunities.reduce((count, item) => count + item.recommendations.length, 0),
       sourceOpportunitiesSha256: opportunitiesHash,
       createdFiles,
-      resumedFiles: [...resumedFiles, artifactPaths.transcript]
+      resumedFiles
     };
   });
 }

--- a/src/determinization/markdown.ts
+++ b/src/determinization/markdown.ts
@@ -1,0 +1,8 @@
+export function markdownText(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .normalize("NFC")
+    .trim()
+    .replace(/\s+/gu, " ")
+    .replace(/([\\`*_[\]<>#|])/gu, "\\$1");
+}

--- a/src/determinization/read-only-snapshot.ts
+++ b/src/determinization/read-only-snapshot.ts
@@ -3,9 +3,19 @@ import { assertSourceManifestCurrent, createSourceManifest } from "./source.js";
 
 export async function withReadOnlyInputs<T>(selections: SourceSelection[], operation: () => Promise<T>): Promise<T> {
   const before = await createSourceManifest(selections);
+  let result: T;
   try {
-    return await operation();
-  } finally {
-    await assertSourceManifestCurrent(before, selections);
+    result = await operation();
+  } catch (operationError) {
+    try {
+      await assertSourceManifestCurrent(before, selections);
+    } catch (mutationError) {
+      throw new AggregateError([operationError, mutationError], "Operation failed and determinization inputs changed", {
+        cause: mutationError
+      });
+    }
+    throw operationError;
   }
+  await assertSourceManifestCurrent(before, selections);
+  return result;
 }

--- a/src/determinization/read-only-snapshot.ts
+++ b/src/determinization/read-only-snapshot.ts
@@ -1,0 +1,11 @@
+import type { SourceSelection } from "./source.js";
+import { assertSourceManifestCurrent, createSourceManifest } from "./source.js";
+
+export async function withReadOnlyInputs<T>(selections: SourceSelection[], operation: () => Promise<T>): Promise<T> {
+  const before = await createSourceManifest(selections);
+  try {
+    return await operation();
+  } finally {
+    await assertSourceManifestCurrent(before, selections);
+  }
+}

--- a/src/determinization/report.ts
+++ b/src/determinization/report.ts
@@ -1,0 +1,87 @@
+import type { AnalysisOpportunitiesDocument } from "./schemas.js";
+import type { DerivativeLineage } from "./research-request.js";
+
+function markdownText(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .normalize("NFC")
+    .trim()
+    .replace(/\s+/gu, " ")
+    .replace(/([\\`*_[\]<>#|])/gu, "\\$1");
+}
+
+function bullets(label: string, values: string[], indent = ""): string[] {
+  return [`${indent}- ${label}:`, ...values.map((value) => `${indent}  - ${markdownText(value)}`)];
+}
+
+export function renderDeterminizationReport(
+  document: AnalysisOpportunitiesDocument,
+  lineage: DerivativeLineage
+): string {
+  const sections = document.opportunities.flatMap((opportunity) => {
+    const sources = opportunity.source_refs.map(
+      (source) => `${source.path} [${source.evidence_kind}]${source.locator ? ` — ${source.locator}` : ""}`
+    );
+    const assets = opportunity.recommendations.flatMap((asset) => {
+      const alternatives = asset.alternative_assessments.length
+        ? asset.alternative_assessments.flatMap((assessment) => [
+            `  - ${assessment.relationship}: ${assessment.conclusion}`,
+            `    - Catalog assets: ${assessment.catalog_asset_ids.length ? assessment.catalog_asset_ids.join(", ") : "none applicable"}`,
+            `    - Rationale: ${markdownText(assessment.rationale)}`
+          ])
+        : ["  - None required for this relationship tier."];
+      return [
+        `#### ${asset.id}: ${markdownText(asset.proposed_name)}`,
+        "",
+        "- Lifecycle: suggested (unverified)",
+        `- Relationship: ${asset.relationship}`,
+        `- Asset kind: ${asset.asset_kind}`,
+        `- Catalog reference: ${asset.catalog_asset_id ?? "none — newly suggested asset"}`,
+        `- Contribution: ${markdownText(asset.contribution)}`,
+        `- Confidence (unverified analyzer analysis): ${asset.confidence}`,
+        `- Expected improvement: ${markdownText(asset.expected_improvement)}`,
+        ...bullets("Supporting evidence", asset.supporting_evidence),
+        ...bullets("Limitations", asset.limitations),
+        "- Lower-tier alternative assessments (unverified analyzer analysis):",
+        ...alternatives,
+        `- New-asset insufficiency justification: ${asset.insufficiency_justification ? markdownText(asset.insufficiency_justification) : "not applicable"}`,
+        ""
+      ];
+    });
+    return [
+      `## ${opportunity.id}: ${markdownText(opportunity.normalized_requirement)}`,
+      "",
+      `- Origin: ${opportunity.origin}`,
+      ...bullets("Source references", sources),
+      `- Classification (unverified analyzer analysis): ${opportunity.classification}`,
+      `- Current automation potential (unverified analyzer analysis): ${opportunity.current_automation_potential}`,
+      `- Remaining human judgment: ${markdownText(opportunity.remaining_human_judgment)}`,
+      `- Confidence (unverified analyzer analysis): ${opportunity.confidence}`,
+      `- Expected improvement: ${markdownText(opportunity.expected_improvement)}`,
+      ...bullets("Analyzer rationale (unverified)", opportunity.supporting_evidence),
+      ...bullets("Analyzer limitations (unverified)", opportunity.limitations),
+      "",
+      "### Suggested deterministic assets",
+      "",
+      ...(assets.length ? assets : ["No deterministic asset was suggested.", ""]),
+      "LanguageTool references describe candidate capability families only. A later evidence stage must establish whether relevant rules, versions, language variants, or configuration exist; no LanguageTool signal by itself fully establishes concision or editorial quality.",
+      ""
+    ];
+  });
+  return [
+    "# Determinization opportunity report",
+    "",
+    `schema_version: ${lineage.schema_version}`,
+    `source_opportunities_sha256: ${lineage.source_opportunities_sha256}`,
+    `opportunity_ids: ${lineage.opportunity_ids.join(", ")}`,
+    "",
+    "> Read-only analysis. Every asset below is suggested and unverified. This report does not propose, verify, adopt, apply, or modify an asset.",
+    "",
+    `Opportunities: ${document.opportunities.length}`,
+    "",
+    ...sections,
+    ""
+  ]
+    .join("\n")
+    .replace(/\n*$/u, "\n");
+}

--- a/src/determinization/report.ts
+++ b/src/determinization/report.ts
@@ -1,14 +1,6 @@
 import type { AnalysisOpportunitiesDocument } from "./schemas.js";
 import type { DerivativeLineage } from "./research-request.js";
-
-function markdownText(value: string): string {
-  return value
-    .replace(/\r\n?/g, "\n")
-    .normalize("NFC")
-    .trim()
-    .replace(/\s+/gu, " ")
-    .replace(/([\\`*_[\]<>#|])/gu, "\\$1");
-}
+import { markdownText } from "./markdown.js";
 
 function bullets(label: string, values: string[], indent = ""): string[] {
   return [`${indent}- ${label}:`, ...values.map((value) => `${indent}  - ${markdownText(value)}`)];
@@ -19,6 +11,7 @@ export function renderDeterminizationReport(
   lineage: DerivativeLineage
 ): string {
   const sections = document.opportunities.flatMap((opportunity) => {
+    const hasLanguageToolAsset = opportunity.recommendations.some(({ asset_kind }) => asset_kind === "languagetool");
     const sources = opportunity.source_refs.map(
       (source) => `${source.path} [${source.evidence_kind}]${source.locator ? ` — ${source.locator}` : ""}`
     );
@@ -64,7 +57,11 @@ export function renderDeterminizationReport(
       "### Suggested deterministic assets",
       "",
       ...(assets.length ? assets : ["No deterministic asset was suggested.", ""]),
-      "LanguageTool references describe candidate capability families only. A later evidence stage must establish whether relevant rules, versions, language variants, or configuration exist; no LanguageTool signal by itself fully establishes concision or editorial quality.",
+      ...(hasLanguageToolAsset
+        ? [
+            "LanguageTool references describe candidate capability families only. A later evidence stage must establish whether relevant rules, versions, language variants, or configuration exist; no LanguageTool signal by itself fully establishes concision or editorial quality."
+          ]
+        : []),
       ""
     ];
   });

--- a/src/determinization/research-prompt.ts
+++ b/src/determinization/research-prompt.ts
@@ -1,13 +1,5 @@
 import type { ResearchRequest } from "./research-request.js";
-
-function markdownText(value: string): string {
-  return value
-    .replace(/\r\n?/g, "\n")
-    .normalize("NFC")
-    .trim()
-    .replace(/\s+/gu, " ")
-    .replace(/([\\`*_[\]<>#|])/gu, "\\$1");
-}
+import { markdownText } from "./markdown.js";
 
 export function renderResearchPrompt(request: ResearchRequest): string {
   const opportunities = request.opportunity_requests.flatMap((opportunity) => [

--- a/src/determinization/research-prompt.ts
+++ b/src/determinization/research-prompt.ts
@@ -1,0 +1,58 @@
+import type { ResearchRequest } from "./research-request.js";
+
+function markdownText(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .normalize("NFC")
+    .trim()
+    .replace(/\s+/gu, " ")
+    .replace(/([\\`*_[\]<>#|])/gu, "\\$1");
+}
+
+export function renderResearchPrompt(request: ResearchRequest): string {
+  const opportunities = request.opportunity_requests.flatMap((opportunity) => [
+    `## ${opportunity.opportunity_id}`,
+    "",
+    `Requirement: ${markdownText(opportunity.normalized_requirement)}`,
+    "",
+    "Source references:",
+    ...opportunity.source_refs.map(
+      (source) =>
+        `- ${markdownText(`${source.path} [${source.evidence_kind}]${source.locator ? ` — ${source.locator}` : ""}`)}`
+    ),
+    "",
+    "Analyzer rationale (unverified):",
+    ...opportunity.supporting_evidence.map((evidence) => `- ${markdownText(evidence)}`),
+    "",
+    "Known limitations:",
+    ...opportunity.limitations.map((limitation) => `- ${markdownText(limitation)}`),
+    "",
+    "Suggested assets and evidence gaps:",
+    ...opportunity.suggested_assets.flatMap((asset) => [
+      `- ${markdownText(`${asset.asset_id} (${asset.relationship}, ${asset.asset_kind}${asset.catalog_asset_id ? `, ${asset.catalog_asset_id}` : ""})`)}`,
+      `  - Contribution: ${markdownText(asset.contribution)}`,
+      ...asset.supporting_evidence.map((evidence) => `  - Existing evidence: ${markdownText(evidence)}`),
+      ...asset.evidence_questions.map((question) => `  - ${markdownText(question)}`),
+      ...asset.known_limitations.map((limitation) => `  - Known limitation: ${markdownText(limitation)}`)
+    ]),
+    ""
+  ]);
+  return [
+    "# Determinization evidence research",
+    "",
+    `schema_version: ${request.schema_version}`,
+    `source_opportunities_sha256: ${request.source_opportunities_sha256}`,
+    `opportunity_ids: ${request.opportunity_ids.join(", ")}`,
+    "",
+    "This is a read-only evidence request. Do not modify the skill, context, catalog, opportunities.json, or any other analysis artifact.",
+    "All assets are suggested and unverified. Use authoritative sources; establish relevant version, language variant, and configuration facts when available, and never invent them.",
+    "",
+    ...opportunities,
+    "## Required response discipline",
+    "",
+    ...request.constraints.map((constraint) => `- ${markdownText(constraint)}`),
+    ""
+  ]
+    .join("\n")
+    .replace(/\n*$/u, "\n");
+}

--- a/src/determinization/research-request.ts
+++ b/src/determinization/research-request.ts
@@ -1,0 +1,85 @@
+import { serializeCanonical } from "./canonical.js";
+import type { AnalysisOpportunitiesDocument } from "./schemas.js";
+
+export interface DerivativeLineage {
+  schema_version: "1.0.0";
+  source_opportunities_sha256: string;
+  opportunity_ids: string[];
+}
+
+export interface ResearchAssetRequest {
+  asset_id: string;
+  relationship: string;
+  asset_kind: string;
+  catalog_asset_id?: string;
+  contribution: string;
+  supporting_evidence: string[];
+  evidence_questions: string[];
+  known_limitations: string[];
+}
+
+export interface ResearchOpportunityRequest {
+  opportunity_id: string;
+  normalized_requirement: string;
+  source_refs: Array<{ path: string; locator?: string; evidence_kind: string }>;
+  supporting_evidence: string[];
+  limitations: string[];
+  suggested_assets: ResearchAssetRequest[];
+}
+
+export interface ResearchRequest extends DerivativeLineage {
+  opportunity_requests: ResearchOpportunityRequest[];
+  constraints: string[];
+}
+
+function evidenceQuestions(relationship: string, assetName: string, catalogAssetId: string | undefined): string[] {
+  const identity = catalogAssetId ? `${assetName} (${catalogAssetId})` : assetName;
+  const questions = [
+    `Which authoritative sources establish whether ${identity} can contribute to this requirement?`,
+    `Which product or rule versions, language variants, runtime constraints, and configuration are relevant to ${identity}, if any?`,
+    `What limitations, false-positive risks, and remaining human judgment apply to ${identity}?`
+  ];
+  if (relationship === "new") {
+    questions.push(
+      `What evidence demonstrates that existing, configurable, and extensible catalog assets are insufficient before ${identity} is created?`
+    );
+  }
+  return questions;
+}
+
+export function createResearchRequest(
+  opportunities: AnalysisOpportunitiesDocument,
+  lineage: DerivativeLineage
+): ResearchRequest {
+  return {
+    ...lineage,
+    opportunity_requests: opportunities.opportunities.map((opportunity) => ({
+      opportunity_id: opportunity.id,
+      normalized_requirement: opportunity.normalized_requirement,
+      source_refs: opportunity.source_refs.map((source) => ({ ...source })),
+      supporting_evidence: [...opportunity.supporting_evidence],
+      limitations: [...opportunity.limitations],
+      suggested_assets: opportunity.recommendations.map((asset) => ({
+        asset_id: asset.id,
+        relationship: asset.relationship,
+        asset_kind: asset.asset_kind,
+        ...(asset.catalog_asset_id && { catalog_asset_id: asset.catalog_asset_id }),
+        contribution: asset.contribution,
+        supporting_evidence: [...asset.supporting_evidence],
+        evidence_questions: evidenceQuestions(asset.relationship, asset.proposed_name, asset.catalog_asset_id),
+        known_limitations: [...asset.limitations]
+      }))
+    })),
+    constraints: [
+      "Research is read-only and must not change the skill, context, catalog, opportunities.json, or other analysis artifacts.",
+      "Treat every deterministic asset as suggested and unverified.",
+      "Use authoritative evidence and record its applicable product or rule version, language variant, and configuration when those facts are available.",
+      "Do not invent versions, configuration, rule availability, verification, or adoption status.",
+      "Record evidence gaps and remaining human judgment explicitly."
+    ]
+  };
+}
+
+export function serializeResearchRequest(request: ResearchRequest): string {
+  return serializeCanonical(request);
+}

--- a/src/determinization/source.ts
+++ b/src/determinization/source.ts
@@ -1,0 +1,136 @@
+import { lstat, readFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { serializeCanonical, sha256 } from "./canonical.js";
+import { DETERMINIZATION_SCHEMA_VERSION } from "./schemas.js";
+
+export type SourceNamespace = "skill" | "evaluation" | "reference" | "context" | "catalog";
+
+export interface SourceSelection {
+  namespace: SourceNamespace;
+  root: string;
+  paths: string[];
+}
+
+export interface SourceManifestEntry {
+  path: string;
+  sha256: string;
+}
+
+export interface AnalysisIdentity {
+  role: "determinizer";
+  transport: string;
+  model?: {
+    provider?: string;
+    name?: string;
+  };
+}
+
+export interface SourceManifest {
+  schema_version: typeof DETERMINIZATION_SCHEMA_VERSION;
+  analysis?: AnalysisIdentity;
+  inputs: SourceManifestEntry[];
+}
+
+const PORTABLE_IDENTITY = /^[A-Za-z0-9][A-Za-z0-9._-]{0,119}$/u;
+
+function normalizeAnalysisIdentity(identity: AnalysisIdentity | undefined): AnalysisIdentity | undefined {
+  if (identity === undefined) return undefined;
+  const unknownIdentityKeys = Object.keys(identity).filter((key) => !["role", "transport", "model"].includes(key));
+  if (unknownIdentityKeys.length > 0) throw new Error("Source analysis identity contains unsupported metadata");
+  if (identity.role !== "determinizer") throw new Error("Source analysis role must be determinizer");
+  if (!PORTABLE_IDENTITY.test(identity.transport)) {
+    throw new Error("Source analysis transport must be a portable nonblank identifier");
+  }
+  const model = identity.model;
+  if (model !== undefined) {
+    const unknownModelKeys = Object.keys(model).filter((key) => !["provider", "name"].includes(key));
+    if (unknownModelKeys.length > 0) throw new Error("Source analysis model contains unsupported metadata");
+    for (const [key, value] of Object.entries(model)) {
+      if (value !== undefined && !PORTABLE_IDENTITY.test(value)) {
+        throw new Error(`Source analysis model ${key} must be a portable nonblank identifier`);
+      }
+    }
+    if (model.provider === undefined && model.name === undefined) {
+      throw new Error("Source analysis model identity cannot be empty");
+    }
+  }
+  return {
+    role: "determinizer",
+    transport: identity.transport,
+    ...(model && {
+      model: { ...(model.provider && { provider: model.provider }), ...(model.name && { name: model.name }) }
+    })
+  };
+}
+
+function portableRelativePath(path: string): string {
+  if (!path || isAbsolute(path) || path.includes("\\"))
+    throw new Error(`Expected a source-relative POSIX path: ${path}`);
+  const parts = path.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error(`Expected a normalized source-relative POSIX path: ${path}`);
+  }
+  return path;
+}
+
+function resolveInside(root: string, portablePath: string): string {
+  const rootPath = resolve(root);
+  const target = resolve(rootPath, ...portableRelativePath(portablePath).split("/"));
+  const rel = relative(rootPath, target);
+  if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`Selected path escapes or aliases its source root: ${portablePath}`);
+  }
+  return target;
+}
+
+export async function createSourceManifest(
+  selections: SourceSelection[],
+  analysis?: AnalysisIdentity
+): Promise<SourceManifest> {
+  const entries: SourceManifestEntry[] = [];
+  const logicalPaths = new Set<string>();
+  for (const selection of selections) {
+    for (const sourcePath of selection.paths) {
+      const portablePath = portableRelativePath(sourcePath);
+      const logicalPath = `${selection.namespace}/${portablePath}`;
+      if (logicalPaths.has(logicalPath)) throw new Error(`Duplicate selected source path: ${logicalPath}`);
+      logicalPaths.add(logicalPath);
+      const target = resolveInside(selection.root, portablePath);
+      let cursor = resolve(selection.root);
+      const rootMetadata = await lstat(cursor);
+      if (rootMetadata.isSymbolicLink())
+        throw new Error(`Symbolic links are not valid determinization inputs: ${logicalPath}`);
+      let metadata = rootMetadata;
+      for (const segment of portablePath.split("/")) {
+        cursor = join(cursor, segment);
+        metadata = await lstat(cursor);
+        if (metadata.isSymbolicLink()) {
+          throw new Error(`Symbolic links are not valid determinization inputs: ${logicalPath}`);
+        }
+      }
+      if (!metadata.isFile()) throw new Error(`Only regular files are valid determinization inputs: ${logicalPath}`);
+      entries.push({ path: logicalPath, sha256: sha256(await readFile(target)) });
+    }
+  }
+  entries.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  const normalizedAnalysis = normalizeAnalysisIdentity(analysis);
+  return {
+    schema_version: DETERMINIZATION_SCHEMA_VERSION,
+    ...(normalizedAnalysis && { analysis: normalizedAnalysis }),
+    inputs: entries
+  };
+}
+
+export function serializeSourceManifest(manifest: SourceManifest): string {
+  return serializeCanonical(manifest);
+}
+
+export async function assertSourceManifestCurrent(
+  expected: SourceManifest,
+  selections: SourceSelection[]
+): Promise<void> {
+  const actual = await createSourceManifest(selections, expected.analysis);
+  if (serializeSourceManifest(actual) !== serializeSourceManifest(expected)) {
+    throw new Error("Determinization inputs are stale: source or catalog fingerprints changed");
+  }
+}

--- a/src/determinization/source.ts
+++ b/src/determinization/source.ts
@@ -19,6 +19,8 @@ export interface SourceManifestEntry {
 export interface AnalysisIdentity {
   role: "determinizer";
   transport: string;
+  request_sha256?: string;
+  response_sha256?: string;
   model?: {
     provider?: string;
     name?: string;
@@ -32,14 +34,26 @@ export interface SourceManifest {
 }
 
 const PORTABLE_IDENTITY = /^[A-Za-z0-9][A-Za-z0-9._-]{0,119}$/u;
+const SHA256 = /^[a-f0-9]{64}$/u;
 
 function normalizeAnalysisIdentity(identity: AnalysisIdentity | undefined): AnalysisIdentity | undefined {
   if (identity === undefined) return undefined;
-  const unknownIdentityKeys = Object.keys(identity).filter((key) => !["role", "transport", "model"].includes(key));
+  const unknownIdentityKeys = Object.keys(identity).filter(
+    (key) => !["role", "transport", "request_sha256", "response_sha256", "model"].includes(key)
+  );
   if (unknownIdentityKeys.length > 0) throw new Error("Source analysis identity contains unsupported metadata");
   if (identity.role !== "determinizer") throw new Error("Source analysis role must be determinizer");
   if (!PORTABLE_IDENTITY.test(identity.transport)) {
     throw new Error("Source analysis transport must be a portable nonblank identifier");
+  }
+  if ((identity.request_sha256 === undefined) !== (identity.response_sha256 === undefined)) {
+    throw new Error("Source analysis request and response hashes must be provided together");
+  }
+  if (
+    (identity.request_sha256 !== undefined && !SHA256.test(identity.request_sha256)) ||
+    (identity.response_sha256 !== undefined && !SHA256.test(identity.response_sha256))
+  ) {
+    throw new Error("Source analysis request and response hashes must be strict SHA-256 values");
   }
   const model = identity.model;
   if (model !== undefined) {
@@ -57,6 +71,8 @@ function normalizeAnalysisIdentity(identity: AnalysisIdentity | undefined): Anal
   return {
     role: "determinizer",
     transport: identity.transport,
+    ...(identity.request_sha256 && { request_sha256: identity.request_sha256 }),
+    ...(identity.response_sha256 && { response_sha256: identity.response_sha256 }),
     ...(model && {
       model: { ...(model.provider && { provider: model.provider }), ...(model.name && { name: model.name }) }
     })

--- a/src/determinization/source.ts
+++ b/src/determinization/source.ts
@@ -1,6 +1,7 @@
-import { lstat, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
-import { serializeCanonical, sha256 } from "./canonical.js";
+import { compareCodePoints, serializeCanonical, sha256 } from "./canonical.js";
 import { DETERMINIZATION_SCHEMA_VERSION } from "./schemas.js";
 
 export type SourceNamespace = "skill" | "evaluation" | "reference" | "context" | "catalog";
@@ -38,29 +39,37 @@ const SHA256 = /^[a-f0-9]{64}$/u;
 
 function normalizeAnalysisIdentity(identity: AnalysisIdentity | undefined): AnalysisIdentity | undefined {
   if (identity === undefined) return undefined;
+  if (identity === null || typeof identity !== "object" || Array.isArray(identity)) {
+    throw new Error("Source analysis identity must be an object");
+  }
   const unknownIdentityKeys = Object.keys(identity).filter(
     (key) => !["role", "transport", "request_sha256", "response_sha256", "model"].includes(key)
   );
   if (unknownIdentityKeys.length > 0) throw new Error("Source analysis identity contains unsupported metadata");
   if (identity.role !== "determinizer") throw new Error("Source analysis role must be determinizer");
-  if (!PORTABLE_IDENTITY.test(identity.transport)) {
+  if (typeof identity.transport !== "string" || !PORTABLE_IDENTITY.test(identity.transport)) {
     throw new Error("Source analysis transport must be a portable nonblank identifier");
   }
   if ((identity.request_sha256 === undefined) !== (identity.response_sha256 === undefined)) {
     throw new Error("Source analysis request and response hashes must be provided together");
   }
   if (
-    (identity.request_sha256 !== undefined && !SHA256.test(identity.request_sha256)) ||
-    (identity.response_sha256 !== undefined && !SHA256.test(identity.response_sha256))
+    (identity.request_sha256 !== undefined &&
+      (typeof identity.request_sha256 !== "string" || !SHA256.test(identity.request_sha256))) ||
+    (identity.response_sha256 !== undefined &&
+      (typeof identity.response_sha256 !== "string" || !SHA256.test(identity.response_sha256)))
   ) {
     throw new Error("Source analysis request and response hashes must be strict SHA-256 values");
   }
   const model = identity.model;
   if (model !== undefined) {
+    if (model === null || typeof model !== "object" || Array.isArray(model)) {
+      throw new Error("Source analysis model must be an object");
+    }
     const unknownModelKeys = Object.keys(model).filter((key) => !["provider", "name"].includes(key));
     if (unknownModelKeys.length > 0) throw new Error("Source analysis model contains unsupported metadata");
     for (const [key, value] of Object.entries(model)) {
-      if (value !== undefined && !PORTABLE_IDENTITY.test(value)) {
+      if (value !== undefined && (typeof value !== "string" || !PORTABLE_IDENTITY.test(value))) {
         throw new Error(`Source analysis model ${key} must be a portable nonblank identifier`);
       }
     }
@@ -107,17 +116,18 @@ export async function createSourceManifest(
   const logicalPaths = new Set<string>();
   for (const selection of selections) {
     for (const sourcePath of selection.paths) {
-      const portablePath = portableRelativePath(sourcePath);
+      const rawPortablePath = portableRelativePath(sourcePath);
+      const portablePath = rawPortablePath.normalize("NFC");
       const logicalPath = `${selection.namespace}/${portablePath}`;
       if (logicalPaths.has(logicalPath)) throw new Error(`Duplicate selected source path: ${logicalPath}`);
       logicalPaths.add(logicalPath);
-      const target = resolveInside(selection.root, portablePath);
+      const target = resolveInside(selection.root, rawPortablePath);
       let cursor = resolve(selection.root);
       const rootMetadata = await lstat(cursor);
       if (rootMetadata.isSymbolicLink())
         throw new Error(`Symbolic links are not valid determinization inputs: ${logicalPath}`);
       let metadata = rootMetadata;
-      for (const segment of portablePath.split("/")) {
+      for (const segment of rawPortablePath.split("/")) {
         cursor = join(cursor, segment);
         metadata = await lstat(cursor);
         if (metadata.isSymbolicLink()) {
@@ -125,10 +135,19 @@ export async function createSourceManifest(
         }
       }
       if (!metadata.isFile()) throw new Error(`Only regular files are valid determinization inputs: ${logicalPath}`);
-      entries.push({ path: logicalPath, sha256: sha256(await readFile(target)) });
+      const handle = await open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
+      try {
+        const openedMetadata = await handle.stat();
+        if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
+          throw new Error(`Source input changed during determinization: ${logicalPath}`);
+        }
+        entries.push({ path: logicalPath, sha256: sha256(await handle.readFile()) });
+      } finally {
+        await handle.close();
+      }
     }
   }
-  entries.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  entries.sort((left, right) => compareCodePoints(left.path, right.path));
   const normalizedAnalysis = normalizeAnalysisIdentity(analysis);
   return {
     schema_version: DETERMINIZATION_SCHEMA_VERSION,

--- a/src/determinization/validation.ts
+++ b/src/determinization/validation.ts
@@ -1,0 +1,16 @@
+import type { DeterministicAssetCatalog } from "./catalog.js";
+import { validateCatalogReferences } from "./catalog.js";
+import { canonicalAnalysisSha256, parseAnalysisOpportunities, type AnalysisOpportunitiesDocument } from "./schemas.js";
+
+export function validateCanonicalAnalysis(
+  value: unknown,
+  catalog: DeterministicAssetCatalog,
+  expectedSha256?: string
+): AnalysisOpportunitiesDocument {
+  const document = parseAnalysisOpportunities(value);
+  validateCatalogReferences(document, catalog);
+  if (expectedSha256 !== undefined && canonicalAnalysisSha256(document) !== expectedSha256) {
+    throw new Error("Canonical opportunities hash mismatch");
+  }
+  return document;
+}

--- a/tests/determinization-analyzer.test.ts
+++ b/tests/determinization-analyzer.test.ts
@@ -1,0 +1,165 @@
+import { resolve } from "node:path";
+import { normalizeAnalysisResponse } from "../src/determinization/analyzer.js";
+import { loadDeterministicAssetCatalog } from "../src/determinization/catalog.js";
+import { canonicalAnalysisSha256, serializeAnalysisOpportunities } from "../src/determinization/schemas.js";
+import { validateCanonicalAnalysis } from "../src/determinization/validation.js";
+
+const catalogPath = resolve("catalog/deterministic-assets/catalog.json");
+
+function conciseResponse(recommendations?: unknown[]) {
+  return {
+    schema_version: "1.0.0",
+    opportunities: [
+      {
+        source_refs: [{ path: "skill/SKILL.md", locator: "Keep the output concise.", evidence_kind: "skill" }],
+        normalized_requirement: "Keep the output concise.",
+        origin: "skill_guidance",
+        classification: "partially_deterministic",
+        current_automation_potential: "medium",
+        remaining_human_judgment:
+          "Editorial judgment must determine whether the result is useful and appropriately concise.",
+        recommendations: recommendations ?? [metricsRecommendation(), languageToolRecommendation()],
+        confidence: "high",
+        expected_improvement: "Repeatable signals can reduce inconsistent review without replacing an editor.",
+        supporting_evidence: ["Length is measurable, while usefulness and clarity remain contextual."],
+        limitations: ["No deterministic asset fully establishes concision."]
+      }
+    ]
+  };
+}
+
+function metricsRecommendation() {
+  return {
+    relationship: "existing",
+    asset_kind: "script",
+    catalog_asset_id: "catalog_text_metrics",
+    proposed_name: "Text metrics",
+    contribution: "Word and sentence counts can provide partial signals.",
+    confidence: "high",
+    expected_improvement: "Adds consistent measurements.",
+    supporting_evidence: ["Length is directly measurable."],
+    limitations: ["Metrics do not establish editorial quality."],
+    alternative_assessments: []
+  };
+}
+
+function languageToolRecommendation() {
+  return {
+    relationship: "existing",
+    asset_kind: "languagetool",
+    catalog_asset_id: "catalog_languagetool_existing_families",
+    proposed_name: "LanguageTool capability families",
+    contribution: "Existing style signals may contribute after later evidence identifies applicable rules.",
+    confidence: "medium",
+    expected_improvement: "May add repeatable style warnings.",
+    supporting_evidence: ["The catalog describes a candidate capability family."],
+    limitations: ["No specific rule is established or verified; editorial judgment remains."],
+    alternative_assessments: []
+  };
+}
+
+test("normalizes untrusted transport output into stable local IDs regardless of response order", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const forwardResponse = conciseResponse();
+  const second = structuredClone(forwardResponse.opportunities[0]);
+  second.normalized_requirement = "Focus on what changed.";
+  second.source_refs[0].locator = "Focus on what changed.";
+  forwardResponse.opportunities.push(second);
+  const reversedResponse = structuredClone(forwardResponse);
+  reversedResponse.opportunities.reverse();
+  reversedResponse.opportunities.forEach((opportunity) => opportunity.recommendations.reverse());
+  const forward = normalizeAnalysisResponse(forwardResponse, catalog);
+  const reversed = normalizeAnalysisResponse(reversedResponse, catalog);
+  expect(serializeAnalysisOpportunities(forward)).toBe(serializeAnalysisOpportunities(reversed));
+  expect(canonicalAnalysisSha256(forward)).toBe(canonicalAnalysisSha256(reversed));
+  expect(forward.opportunities[0].id).toMatch(/^opp_[a-f0-9]{20}$/);
+  expect(
+    forward.opportunities[0].recommendations.every(({ lifecycle_status }) => lifecycle_status === "suggested")
+  ).toBe(true);
+});
+
+test("sorts source references canonically and preserves the same bytes and hash", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const forward = conciseResponse();
+  forward.opportunities[0].origin = "both";
+  forward.opportunities[0].source_refs.push({
+    path: "evaluation/eval-cases.json",
+    locator: "case:concise",
+    evidence_kind: "evaluation"
+  });
+  const reversed = structuredClone(forward);
+  reversed.opportunities[0].source_refs.reverse();
+  const normalizedForward = normalizeAnalysisResponse(forward, catalog);
+  const normalizedReversed = normalizeAnalysisResponse(reversed, catalog);
+  expect(serializeAnalysisOpportunities(normalizedForward)).toBe(serializeAnalysisOpportunities(normalizedReversed));
+  expect(canonicalAnalysisSha256(normalizedForward)).toBe(canonicalAnalysisSha256(normalizedReversed));
+});
+
+test("rejects mismatched namespaces, inconsistent origins, catalog provenance, and supplemental-only provenance", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+
+  const mismatched = conciseResponse();
+  mismatched.opportunities[0].source_refs[0].evidence_kind = "evaluation";
+  mismatched.opportunities[0].origin = "evaluation_evidence";
+  expect(() => normalizeAnalysisResponse(mismatched, catalog)).toThrow(/namespace skill does not match/);
+
+  const wrongOrigin = conciseResponse();
+  wrongOrigin.opportunities[0].origin = "evaluation_evidence";
+  expect(() => normalizeAnalysisResponse(wrongOrigin, catalog)).toThrow(/origin is inconsistent/);
+
+  const catalogSource = conciseResponse();
+  catalogSource.opportunities[0].source_refs[0].path = "catalog/language.json";
+  expect(() => normalizeAnalysisResponse(catalogSource, catalog)).toThrow(/namespace catalog does not match/);
+
+  const contextOnly = conciseResponse();
+  contextOnly.opportunities[0].source_refs = [
+    { path: "context/rubric.md", locator: "concise", evidence_kind: "context" }
+  ];
+  expect(() => normalizeAnalysisResponse(contextOnly, catalog)).toThrow(/origin is inconsistent/);
+});
+
+test("rejects transport IDs, lifecycle claims, unsupported schemas, and unknown catalog assets", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const withOpportunityId = conciseResponse() as ReturnType<typeof conciseResponse> & {
+    opportunities: Array<Record<string, unknown>>;
+  };
+  withOpportunityId.opportunities[0].id = "opp_model_owned";
+  expect(() => normalizeAnalysisResponse(withOpportunityId, catalog)).toThrow(/unsupported fields: id/);
+
+  const withLifecycle = conciseResponse();
+  Object.assign(withLifecycle.opportunities[0].recommendations[0] as Record<string, unknown>, {
+    lifecycle_status: "verified"
+  });
+  expect(() => normalizeAnalysisResponse(withLifecycle, catalog)).toThrow(/unsupported fields: lifecycle_status/);
+  expect(() => normalizeAnalysisResponse({ ...conciseResponse(), schema_version: "2.0.0" }, catalog)).toThrow(
+    /Unsupported analysis response schema/
+  );
+
+  const unknown = conciseResponse();
+  (unknown.opportunities[0].recommendations[0] as Record<string, unknown>).catalog_asset_id = "catalog_unknown_asset";
+  expect(() => normalizeAnalysisResponse(unknown, catalog)).toThrow(/Unknown catalog asset/);
+});
+
+test("rejects unjustified new assets before they become canonical", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const newAsset = {
+    relationship: "new",
+    asset_kind: "repository_validator",
+    proposed_name: "Concision policy validator",
+    contribution: "Could enforce a project-specific boundary.",
+    confidence: "low",
+    expected_improvement: "Might add a consistent project signal.",
+    supporting_evidence: ["The project has a local convention."],
+    limitations: ["Its threshold is not evidenced."],
+    alternative_assessments: []
+  };
+  expect(() => normalizeAnalysisResponse(conciseResponse([newAsset]), catalog)).toThrow(
+    /Invalid analysis opportunities/
+  );
+});
+
+test("fails closed when canonical opportunity bytes do not match their expected hash", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const document = normalizeAnalysisResponse(conciseResponse(), catalog);
+  expect(() => validateCanonicalAnalysis(document, catalog, "0".repeat(64))).toThrow(/hash mismatch/);
+});

--- a/tests/determinization-analyzer.test.ts
+++ b/tests/determinization-analyzer.test.ts
@@ -1,14 +1,19 @@
-import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { normalizeAnalysisResponse } from "../src/determinization/analyzer.js";
 import { loadDeterministicAssetCatalog } from "../src/determinization/catalog.js";
-import { canonicalAnalysisSha256, serializeAnalysisOpportunities } from "../src/determinization/schemas.js";
+import { renderDeterminizationReport } from "../src/determinization/report.js";
+import {
+  DETERMINIZATION_SCHEMA_VERSION,
+  canonicalAnalysisSha256,
+  serializeAnalysisOpportunities
+} from "../src/determinization/schemas.js";
 import { validateCanonicalAnalysis } from "../src/determinization/validation.js";
 
-const catalogPath = resolve("catalog/deterministic-assets/catalog.json");
+const catalogPath = fileURLToPath(new URL("../catalog/deterministic-assets/catalog.json", import.meta.url));
 
 function conciseResponse(recommendations?: unknown[]) {
   return {
-    schema_version: "1.0.0",
+    schema_version: DETERMINIZATION_SCHEMA_VERSION,
     opportunities: [
       {
         source_refs: [{ path: "skill/SKILL.md", locator: "Keep the output concise.", evidence_kind: "skill" }],
@@ -58,6 +63,28 @@ function languageToolRecommendation() {
   };
 }
 
+function configurableLanguageToolRecommendation() {
+  return {
+    relationship: "configurable",
+    asset_kind: "languagetool",
+    catalog_asset_id: "catalog_languagetool_project_configuration",
+    proposed_name: "LanguageTool project configuration",
+    contribution: "Project configuration may select applicable rules.",
+    confidence: "medium",
+    expected_improvement: "May make selected checks repeatable.",
+    supporting_evidence: ["The catalog describes a configurable capability."],
+    limitations: ["Applicable rules still require evidence."],
+    alternative_assessments: [
+      {
+        relationship: "existing",
+        catalog_asset_ids: ["catalog_languagetool_existing_families"],
+        conclusion: "insufficient",
+        rationale: "Existing families require project-specific selection."
+      }
+    ]
+  };
+}
+
 test("normalizes untrusted transport output into stable local IDs regardless of response order", async () => {
   const catalog = await loadDeterministicAssetCatalog(catalogPath);
   const forwardResponse = conciseResponse();
@@ -78,6 +105,25 @@ test("normalizes untrusted transport output into stable local IDs regardless of 
   ).toBe(true);
 });
 
+test("maps every catalog-owned recommendation field to exact catalog metadata", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const catalogAsset = catalog.assets.find(({ id }) => id === "catalog_text_metrics");
+  const document = normalizeAnalysisResponse(conciseResponse(), catalog);
+  const recommendation = document.opportunities[0].recommendations.find(
+    ({ catalog_asset_id }) => catalog_asset_id === catalogAsset?.id
+  );
+
+  expect(catalogAsset).toBeDefined();
+  expect(recommendation).toMatchObject({
+    proposed_name: catalogAsset?.name,
+    contribution: catalogAsset?.contribution,
+    expected_improvement:
+      "Potential improvement requires later evidence and verification; catalog metadata establishes only the stated capability contribution.",
+    supporting_evidence: [`Catalog capability evidence basis: ${catalogAsset?.evidence_basis}`],
+    limitations: catalogAsset?.limitations.map((limitation) => `Catalog capability limitation: ${limitation}`)
+  });
+});
+
 test("sorts source references canonically and preserves the same bytes and hash", async () => {
   const catalog = await loadDeterministicAssetCatalog(catalogPath);
   const forward = conciseResponse();
@@ -93,6 +139,21 @@ test("sorts source references canonically and preserves the same bytes and hash"
   const normalizedReversed = normalizeAnalysisResponse(reversed, catalog);
   expect(serializeAnalysisOpportunities(normalizedForward)).toBe(serializeAnalysisOpportunities(normalizedReversed));
   expect(canonicalAnalysisSha256(normalizedForward)).toBe(canonicalAnalysisSha256(normalizedReversed));
+});
+
+test("normalizes composed and decomposed source-reference paths to the same canonical identity", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const composed = conciseResponse();
+  composed.opportunities[0].source_refs[0].path = "skill/caf\u00e9.md";
+  const decomposed = structuredClone(composed);
+  decomposed.opportunities[0].source_refs[0].path = "skill/cafe\u0301.md";
+
+  const normalizedComposed = normalizeAnalysisResponse(composed, catalog);
+  const normalizedDecomposed = normalizeAnalysisResponse(decomposed, catalog);
+
+  expect(normalizedDecomposed.opportunities[0].source_refs[0].path).toBe("skill/caf\u00e9.md");
+  expect(serializeAnalysisOpportunities(normalizedDecomposed)).toBe(serializeAnalysisOpportunities(normalizedComposed));
+  expect(normalizedDecomposed.opportunities[0].id).toBe(normalizedComposed.opportunities[0].id);
 });
 
 test("rejects mismatched namespaces, inconsistent origins, catalog provenance, and supplemental-only provenance", async () => {
@@ -138,6 +199,58 @@ test("rejects transport IDs, lifecycle claims, unsupported schemas, and unknown 
   const unknown = conciseResponse();
   (unknown.opportunities[0].recommendations[0] as Record<string, unknown>).catalog_asset_id = "catalog_unknown_asset";
   expect(() => normalizeAnalysisResponse(unknown, catalog)).toThrow(/Unknown catalog asset/);
+});
+
+test("rejects unknown or incomplete alternative assessment fields", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const withUnknownField = configurableLanguageToolRecommendation();
+  Object.assign(withUnknownField.alternative_assessments[0], { unexpected: true });
+  expect(() => normalizeAnalysisResponse(conciseResponse([withUnknownField]), catalog)).toThrow(
+    /Alternative assessment 0\.0 contains unsupported fields: unexpected/
+  );
+
+  const withoutRationale = configurableLanguageToolRecommendation();
+  delete (withoutRationale.alternative_assessments[0] as { rationale?: string }).rationale;
+  expect(() => normalizeAnalysisResponse(conciseResponse([withoutRationale]), catalog)).toThrow(
+    /Invalid analysis opportunities/
+  );
+});
+
+test("rejects invalid recommendation identity field types before deriving IDs", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  for (const [field, value, message] of [
+    ["relationship", 1, /relationship and asset_kind must be text/],
+    ["asset_kind", { kind: "script" }, /relationship and asset_kind must be text/],
+    ["catalog_asset_id", { id: "catalog_text_metrics" }, /catalog_asset_id must be text/],
+    ["proposed_name", ["Text metrics"], /proposed_name must be text/]
+  ] as const) {
+    const response = conciseResponse();
+    (response.opportunities[0].recommendations[0] as Record<string, unknown>)[field] = value;
+    expect(() => normalizeAnalysisResponse(response, catalog)).toThrow(message);
+  }
+});
+
+test("renders the LanguageTool disclaimer only for opportunities that suggest LanguageTool", async () => {
+  const catalog = await loadDeterministicAssetCatalog(catalogPath);
+  const withoutLanguageTool = normalizeAnalysisResponse(conciseResponse([metricsRecommendation()]), catalog);
+  const withoutLanguageToolHash = canonicalAnalysisSha256(withoutLanguageTool);
+  const lineage = {
+    schema_version: DETERMINIZATION_SCHEMA_VERSION,
+    source_opportunities_sha256: withoutLanguageToolHash,
+    opportunity_ids: withoutLanguageTool.opportunities.map(({ id }) => id)
+  };
+  const disclaimer = "LanguageTool references describe candidate capability families only.";
+
+  expect(renderDeterminizationReport(withoutLanguageTool, lineage)).not.toContain(disclaimer);
+
+  const withLanguageTool = normalizeAnalysisResponse(conciseResponse(), catalog);
+  expect(
+    renderDeterminizationReport(withLanguageTool, {
+      ...lineage,
+      source_opportunities_sha256: canonicalAnalysisSha256(withLanguageTool),
+      opportunity_ids: withLanguageTool.opportunities.map(({ id }) => id)
+    })
+  ).toContain(disclaimer);
 });
 
 test("rejects unjustified new assets before they become canonical", async () => {

--- a/tests/determinization-artifacts.test.ts
+++ b/tests/determinization-artifacts.test.ts
@@ -1,7 +1,12 @@
-import { cp, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { writeAnalysisArtifacts } from "../src/determinization/artifacts.js";
+import {
+  assertAnalysisArtifactBoundary,
+  resumeAnalysisArtifacts,
+  writeAnalysisArtifacts
+} from "../src/determinization/artifacts.js";
+import { serializeCanonical, sha256 } from "../src/determinization/canonical.js";
 import { loadDeterministicAssetCatalog } from "../src/determinization/catalog.js";
 import type { SourceSelection } from "../src/determinization/source.js";
 
@@ -93,13 +98,19 @@ async function artifactBytes(root: string) {
 test("writes deterministic hash-linked artifacts across fresh temporary directories", async () => {
   const first = await workspace("det-artifacts-one-");
   const second = await workspace("det-artifacts-two-");
-  const transcript = { request: { role: "determinizer" }, response: conciseResponse() };
+  const expectedAnalysisRequest = {
+    system: "determinize",
+    prompt: "analyze",
+    model: { provider: "anthropic", name: "fixture" }
+  };
+  const transcript = { request: expectedAnalysisRequest, response: conciseResponse() };
   const one = await writeAnalysisArtifacts({
     outputRoot: join(first.root, "workspace/determinization"),
     selections: first.selections,
     catalogIndexPath: first.catalogIndexPath,
     analysis: { role: "determinizer", transport: "direct_model", model: { provider: "anthropic", name: "fixture" } },
     analysisResponse: conciseResponse(),
+    expectedAnalysisRequest,
     transcript
   });
   const two = await writeAnalysisArtifacts({
@@ -108,6 +119,7 @@ test("writes deterministic hash-linked artifacts across fresh temporary director
     catalogIndexPath: second.catalogIndexPath,
     analysis: { role: "determinizer", transport: "direct_model", model: { provider: "anthropic", name: "fixture" } },
     analysisResponse: conciseResponse(),
+    expectedAnalysisRequest,
     transcript
   });
   expect(await artifactBytes(one.paths.root)).toEqual(await artifactBytes(two.paths.root));
@@ -116,11 +128,16 @@ test("writes deterministic hash-linked artifacts across fresh temporary director
     expect(await readFile(path, "utf8")).toContain(one.sourceOpportunitiesSha256);
   }
   expect(canonical).not.toContain("audit_only");
-  const source = JSON.parse(await readFile(one.paths.source, "utf8")) as { inputs: Array<{ path: string }> };
+  const source = JSON.parse(await readFile(one.paths.source, "utf8")) as {
+    analysis: { request_sha256: string; response_sha256: string };
+    inputs: Array<{ path: string }>;
+  };
   expect(source.inputs.filter(({ path }) => path.startsWith("catalog/")).map(({ path }) => path)).toEqual(
     catalogPaths.map((path) => `catalog/${path}`).sort()
   );
   expect(await readFile(one.paths.source, "utf8")).toContain('"role": "determinizer"');
+  expect(source.analysis.request_sha256).toMatch(/^[a-f0-9]{64}$/);
+  expect(source.analysis.response_sha256).toMatch(/^[a-f0-9]{64}$/);
   expect(one.opportunityCount).toBe(1);
   expect(one.recommendationCount).toBe(2);
 });
@@ -159,6 +176,9 @@ test("leaves selected skill, context, and catalog unchanged on success and failu
     catalogIndexPath: project.catalogIndexPath,
     analysisResponse: conciseResponse()
   });
+  await expect(
+    assertAnalysisArtifactBoundary(join(project.skill, "preflight-generated"), project.selections)
+  ).rejects.toThrow(/must not be inside/);
   await expect(
     writeAnalysisArtifacts({
       outputRoot: join(project.root, "failed-output"),
@@ -203,6 +223,86 @@ test("leaves selected skill, context, and catalog unchanged on success and failu
       analysisResponse: conciseResponse()
     })
   ).rejects.toThrow(/must not be inside/);
+});
+
+test("resume rejects tampered, non-canonical, or semantically unrelated transcripts", async () => {
+  const project = await workspace("det-artifacts-transcript-resume-");
+  const outputRoot = join(project.root, "workspace/determinization");
+  const model = { provider: "anthropic", name: "fixture" };
+  const response = conciseResponse();
+  const expectedAnalysisRequest = { system: "determinize", prompt: "canonical prompt", model };
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.root, "mismatched-transcript"),
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      analysis: { role: "determinizer", transport: "direct_model", model },
+      analysisResponse: response,
+      expectedAnalysisRequest,
+      transcript: {
+        request: { ...expectedAnalysisRequest, prompt: "different prompt" },
+        response
+      }
+    })
+  ).rejects.toThrow(/does not match the expected analysis request/);
+  const result = await writeAnalysisArtifacts({
+    outputRoot,
+    selections: project.selections,
+    catalogIndexPath: project.catalogIndexPath,
+    analysis: { role: "determinizer", transport: "direct_model", model },
+    analysisResponse: response,
+    expectedAnalysisRequest,
+    transcript: {
+      request: expectedAnalysisRequest,
+      response
+    }
+  });
+  const originalTranscript = await readFile(result.paths.transcript, "utf8");
+  await rm(result.paths.report);
+  const resume = () =>
+    resumeAnalysisArtifacts({
+      outputRoot,
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      expectedModel: model,
+      expectedAnalysisRequest
+    });
+
+  const wrongSchema = JSON.parse(originalTranscript) as Record<string, unknown>;
+  wrongSchema.schema_version = "9.9.9";
+  await writeFile(result.paths.transcript, serializeCanonical(wrongSchema));
+  await expect(resume()).rejects.toThrow(/transcript provenance/);
+  await expect(readFile(result.paths.report, "utf8")).rejects.toThrow(/ENOENT/);
+
+  const wrongRequest = JSON.parse(originalTranscript) as Record<string, unknown>;
+  wrongRequest.request = {
+    system: "replacement system",
+    prompt: "replacement prompt",
+    model
+  };
+  wrongRequest.request_sha256 = sha256(serializeCanonical(wrongRequest.request));
+  await writeFile(result.paths.transcript, serializeCanonical(wrongRequest));
+  await expect(resume()).rejects.toThrow(/transcript provenance/);
+
+  const wrongResponse = JSON.parse(originalTranscript) as Record<string, unknown>;
+  wrongResponse.response = { schema_version: "1.0.0", opportunities: [] };
+  wrongResponse.response_sha256 = sha256(serializeCanonical(wrongResponse.response));
+  await writeFile(result.paths.transcript, serializeCanonical(wrongResponse));
+  await expect(resume()).rejects.toThrow(/transcript provenance/);
+
+  const overwrittenCatalogField = JSON.parse(originalTranscript) as Record<string, unknown>;
+  const overwrittenResponse = overwrittenCatalogField.response as {
+    opportunities: Array<{ recommendations: Array<Record<string, unknown>> }>;
+  };
+  overwrittenResponse.opportunities[0].recommendations[0].contribution =
+    "Tampered raw claim that normalization would replace";
+  overwrittenCatalogField.response_sha256 = sha256(serializeCanonical(overwrittenResponse));
+  await writeFile(result.paths.transcript, serializeCanonical(overwrittenCatalogField));
+  await expect(resume()).rejects.toThrow(/transcript provenance/);
+  await expect(readFile(result.paths.report, "utf8")).rejects.toThrow(/ENOENT/);
+
+  await writeFile(result.paths.transcript, `${originalTranscript.trimEnd()}  \n`);
+  await expect(resume()).rejects.toThrow(/transcript provenance/);
 });
 
 test("rejects nested output-directory and artifact-file symlinks without writing through them", async () => {
@@ -317,12 +417,26 @@ test("catalog capability metadata overrides adversarial model claims while trans
   languageTool.expected_improvement = marker;
   languageTool.supporting_evidence = [marker];
   languageTool.limitations = [marker];
+  const expectedAnalysisRequest = {
+    system: "determinize",
+    prompt: "analyze catalog claims",
+    model: { provider: "anthropic", name: "fixture" }
+  };
   const result = await writeAnalysisArtifacts({
     outputRoot: join(project.root, "workspace/determinization"),
     selections: project.selections,
     catalogIndexPath: project.catalogIndexPath,
+    analysis: {
+      role: "determinizer",
+      transport: "direct_model",
+      model: { provider: "anthropic", name: "fixture" }
+    },
     analysisResponse: response,
-    transcript: { request: { role: "determinizer" }, response }
+    expectedAnalysisRequest,
+    transcript: {
+      request: expectedAnalysisRequest,
+      response
+    }
   });
   const canonical = await readFile(result.paths.opportunities, "utf8");
   const report = await readFile(result.paths.report, "utf8");

--- a/tests/determinization-artifacts.test.ts
+++ b/tests/determinization-artifacts.test.ts
@@ -1,0 +1,335 @@
+import { cp, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { writeAnalysisArtifacts } from "../src/determinization/artifacts.js";
+import { loadDeterministicAssetCatalog } from "../src/determinization/catalog.js";
+import type { SourceSelection } from "../src/determinization/source.js";
+
+const catalogIndex = resolve("catalog/deterministic-assets/catalog.json");
+const catalogRoot = dirname(catalogIndex);
+const catalogPaths = ["catalog.json", "javascript-typescript.json", "language.json", "markdown.json"];
+
+function conciseResponse() {
+  return {
+    schema_version: "1.0.0",
+    opportunities: [
+      {
+        source_refs: [{ path: "skill/SKILL.md", locator: "Keep the output concise.", evidence_kind: "skill" }],
+        normalized_requirement: "Keep the output concise.",
+        origin: "skill_guidance",
+        classification: "partially_deterministic",
+        current_automation_potential: "medium",
+        remaining_human_judgment:
+          "Editorial judgment must determine whether the result is useful and appropriately concise.",
+        recommendations: [
+          {
+            relationship: "existing",
+            asset_kind: "script",
+            catalog_asset_id: "catalog_text_metrics",
+            proposed_name: "Text metrics",
+            contribution: "Word and sentence counts can provide partial signals.",
+            confidence: "high",
+            expected_improvement: "Adds consistent measurements.",
+            supporting_evidence: ["Length is directly measurable."],
+            limitations: ["Metrics do not establish editorial quality."],
+            alternative_assessments: []
+          },
+          {
+            relationship: "existing",
+            asset_kind: "languagetool",
+            catalog_asset_id: "catalog_languagetool_existing_families",
+            proposed_name: "LanguageTool capability families",
+            contribution: "Existing style signals may contribute after later evidence identifies applicable rules.",
+            confidence: "medium",
+            expected_improvement: "May add repeatable style warnings.",
+            supporting_evidence: ["The catalog describes a candidate capability family."],
+            limitations: ["No specific rule is established or verified; editorial judgment remains."],
+            alternative_assessments: []
+          }
+        ],
+        confidence: "high",
+        expected_improvement: "Repeatable signals can reduce inconsistent review without replacing an editor.",
+        supporting_evidence: ["Length is measurable, while usefulness and clarity remain contextual."],
+        limitations: ["No deterministic asset fully establishes concision."]
+      }
+    ]
+  };
+}
+
+async function workspace(prefix: string, selectedCatalogRoot = catalogRoot) {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  const skill = join(root, "selected-skill");
+  const context = join(root, "context");
+  await import("node:fs/promises").then(({ mkdir }) => Promise.all([mkdir(skill), mkdir(context)]));
+  await writeFile(join(skill, "SKILL.md"), "# Release Summary\n\nKeep the output concise.\n");
+  await writeFile(join(context, "rubric.md"), "Prefer useful, concise release notes.\n");
+  const selections: SourceSelection[] = [
+    { namespace: "skill", root: skill, paths: ["SKILL.md"] },
+    { namespace: "context", root: context, paths: ["rubric.md"] },
+    { namespace: "catalog", root: selectedCatalogRoot, paths: catalogPaths }
+  ];
+  return {
+    root,
+    skill,
+    context,
+    selections,
+    catalogRoot: selectedCatalogRoot,
+    catalogIndexPath: join(selectedCatalogRoot, "catalog.json")
+  };
+}
+
+async function artifactBytes(root: string) {
+  const relativePaths = [
+    "source.json",
+    "opportunities.json",
+    "report.md",
+    "research-request.json",
+    "prompts/research.md",
+    "transcript.json"
+  ];
+  return Promise.all(relativePaths.map((path) => readFile(join(root, path), "utf8")));
+}
+
+test("writes deterministic hash-linked artifacts across fresh temporary directories", async () => {
+  const first = await workspace("det-artifacts-one-");
+  const second = await workspace("det-artifacts-two-");
+  const transcript = { request: { role: "determinizer" }, response: conciseResponse() };
+  const one = await writeAnalysisArtifacts({
+    outputRoot: join(first.root, "workspace/determinization"),
+    selections: first.selections,
+    catalogIndexPath: first.catalogIndexPath,
+    analysis: { role: "determinizer", transport: "direct_model", model: { provider: "anthropic", name: "fixture" } },
+    analysisResponse: conciseResponse(),
+    transcript
+  });
+  const two = await writeAnalysisArtifacts({
+    outputRoot: join(second.root, "workspace/determinization"),
+    selections: second.selections,
+    catalogIndexPath: second.catalogIndexPath,
+    analysis: { role: "determinizer", transport: "direct_model", model: { provider: "anthropic", name: "fixture" } },
+    analysisResponse: conciseResponse(),
+    transcript
+  });
+  expect(await artifactBytes(one.paths.root)).toEqual(await artifactBytes(two.paths.root));
+  const canonical = await readFile(one.paths.opportunities, "utf8");
+  for (const path of [one.paths.report, one.paths.researchRequest, one.paths.researchPrompt, one.paths.transcript]) {
+    expect(await readFile(path, "utf8")).toContain(one.sourceOpportunitiesSha256);
+  }
+  expect(canonical).not.toContain("audit_only");
+  const source = JSON.parse(await readFile(one.paths.source, "utf8")) as { inputs: Array<{ path: string }> };
+  expect(source.inputs.filter(({ path }) => path.startsWith("catalog/")).map(({ path }) => path)).toEqual(
+    catalogPaths.map((path) => `catalog/${path}`).sort()
+  );
+  expect(await readFile(one.paths.source, "utf8")).toContain('"role": "determinizer"');
+  expect(one.opportunityCount).toBe(1);
+  expect(one.recommendationCount).toBe(2);
+});
+
+test("resumes only byte-identical artifacts and rejects partial mismatches", async () => {
+  const project = await workspace("det-artifacts-resume-");
+  const options = {
+    outputRoot: join(project.root, "workspace/determinization"),
+    selections: project.selections,
+    catalogIndexPath: project.catalogIndexPath,
+    analysisResponse: conciseResponse()
+  };
+  const first = await writeAnalysisArtifacts(options);
+  const resumed = await writeAnalysisArtifacts(options);
+  expect(resumed.resumedFiles.length).toBe(first.createdFiles.length);
+  const canonical = await readFile(first.paths.opportunities, "utf8");
+  await writeFile(first.paths.opportunities, `${canonical.trimEnd()} \n`);
+  await expect(writeAnalysisArtifacts(options)).rejects.toThrow(/does not match canonical bytes/);
+  await writeFile(first.paths.opportunities, canonical);
+  await writeFile(first.paths.report, "stale report\n");
+  await expect(writeAnalysisArtifacts(options)).rejects.toThrow(/does not match canonical bytes/);
+  expect(await readFile(first.paths.opportunities, "utf8")).toContain('"schema_version": "1.0.0"');
+});
+
+test("leaves selected skill, context, and catalog unchanged on success and failure", async () => {
+  const project = await workspace("det-artifacts-readonly-");
+  const selected = [
+    join(project.skill, "SKILL.md"),
+    join(project.context, "rubric.md"),
+    ...catalogPaths.map((path) => join(project.catalogRoot, path))
+  ];
+  const before = await Promise.all(selected.map((path) => readFile(path)));
+  await writeAnalysisArtifacts({
+    outputRoot: join(project.root, "workspace/determinization"),
+    selections: project.selections,
+    catalogIndexPath: project.catalogIndexPath,
+    analysisResponse: conciseResponse()
+  });
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.root, "failed-output"),
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      analysisResponse: { schema_version: "9.0.0", opportunities: [] }
+    })
+  ).rejects.toThrow(/Unsupported/);
+  expect(await Promise.all(selected.map((path) => readFile(path)))).toEqual(before);
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.skill, "generated"),
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/must not be inside/);
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.root, "unselected-catalog-output"),
+      selections: project.selections,
+      catalogIndexPath: join(project.context, "rubric.md"),
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/selected catalog root/);
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.root, "incomplete-catalog-output"),
+      selections: project.selections.map((selection) =>
+        selection.namespace === "catalog" ? { ...selection, paths: ["catalog.json"] } : selection
+      ),
+      catalogIndexPath: project.catalogIndexPath,
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/every schema 1.0.0 domain file/);
+  await symlink(project.skill, join(project.root, "redirected-output"));
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.root, "redirected-output/generated"),
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/must not be inside/);
+});
+
+test("rejects nested output-directory and artifact-file symlinks without writing through them", async () => {
+  const directoryProject = await workspace("det-artifacts-directory-symlink-");
+  const directoryOutput = join(directoryProject.root, "workspace/determinization");
+  await mkdir(directoryOutput, { recursive: true });
+  await symlink(directoryProject.skill, join(directoryOutput, "prompts"));
+  const skillBefore = await readFile(join(directoryProject.skill, "SKILL.md"), "utf8");
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: directoryOutput,
+      selections: directoryProject.selections,
+      catalogIndexPath: directoryProject.catalogIndexPath,
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/directory component must not be a symlink/);
+  expect(await readFile(join(directoryProject.skill, "SKILL.md"), "utf8")).toBe(skillBefore);
+  await expect(readFile(join(directoryProject.skill, "research.md"), "utf8")).rejects.toThrow(/ENOENT/);
+
+  const fileProject = await workspace("det-artifacts-file-symlink-");
+  const fileOutput = join(fileProject.root, "workspace/determinization");
+  await mkdir(fileOutput, { recursive: true });
+  await symlink(join(fileProject.skill, "SKILL.md"), join(fileOutput, "opportunities.json"));
+  const fileSkillBefore = await readFile(join(fileProject.skill, "SKILL.md"), "utf8");
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: fileOutput,
+      selections: fileProject.selections,
+      catalogIndexPath: fileProject.catalogIndexPath,
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/Artifact file must not be a symlink/);
+  expect(await readFile(join(fileProject.skill, "SKILL.md"), "utf8")).toBe(fileSkillBefore);
+});
+
+test("report and research projection preserve the read-only phase boundary", async () => {
+  const project = await workspace("det-artifacts-claims-");
+  const response = conciseResponse();
+  response.opportunities[0].supporting_evidence = ["Line one\n# injected heading remains one field."];
+  const result = await writeAnalysisArtifacts({
+    outputRoot: join(project.root, "workspace/determinization"),
+    selections: project.selections,
+    catalogIndexPath: project.catalogIndexPath,
+    analysisResponse: response
+  });
+  const report = await readFile(result.paths.report, "utf8");
+  expect(report).toContain("partially_deterministic");
+  expect(report).toContain("Origin: skill_guidance");
+  expect(report).toContain("skill/SKILL.md \\[skill\\]");
+  expect(report).toContain("Relationship: existing");
+  expect(report).toContain("Catalog reference: catalog_text_metrics");
+  expect(report).toContain("Lower-tier alternative assessments");
+  expect(report).toContain("Line one \\# injected heading remains one field.");
+  expect(report).not.toContain("Line one\n# injected heading");
+  expect(report.endsWith("\n")).toBe(true);
+  expect(report.endsWith("\n\n")).toBe(false);
+  expect(report).toContain("suggested and unverified");
+  expect(report).toMatch(/[Ee]ditorial judgment/);
+  expect(report).toContain("no LanguageTool signal by itself fully establishes concision");
+  expect(report).not.toMatch(/lifecycle_status: (?:verified|adopted)/);
+  const prompt = await readFile(result.paths.researchPrompt, "utf8");
+  expect(prompt).toContain("read-only evidence request");
+  expect(prompt).toContain("authoritative evidence");
+  expect(prompt).not.toContain("Apply the");
+  expect(prompt).toContain("catalog\\_text\\_metrics");
+  expect(prompt).toContain("product or rule versions, language variants, runtime constraints, and configuration");
+  expect(prompt).toContain("Contribution: Deterministic metrics can measure properties");
+  expect(prompt).toContain("Existing evidence: Catalog capability evidence basis:");
+  expect(prompt).toContain("Line one \\# injected heading remains one field.");
+  expect(prompt).not.toContain("\n# injected heading");
+  const request = JSON.parse(await readFile(result.paths.researchRequest, "utf8")) as {
+    opportunity_requests: Array<{
+      source_refs: unknown[];
+      suggested_assets: Array<{ contribution: string; supporting_evidence: string[]; evidence_questions: string[] }>;
+    }>;
+  };
+  expect(request.opportunity_requests[0].source_refs).toHaveLength(1);
+  expect(request.opportunity_requests[0].suggested_assets[0].contribution).toBeTruthy();
+  expect(request.opportunity_requests[0].suggested_assets[0].supporting_evidence).toHaveLength(1);
+  expect(request.opportunity_requests[0].suggested_assets[0].evidence_questions).toHaveLength(3);
+});
+
+test("loads the catalog from selected bytes instead of accepting an earlier stale catalog", async () => {
+  const root = await mkdtemp(join(tmpdir(), "det-artifacts-catalog-freshness-"));
+  const copiedCatalog = join(root, "catalog");
+  await mkdir(copiedCatalog);
+  await Promise.all(catalogPaths.map((path) => cp(join(catalogRoot, path), join(copiedCatalog, path))));
+  const stalePriorLoad = await loadDeterministicAssetCatalog(join(copiedCatalog, "catalog.json"));
+  expect(stalePriorLoad.assets.some(({ id }) => id === "catalog_text_metrics")).toBe(true);
+  const languagePath = join(copiedCatalog, "language.json");
+  const language = JSON.parse(await readFile(languagePath, "utf8")) as { assets: Array<{ id: string }> };
+  language.assets = language.assets.filter(({ id }) => id !== "catalog_text_metrics");
+  await writeFile(languagePath, `${JSON.stringify(language, null, 2)}\n`);
+  const project = await workspace("det-artifacts-catalog-project-", copiedCatalog);
+  await expect(
+    writeAnalysisArtifacts({
+      outputRoot: join(project.root, "workspace/determinization"),
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      analysisResponse: conciseResponse()
+    })
+  ).rejects.toThrow(/Unknown catalog asset/);
+});
+
+test("catalog capability metadata overrides adversarial model claims while transcript retains the raw response", async () => {
+  const project = await workspace("det-artifacts-catalog-claims-");
+  const response = conciseResponse();
+  const marker = "EXISTING_CONFIGURED_VERIFIED_FULLY_SOLVES_CONCISION";
+  const languageTool = response.opportunities[0].recommendations[1];
+  languageTool.proposed_name = marker;
+  languageTool.contribution = marker;
+  languageTool.expected_improvement = marker;
+  languageTool.supporting_evidence = [marker];
+  languageTool.limitations = [marker];
+  const result = await writeAnalysisArtifacts({
+    outputRoot: join(project.root, "workspace/determinization"),
+    selections: project.selections,
+    catalogIndexPath: project.catalogIndexPath,
+    analysisResponse: response,
+    transcript: { request: { role: "determinizer" }, response }
+  });
+  const canonical = await readFile(result.paths.opportunities, "utf8");
+  const report = await readFile(result.paths.report, "utf8");
+  const transcript = await readFile(result.paths.transcript, "utf8");
+  expect(canonical).not.toContain(marker);
+  expect(report).not.toContain(marker);
+  expect(canonical).toContain("This catalogs a capability family only");
+  expect(report).toContain("suggested (unverified)");
+  expect(transcript).toContain(marker);
+});

--- a/tests/determinization-artifacts.test.ts
+++ b/tests/determinization-artifacts.test.ts
@@ -6,8 +6,14 @@ import {
   resumeAnalysisArtifacts,
   writeAnalysisArtifacts
 } from "../src/determinization/artifacts.js";
+import { normalizeAnalysisResponse } from "../src/determinization/analyzer.js";
 import { serializeCanonical, sha256 } from "../src/determinization/canonical.js";
 import { loadDeterministicAssetCatalog } from "../src/determinization/catalog.js";
+import {
+  canonicalAnalysisSha256,
+  orderAnalysisOpportunities,
+  serializeAnalysisOpportunities
+} from "../src/determinization/schemas.js";
 import type { SourceSelection } from "../src/determinization/source.js";
 
 const catalogIndex = resolve("catalog/deterministic-assets/catalog.json");
@@ -65,7 +71,7 @@ async function workspace(prefix: string, selectedCatalogRoot = catalogRoot) {
   const root = await mkdtemp(join(tmpdir(), prefix));
   const skill = join(root, "selected-skill");
   const context = join(root, "context");
-  await import("node:fs/promises").then(({ mkdir }) => Promise.all([mkdir(skill), mkdir(context)]));
+  await Promise.all([mkdir(skill), mkdir(context)]);
   await writeFile(join(skill, "SKILL.md"), "# Release Summary\n\nKeep the output concise.\n");
   await writeFile(join(context, "rubric.md"), "Prefer useful, concise release notes.\n");
   const selections: SourceSelection[] = [
@@ -258,6 +264,7 @@ test("resume rejects tampered, non-canonical, or semantically unrelated transcri
     }
   });
   const originalTranscript = await readFile(result.paths.transcript, "utf8");
+  const originalReport = await readFile(result.paths.report, "utf8");
   await rm(result.paths.report);
   const resume = () =>
     resumeAnalysisArtifacts({
@@ -271,8 +278,18 @@ test("resume rejects tampered, non-canonical, or semantically unrelated transcri
   const wrongSchema = JSON.parse(originalTranscript) as Record<string, unknown>;
   wrongSchema.schema_version = "9.9.9";
   await writeFile(result.paths.transcript, serializeCanonical(wrongSchema));
-  await expect(resume()).rejects.toThrow(/transcript provenance/);
+  await expect(resume()).rejects.toThrow(/transcript shape/);
   await expect(readFile(result.paths.report, "utf8")).rejects.toThrow(/ENOENT/);
+
+  const extraField = JSON.parse(originalTranscript) as Record<string, unknown>;
+  extraField.unexpected = true;
+  await writeFile(result.paths.transcript, serializeCanonical(extraField));
+  await expect(resume()).rejects.toThrow(/transcript shape/);
+
+  const missingRequest = JSON.parse(originalTranscript) as Record<string, unknown>;
+  delete missingRequest.request;
+  await writeFile(result.paths.transcript, serializeCanonical(missingRequest));
+  await expect(resume()).rejects.toThrow(/transcript shape/);
 
   const wrongRequest = JSON.parse(originalTranscript) as Record<string, unknown>;
   wrongRequest.request = {
@@ -303,6 +320,69 @@ test("resume rejects tampered, non-canonical, or semantically unrelated transcri
 
   await writeFile(result.paths.transcript, `${originalTranscript.trimEnd()}  \n`);
   await expect(resume()).rejects.toThrow(/transcript provenance/);
+
+  await writeFile(result.paths.transcript, originalTranscript);
+  const resumed = await resume();
+  expect(await readFile(result.paths.report, "utf8")).toBe(originalReport);
+  expect(resumed.createdFiles).toEqual([result.paths.report]);
+  expect(resumed.resumedFiles).toEqual([
+    result.paths.source,
+    result.paths.opportunities,
+    result.paths.researchRequest,
+    result.paths.researchPrompt
+  ]);
+  expect(resumed.sourceOpportunitiesSha256).toBe(result.sourceOpportunitiesSha256);
+});
+
+test("resume rejects a self-consistent chain with an unselected source reference", async () => {
+  const project = await workspace("det-artifacts-resume-source-reference-");
+  const outputRoot = join(project.root, "workspace/determinization");
+  const model = { provider: "anthropic", name: "fixture" };
+  const expectedAnalysisRequest = { system: "determinize", prompt: "canonical prompt", model };
+  const result = await writeAnalysisArtifacts({
+    outputRoot,
+    selections: project.selections,
+    catalogIndexPath: project.catalogIndexPath,
+    analysis: { role: "determinizer", transport: "direct_model", model },
+    analysisResponse: conciseResponse(),
+    expectedAnalysisRequest,
+    transcript: { request: expectedAnalysisRequest, response: conciseResponse() }
+  });
+  const tamperedResponse = conciseResponse();
+  tamperedResponse.opportunities[0].source_refs[0].path = "skill/not-selected.md";
+  const catalog = await loadDeterministicAssetCatalog(project.catalogIndexPath);
+  const analysis = orderAnalysisOpportunities(normalizeAnalysisResponse(tamperedResponse, catalog));
+  const opportunitiesBytes = serializeAnalysisOpportunities(analysis);
+  const opportunitiesHash = canonicalAnalysisSha256(analysis);
+  const responseHash = sha256(serializeCanonical(tamperedResponse));
+  const source = JSON.parse(await readFile(result.paths.source, "utf8")) as {
+    analysis: { response_sha256: string };
+  } & Record<string, unknown>;
+  source.analysis.response_sha256 = responseHash;
+  const sourceBytes = serializeCanonical(source);
+  const transcript = JSON.parse(await readFile(result.paths.transcript, "utf8")) as Record<string, unknown>;
+  transcript.response = tamperedResponse;
+  transcript.response_sha256 = responseHash;
+  transcript.source_manifest_sha256 = sha256(sourceBytes);
+  transcript.source_opportunities_sha256 = opportunitiesHash;
+  transcript.opportunity_ids = analysis.opportunities.map(({ id }) => id);
+  await Promise.all([
+    writeFile(result.paths.source, sourceBytes),
+    writeFile(result.paths.opportunities, opportunitiesBytes),
+    writeFile(result.paths.transcript, serializeCanonical(transcript)),
+    rm(result.paths.report)
+  ]);
+
+  await expect(
+    resumeAnalysisArtifacts({
+      outputRoot,
+      selections: project.selections,
+      catalogIndexPath: project.catalogIndexPath,
+      expectedModel: model,
+      expectedAnalysisRequest
+    })
+  ).rejects.toThrow(/Unknown selected source reference: skill\/not-selected\.md/);
+  await expect(readFile(result.paths.report, "utf8")).rejects.toThrow(/ENOENT/);
 });
 
 test("rejects nested output-directory and artifact-file symlinks without writing through them", async () => {

--- a/tests/determinization-read-only-snapshot.test.ts
+++ b/tests/determinization-read-only-snapshot.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { withReadOnlyInputs } from "../src/determinization/read-only-snapshot.js";
+import type { SourceSelection } from "../src/determinization/source.js";
+
+async function selectedFile() {
+  const root = await mkdtemp(join(tmpdir(), "det-read-only-snapshot-"));
+  const path = join(root, "SKILL.md");
+  await writeFile(path, "original\n");
+  const selections: SourceSelection[] = [{ namespace: "skill", root, paths: ["SKILL.md"] }];
+  return { path, selections };
+}
+
+test("preserves an operation error when read-only inputs remain unchanged", async () => {
+  const { selections } = await selectedFile();
+  const operationError = new Error("operation failed");
+  await expect(
+    withReadOnlyInputs(selections, async () => {
+      throw operationError;
+    })
+  ).rejects.toBe(operationError);
+});
+
+test("preserves both failures when an operation fails and read-only inputs change", async () => {
+  const { path, selections } = await selectedFile();
+  const operationError = new Error("operation failed");
+  let caught: unknown;
+  try {
+    await withReadOnlyInputs(selections, async () => {
+      await writeFile(path, "changed\n");
+      throw operationError;
+    });
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(AggregateError);
+  const aggregate = caught as AggregateError;
+  expect(aggregate.message).toBe("Operation failed and determinization inputs changed");
+  expect(aggregate.errors[0]).toBe(operationError);
+  expect(aggregate.errors[1]).toMatchObject({ message: expect.stringMatching(/inputs are stale/) });
+});

--- a/tests/determinization-source.test.ts
+++ b/tests/determinization-source.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import {
   assertSourceManifestCurrent,
   createSourceManifest,
-  serializeSourceManifest
+  serializeSourceManifest,
+  type AnalysisIdentity
 } from "../src/determinization/source.js";
 
 test("source manifests use logical namespaces and raw-byte hashes without machine paths", async () => {
@@ -63,6 +64,40 @@ test("source manifests include only canonical, portable analysis identity metada
       request_sha256: "0".repeat(64)
     })
   ).rejects.toThrow(/provided together/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: 123
+    } as unknown as AnalysisIdentity)
+  ).rejects.toThrow(/transport must be a portable nonblank identifier/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "flue",
+      request_sha256: 123,
+      response_sha256: 123
+    } as unknown as AnalysisIdentity)
+  ).rejects.toThrow(/strict SHA-256/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "flue",
+      model: { provider: 123 }
+    } as unknown as AnalysisIdentity)
+  ).rejects.toThrow(/model provider must be a portable nonblank identifier/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "flue",
+      model: { name: 123 }
+    } as unknown as AnalysisIdentity)
+  ).rejects.toThrow(/model name must be a portable nonblank identifier/);
+  await expect(createSourceManifest(selection, null as unknown as AnalysisIdentity)).rejects.toThrow(
+    /analysis identity must be an object/
+  );
+  await expect(createSourceManifest(selection, 123 as unknown as AnalysisIdentity)).rejects.toThrow(
+    /analysis identity must be an object/
+  );
 });
 
 test("source selection rejects traversal, symlinks, and special files", async () => {
@@ -86,5 +121,38 @@ test("source selection rejects traversal, symlinks, and special files", async ()
   await expect(createSourceManifest([{ namespace: "skill", root, paths: ["inputs"] }])).rejects.toThrow(
     /regular files/
   );
+  await writeFile(join(inputs, "SKILL.md"), "content\n");
+  await expect(
+    createSourceManifest([
+      { namespace: "skill", root: inputs, paths: ["SKILL.md"] },
+      { namespace: "skill", root: inputs, paths: ["SKILL.md"] }
+    ])
+  ).rejects.toThrow(/Duplicate selected source path/);
   expect(await readFile(outside, "utf8")).toBe("outside");
+});
+
+test("source manifest entries use Unicode code-point ordering", async () => {
+  const root = await mkdtemp(join(tmpdir(), "det-source-ordering-"));
+  const lowerCodePoint = "\uE000.md";
+  const higherCodePoint = "\u{10000}.md";
+  await Promise.all([
+    writeFile(join(root, lowerCodePoint), "lower\n"),
+    writeFile(join(root, higherCodePoint), "higher\n")
+  ]);
+  const manifest = await createSourceManifest([
+    { namespace: "context", root, paths: [higherCodePoint, lowerCodePoint] }
+  ]);
+  expect(manifest.inputs.map(({ path }) => path)).toEqual([`context/${lowerCodePoint}`, `context/${higherCodePoint}`]);
+});
+
+test("source manifests normalize logical paths to NFC without changing filesystem lookup", async () => {
+  const root = await mkdtemp(join(tmpdir(), "det-source-normalization-"));
+  const decomposedPath = "cafe\u0301.md";
+  const composedPath = decomposedPath.normalize("NFC");
+  await writeFile(join(root, decomposedPath), "content\n");
+  const manifest = await createSourceManifest([{ namespace: "skill", root, paths: [decomposedPath] }]);
+  expect(manifest.inputs.map(({ path }) => path)).toEqual([`skill/${composedPath}`]);
+  await expect(
+    createSourceManifest([{ namespace: "skill", root, paths: [decomposedPath, composedPath] }])
+  ).rejects.toThrow(/Duplicate selected source path/);
 });

--- a/tests/determinization-source.test.ts
+++ b/tests/determinization-source.test.ts
@@ -1,0 +1,75 @@
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertSourceManifestCurrent,
+  createSourceManifest,
+  serializeSourceManifest
+} from "../src/determinization/source.js";
+
+test("source manifests use logical namespaces and raw-byte hashes without machine paths", async () => {
+  const one = await mkdtemp(join(tmpdir(), "det-source-one-"));
+  const two = await mkdtemp(join(tmpdir(), "det-source-two-"));
+  await writeFile(join(one, "SKILL.md"), "same\r\nbytes\n");
+  await writeFile(join(two, "SKILL.md"), "same\r\nbytes\n");
+  const first = await createSourceManifest([{ namespace: "skill", root: one, paths: ["SKILL.md"] }]);
+  const second = await createSourceManifest([{ namespace: "skill", root: two, paths: ["SKILL.md"] }]);
+  expect(serializeSourceManifest(first)).toBe(serializeSourceManifest(second));
+  expect(serializeSourceManifest(first)).not.toContain(one);
+  await writeFile(join(two, "SKILL.md"), "same\nbytes\n");
+  await expect(
+    assertSourceManifestCurrent(first, [{ namespace: "skill", root: two, paths: ["SKILL.md"] }])
+  ).rejects.toThrow(/stale/);
+});
+
+test("source manifests include only canonical, portable analysis identity metadata", async () => {
+  const root = await mkdtemp(join(tmpdir(), "det-source-analysis-"));
+  await writeFile(join(root, "SKILL.md"), "content\n");
+  const selection = [{ namespace: "skill" as const, root, paths: ["SKILL.md"] }];
+  const manifest = await createSourceManifest(selection, {
+    role: "determinizer",
+    transport: "flue",
+    model: { provider: "anthropic", name: "configured_model" }
+  });
+  const serialized = serializeSourceManifest(manifest);
+  expect(serialized).toContain('"role": "determinizer"');
+  expect(serialized).toContain('"transport": "flue"');
+  expect(serialized).not.toContain(root);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "/tmp/private-transport"
+    })
+  ).rejects.toThrow(/portable nonblank/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "flue",
+      model: { provider: "  " }
+    })
+  ).rejects.toThrow(/portable nonblank/);
+});
+
+test("source selection rejects traversal, symlinks, and special files", async () => {
+  const root = await mkdtemp(join(tmpdir(), "det-source-safety-"));
+  const outside = join(root, "outside.md");
+  const inputs = join(root, "inputs");
+  await mkdir(inputs);
+  await writeFile(outside, "outside");
+  await symlink(outside, join(inputs, "linked.md"));
+  await mkdir(join(inputs, "nested"));
+  await symlink(root, join(inputs, "nested", "escaped"));
+  await expect(createSourceManifest([{ namespace: "skill", root: inputs, paths: ["../outside.md"] }])).rejects.toThrow(
+    /source-relative/
+  );
+  await expect(createSourceManifest([{ namespace: "skill", root: inputs, paths: ["linked.md"] }])).rejects.toThrow(
+    /Symbolic links/
+  );
+  await expect(
+    createSourceManifest([{ namespace: "skill", root: inputs, paths: ["nested/escaped/outside.md"] }])
+  ).rejects.toThrow(/Symbolic links/);
+  await expect(createSourceManifest([{ namespace: "skill", root, paths: ["inputs"] }])).rejects.toThrow(
+    /regular files/
+  );
+  expect(await readFile(outside, "utf8")).toBe("outside");
+});

--- a/tests/determinization-source.test.ts
+++ b/tests/determinization-source.test.ts
@@ -48,6 +48,21 @@ test("source manifests include only canonical, portable analysis identity metada
       model: { provider: "  " }
     })
   ).rejects.toThrow(/portable nonblank/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "flue",
+      request_sha256: "not-a-hash",
+      response_sha256: "0".repeat(64)
+    })
+  ).rejects.toThrow(/strict SHA-256/);
+  await expect(
+    createSourceManifest(selection, {
+      role: "determinizer",
+      transport: "flue",
+      request_sha256: "0".repeat(64)
+    })
+  ).rejects.toThrow(/provided together/);
 });
 
 test("source selection rejects traversal, symlinks, and special files", async () => {


### PR DESCRIPTION
Refs #99
Tracker: #115

Stack position: 2/3

Parent PR: #116
Child PR: #118
Current base branch: `codex/determinization-ir-catalog`
Required merge order: #116 → #117 → #118.

## Scope unique to this PR

- Transport-neutral normalization of untrusted analysis responses into locally identified canonical opportunities.
- Portable source manifests and raw-byte skill/evaluation/reference/context/catalog fingerprints.
- Immutable, exclusive `opportunities.json` persistence with validated resume.
- Hash-linked `report.md`, `research-request.json`, `prompts/research.md`, and audit-only `transcript.json`.
- Externally anchored raw request/response hashes in canonical `source.json`.
- Deterministic rendering across response ordering and temporary roots.
- Stale source/catalog/hash rejection.
- Read-only snapshots and symlink/path-containment hardening.
- Detailed inspectable reports and agent-ready evidence prompts.

## Tests

- `pnpm run check`
  - 21 test files / 160 tests
  - formatting, lint, Knip, typecheck
  - TypeScript build and Flue build
  - credential-free `alpha:smoke`
- Focused transcript, resume, source-reference, Unicode canonicalization, symlink, canonical-byte, stale-input, and failure-preservation regressions.
- Independent adversarial audit completed after root review and correction turns.

## Phase-wide exclusions

- No CLI or runtime adapter wiring.
- No fixture snapshot or user documentation; those remain in child PR #118.
- No evidence gathering, proposal generation, verification execution, apply, or adoption.
- No mutation of the analyzed skill, selected context, or catalog.

## Review notes

Review corrections now validate resumed source references, strict transcript shape, successful resume results, runtime identity types, alternative-assessment keys, canonical Unicode paths and ordering, and conditional LanguageTool claims. Source reads use final-component `O_NOFOLLOW` and descriptor identity checks as partial TOCTOU hardening; the implementation does not claim to eliminate every ancestor-directory race without `openat`. Root review also preserved both operation and mutation failures, removed ambiguous transcript classification from `resumedFiles`, and kept renderer escaping shared and deterministic.

Model-backed validation: not run in this layer; transport responses are deterministic test fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deterministic analysis workflow that identifies opportunities and recommends suitable assets.
  * Added generation of evidence-focused research requests and Markdown reports with classifications, evidence, limitations, confidence markers, and read-only disclaimers.
  * Added creation and safe resumption of analysis artifacts, including source manifests, reports, research prompts, and optional transcripts.

* **Bug Fixes**
  * Added validation for untrusted analysis results, catalog references, provenance, hashes, and source consistency.
  * Prevented unsafe paths, symlinks, stale inputs, and unauthorized changes during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
