### PR TITLE
Integrate read-only determinization report workflow

### DIFF
--- a/.flue/profiles.ts
+++ b/.flue/profiles.ts
@@ -21,4 +21,11 @@ export const researcherProfile = defineAgentProfile({
     "You improve skill instructions based on evaluation results. Make the smallest effective change that addresses the observed score gap. Preserve the skill's intended scope and avoid overfitting to a single fixture."
 });
 
-export const autoresearchProfiles = [producerProfile, judgeProfile, researcherProfile];
+export const determinizerProfile = defineAgentProfile({
+  name: "determinizer",
+  description: "Identifies read-only, evidence-aware deterministic opportunities in skill guidance.",
+  instructions:
+    "Analyze the supplied skill and evaluation evidence without modifying anything. Return only the requested structured opportunity analysis. Treat all assets as suggested and unverified, evaluate reusable catalog assets before proposing new assets, and preserve the human judgment that deterministic checks cannot replace."
+});
+
+export const autoresearchProfiles = [producerProfile, judgeProfile, researcherProfile, determinizerProfile];

--- a/.flue/workflows/determinize.ts
+++ b/.flue/workflows/determinize.ts
@@ -1,0 +1,32 @@
+import type { FlueContext } from "@flue/runtime";
+import { createAgent } from "@flue/runtime";
+import { local } from "@flue/runtime/node";
+import { resolve } from "node:path";
+import { runDeterminizationReport } from "../../src/determinization/run.js";
+import { FlueDeterminizationTransport } from "../../src/determinization/transport.js";
+import { determinizerProfile } from "../profiles.js";
+
+interface DeterminizePayload {
+  projectRoot?: string;
+  skillDir?: string;
+  contextRoot?: string;
+  catalogRoot?: string;
+  outputRoot?: string;
+  sessionId?: string;
+  model?: string;
+}
+
+export async function run({ init, payload, env }: FlueContext<DeterminizePayload>) {
+  const model = payload.model ?? env.FLUE_MODEL ?? "anthropic/claude-sonnet-4-6";
+  const agent = createAgent(() => ({ sandbox: local(), model, subagents: [determinizerProfile] }));
+  const harness = await init(agent);
+  const session = await harness.session(payload.sessionId ?? "determinize-report");
+  return runDeterminizationReport({
+    projectRoot: resolve(payload.projectRoot ?? process.cwd()),
+    transport: new FlueDeterminizationTransport(session),
+    ...(payload.skillDir && { skillDir: payload.skillDir }),
+    ...(payload.contextRoot && { contextRoot: payload.contextRoot }),
+    ...(payload.catalogRoot && { catalogRoot: payload.catalogRoot }),
+    ...(payload.outputRoot && { outputRoot: payload.outputRoot })
+  });
+}

--- a/.flue/workflows/determinize.ts
+++ b/.flue/workflows/determinize.ts
@@ -16,14 +16,28 @@ interface DeterminizePayload {
   model?: string;
 }
 
+const DEFAULT_MODEL = "anthropic/claude-sonnet-4-6";
+const ANTHROPIC_MODEL_PATTERN = /^anthropic\/[^/\s]+$/u;
+
+function parseModelOverride(model: string | undefined): { provider: "anthropic"; name: string } | undefined {
+  if (model === undefined) return undefined;
+  if (!ANTHROPIC_MODEL_PATTERN.test(model)) {
+    throw new Error("Determinization model must use the format anthropic/<non-empty-model>");
+  }
+  return { provider: "anthropic", name: model.slice("anthropic/".length) };
+}
+
 export async function run({ init, payload, env }: FlueContext<DeterminizePayload>) {
-  const model = payload.model ?? env.FLUE_MODEL ?? "anthropic/claude-sonnet-4-6";
-  const agent = createAgent(() => ({ sandbox: local(), model, subagents: [determinizerProfile] }));
+  const rawModelOverride = payload.model ?? env.FLUE_MODEL;
+  const modelOverride = parseModelOverride(rawModelOverride);
+  const agentModel = modelOverride ? `${modelOverride.provider}/${modelOverride.name}` : DEFAULT_MODEL;
+  const agent = createAgent(() => ({ sandbox: local(), model: agentModel, subagents: [determinizerProfile] }));
   const harness = await init(agent);
   const session = await harness.session(payload.sessionId ?? "determinize-report");
   return runDeterminizationReport({
     projectRoot: resolve(payload.projectRoot ?? process.cwd()),
     transport: new FlueDeterminizationTransport(session),
+    ...(modelOverride && { modelOverride }),
     ...(payload.skillDir && { skillDir: payload.skillDir }),
     ...(payload.contextRoot && { contextRoot: payload.contextRoot }),
     ...(payload.catalogRoot && { catalogRoot: payload.catalogRoot }),

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ test-results/
 **/workspace/iterations/
 **/workspace/cost-summary.json
 **/workspace/run-logs/
+**/workspace/determinization/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Generated research output lands under `workspace/iterations/<n>/`. Do not commit
 - Update docs and tests when config shape, artifact layout, commands, or model flow changes.
 - Never commit `.env`, resolved API keys, provider secrets, or transcripts containing secrets.
 - Score and summary writes often use exclusive file creation; rerun failures may indicate existing artifacts rather than logic failure.
+- Enforce bounded reads before allocation: when a file has a size limit, use `lstat`/`stat` and reject an oversized file before `readFile`. Keep a post-read byte check for races and encoding differences; checking only after a full read does not protect memory.
 - Keep `pnpm run check` and `alpha:smoke` credential-free. Do not route smoke runs through Varlock or require `op`; use Varlock only for model-backed commands.
 
 ## What Is Still Alpha

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Guide
+
+Read `AGENTS.md` first; it is the canonical repository guide.
+
+## Bounded File Reads
+
+When a file is subject to a size limit, use `lstat`/`stat` and reject it before `readFile` if its reported size is already too large. Retain a post-read byte check for races and encoding differences. A limit checked only after reading the full file does not protect memory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,10 @@ The harness should:
 ```text
 .flue/
   workflows/autoresearch.ts   Flue workflow entrypoint.
-  profiles.ts                 Named producer, judge, and researcher subagent profiles.
+  workflows/determinize.ts    Read-only determinization workflow entrypoint.
+  profiles.ts                 Named producer, judge, researcher, and determinizer profiles.
+catalog/
+  deterministic-assets/       Repository-owned reusable asset catalog.
 docs/
   alpha-run.md                Alpha run and credential workflow.
   using-the-harness.md        User guide for running custom skill projects.
@@ -35,7 +38,8 @@ src/
   run-options.ts              Canonical normalized run options used by CLI and Flue adapters.
   project-layout.ts           Canonical generated-artifact paths and filenames.
   artifact-lifecycle.ts       Provider-independent transcript and research-artifact persistence.
-  flue-harness.ts             Flue session adapters for producer/judge/researcher.
+  determinization/            Canonical opportunity analysis, artifacts, and transports.
+  flue-harness.ts             Autoresearch Flue adapters for producer/judge/researcher.
   model-agent.ts              Prompt builders, schemas, artifact application helpers.
   runner.ts                   Eval runner and concurrency helper.
   sandbox.ts                  Local readonly/write sandbox abstraction.
@@ -65,6 +69,8 @@ src/flue-harness.ts
 ```
 
 It uses `session.task(..., { agent, result })` so Flue runs the named subagent profile and performs structured-output validation before the harness writes artifacts or scores.
+
+The determinizer does not use `src/flue-harness.ts`. Its separate `.flue/workflows/determinize.ts` workflow calls the transport-neutral determinization runner through the Flue transport in `src/determinization/transport.ts`.
 
 ## Research Flow
 
@@ -105,6 +111,8 @@ Important contracts:
 - `EvalScoreSchema`
 - `ModelProduceResponseSchema`
 - `SkillResearchPatchSchema`
+- `AnalysisOpportunitiesDocumentSchema`
+- `CatalogIndexSchema` and `CatalogDomainDocumentSchema`
 
 When changing a schema:
 
@@ -122,6 +130,10 @@ the Flue workflow translates camelCase payload fields. Both must call
 Generated workspace locations and artifact filenames belong in
 `src/project-layout.ts`. Cleanup, resume, and persistence must consume that
 manifest so a new generated artifact is declared once and remains auditable.
+
+Determinization has one canonical analysis source of truth: `workspace/determinization/opportunities.json`. Reports, research requests, prompts, and transcripts carry its SHA-256 hash and opportunity IDs. Preserve this lineage, stable IDs, canonical ordering, portable source paths, and the immutability of original analysis fields.
+
+Normal determinization runs are read-only for the selected skill, optional context root, and `catalog/deterministic-assets/`. Phase 1 may only mark assets `suggested`; do not add proposal, verification, apply, adoption, or catalog-mutation behavior to this stage. LanguageTool catalog entries are candidate capability families, not claims that a rule exists, is configured, or fully replaces editorial judgment.
 
 ## Fixtures
 
@@ -183,6 +195,12 @@ Then run the same ordered verification command as CI:
 
 ```bash
 pnpm run check
+```
+
+To inspect the committed deterministic-extraction fixture without credentials:
+
+```bash
+pnpm run alpha:determinize
 ```
 
 The `check` script is the single source of truth for the verification order. Its final `alpha:smoke` command imports the

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ pnpm run build
 pnpm run flue:build
 pnpm run autoresearch -- smoke --project path/to/project
 varlock run -- pnpm run autoresearch -- research --project path/to/project
+node dist/src/cli.js determinize report --project path/to/project --response-file path/to/analysis-response.json
 pnpm run alpha:smoke
 pnpm run alpha:research
+pnpm run alpha:determinize
 ```
 
 The `smoke` and `research` commands derive normal Flue payload fields and the session name, use `origin_skill` and model settings from the project config, and avoid inline JSON. Direct Flue payload invocation remains available for advanced debugging.
@@ -55,6 +57,8 @@ The `smoke` and `research` commands derive normal Flue payload fields and the se
 `alpha:research` runs the model-backed Flue harness through `varlock run`.
 
 Flue-backed commands are quiet by default and write a complete append-only process log under the target project's `workspace/run-logs/`. Pass `-- --verbose` to expose full Flue output in the terminal, or `-- --no-run-log` to explicitly opt out of the local log.
+
+`determinize report` performs read-only analysis and writes an inspectable report plus its canonical opportunity data under `workspace/determinization/`. Use a recorded `--response-file` for a credential-free deterministic run, or run through Varlock for a direct Anthropic model call. The analysis only suggests unverified deterministic assets: it does not propose, verify, apply, or adopt them, and it never modifies the selected skill, external context, or repository-owned asset catalog.
 
 ## Using The Harness
 

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -66,6 +66,40 @@ This requires `ANTHROPIC_API_KEY` to resolve through Varlock.
 pnpm run alpha:research
 ```
 
+## Run The Read-Only Determinization Fixture
+
+The committed response fixture makes the complete report reproducible without credentials or a model call:
+
+```bash
+pnpm run alpha:determinize
+```
+
+Inspect the generated report at:
+
+```text
+fixtures/projects/release-notes-alpha/workspace/determinization/report.md
+```
+
+The command also prints that absolute path plus opportunity and deterministic-asset counts. The fixture intentionally classifies “Keep the output concise” as partially deterministic: text metrics and LanguageTool capability families may contribute, a custom LanguageTool rule may be worth later investigation, and editorial judgment remains necessary.
+
+All reported assets are suggested and unverified. This run does not establish that a LanguageTool rule exists or is configured, and it does not propose, verify, apply, or adopt anything. The fixture skill and repository catalog remain read-only.
+
+For a live Flue-backed analysis with Anthropic credentials, build and run:
+
+```bash
+pnpm run build
+varlock run -- node dist/src/flue-runner.js determinize \
+  --project fixtures/projects/release-notes-alpha
+```
+
+Determinization resume is available only through the direct `determinize report` CLI, not the Flue wrapper. It validates current inputs and re-renders the existing immutable `opportunities.json` without another model call:
+
+```bash
+node dist/src/cli.js determinize report \
+  --project fixtures/projects/release-notes-alpha \
+  --resume
+```
+
 Normal runs print compact phase/eval progress and write the complete Flue process stream under `fixtures/projects/release-notes-alpha/workspace/run-logs/`. Add `-- --verbose` to `alpha:smoke` or `alpha:research` to expose the full stream in the terminal, or `-- --no-run-log` to explicitly disable the local audit log.
 
 This runs the Flue workflow with:

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -229,7 +229,7 @@ Set `budget_usd` in `config.json` to cap observed spend for repeated runs, or pa
 varlock run -- pnpm run autoresearch -- research --project path/to/my-autoresearch-project --budget-usd 0.5
 ```
 
-The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue runs currently record call counts, but they do not expose token usage to this harness, so dollar-cost caps only take effect when usage and known pricing are available. Treat the dollar estimate as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
+The cap is based on observed provider usage. Direct Anthropic runs can include token usage and a narrow known-price estimate for the committed Claude 4.5/4.6 Haiku and Sonnet configs. Flue autoresearch runs currently record call counts only; the determinization report records the usage and model-registry-derived cost returned by Flue. Dollar-cost caps only take effect where the corresponding flow records cost data. Treat any dollar value as a guardrail, not an invoice: provider pricing, long-context pricing, regional routing, caching, batch discounts, and account-specific terms can change the actual bill.
 
 Each successful run writes:
 

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -12,6 +12,8 @@ The current alpha flow is:
 4. Run the Flue autoresearch agent.
 5. Inspect the candidate skill and eval artifacts.
 
+You can then run a separate, read-only determinization report to identify where deterministic assets could reduce human judgment without claiming that those assets have been verified or adopted.
+
 ## What the Harness Does
 
 For each research iteration, the harness runs three Flue-backed phases:
@@ -154,6 +156,58 @@ These role/model choices are starting suggestions, not requirements. Try differe
 Flue subagent profiles live in `.flue/profiles.ts`. The configured role labels are still passed through prompts as project context, while Flue behavior comes from the named `producer`, `judge`, and `researcher` profiles.
 
 For a multi-skill project, use one track per skill or skill responsibility. For example, a security project might have an `audit` track that targets `skills/security-audit` and an `authoring` track that targets `skills/secure-authoring`.
+
+The optional `models.determinizer` entry selects the model used by `determinize report`. When it is absent, the command falls back to `models.researcher`, then the top-level `model`, and finally `anthropic/claude-sonnet-4-6`.
+
+## Read-Only Determinization Report
+
+Build the CLI, then analyze the project with either a recorded structured response or a direct Anthropic call:
+
+```bash
+pnpm run build
+node dist/src/cli.js determinize report \
+  --project path/to/my-autoresearch-project \
+  --response-file path/to/analysis-response.json
+
+varlock run -- node dist/src/cli.js determinize report \
+  --project path/to/my-autoresearch-project \
+  --model-client anthropic
+```
+
+Without `--skill`, the command selects the highest-scoring iteration with a valid `skill/SKILL.md`, breaking equal scores by the lower iteration number. If none exists, it uses the configured `origin_skill`. Pass `--skill <dir>` to select a skill explicitly.
+
+The source manifest fingerprints the selected skill, eval definitions, project `input/`, reference context, and the applicable baseline or iteration task, input, output, scores, and summary. These inputs are included in the analyzer context so a changed task fixture makes an existing report stale.
+
+`--context-root <dir>` may add external repository context, but only the allowlisted `AGENTS.md`, `README.md`, and `package.json` files are read. The context root must not contain the project's determinization output directory; this strict separation keeps generated artifacts outside the read-only context. The selected skill, project evidence, optional context, and repository-owned catalog are input-only. The command rejects symbolic links and does not write beneath those roots.
+
+The default output is:
+
+```text
+workspace/determinization/
+  source.json
+  opportunities.json
+  report.md
+  research-request.json
+  prompts/research.md
+  transcript.json
+```
+
+`opportunities.json` is the immutable canonical analysis. Each derivative records its SHA-256 hash and ordered opportunity IDs so stale or mismatched artifacts can be rejected. `--resume` validates the current source and catalog fingerprints, then re-renders derivatives from that canonical file without calling a model. It cannot be combined with a response file or model client.
+
+On success, normal CLI output prints the absolute report path and useful opportunity, deterministic-asset, and model-call counts. Use `--json` when a caller needs the structured result.
+
+Every Phase 1 asset is `suggested` and unverified. LanguageTool entries describe possible capability families, configuration, or extension points; they do not establish that a relevant rule exists, is configured, or fully solves the requirement. For example, “Keep the output concise” remains partially deterministic: metrics and LanguageTool may contribute, while editorial judgment is still necessary.
+
+This stage produces no evidence findings, asset proposal, verification result, application plan, catalog change, or skill edit. Proposal, verification, apply, and adoption behavior are explicitly out of scope.
+
+The Flue wrapper provides the same read-only analysis through its `determinizer` profile:
+
+```bash
+pnpm run build
+node dist/src/flue-runner.js determinize --project path/to/my-autoresearch-project
+```
+
+The Flue path is model-backed and requires the configured Anthropic credentials. The direct CLI's `--response-file` mode is the repeatable credential-free inspection path.
 
 ## Cost Preview And Budget
 

--- a/fixtures/expected/determinization/release-notes-alpha/analysis-response.json
+++ b/fixtures/expected/determinization/release-notes-alpha/analysis-response.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1.0.0",
+  "opportunities": [
+    {
+      "source_refs": [
+        {
+          "path": "skill/SKILL.md",
+          "locator": "Keep the output concise.",
+          "evidence_kind": "skill"
+        }
+      ],
+      "normalized_requirement": "Keep the output concise.",
+      "origin": "skill_guidance",
+      "classification": "partially_deterministic",
+      "current_automation_potential": "medium",
+      "remaining_human_judgment": "An editor must judge whether the release note is useful, appropriately concise, and complete for its developer audience.",
+      "recommendations": [
+        {
+          "relationship": "existing",
+          "asset_kind": "script",
+          "catalog_asset_id": "catalog_text_metrics",
+          "proposed_name": "Text metrics",
+          "contribution": "Word count and sentence-length metrics can contribute bounded concision signals.",
+          "confidence": "high",
+          "expected_improvement": "Adds repeatable measurements without treating brevity as quality.",
+          "supporting_evidence": ["Length is measurable."],
+          "limitations": ["Metrics cannot determine whether important changes were omitted."],
+          "alternative_assessments": []
+        },
+        {
+          "relationship": "existing",
+          "asset_kind": "languagetool",
+          "catalog_asset_id": "catalog_languagetool_existing_families",
+          "proposed_name": "LanguageTool style capability families",
+          "contribution": "Style warnings may contribute signals for wordiness and sentence construction.",
+          "confidence": "medium",
+          "expected_improvement": "May identify repeatable style issues after relevant rules are evidenced.",
+          "supporting_evidence": ["LanguageTool exposes grammar and style capability families."],
+          "limitations": ["No specific rule is established and style warnings cannot prove concision."],
+          "alternative_assessments": []
+        },
+        {
+          "relationship": "extensible",
+          "asset_kind": "languagetool",
+          "catalog_asset_id": "catalog_languagetool_custom_rules",
+          "proposed_name": "Project-owned LanguageTool rules",
+          "contribution": "A custom rule may add value for project-specific prohibited wording or terminology.",
+          "confidence": "low",
+          "expected_improvement": "Could make narrow editorial policies repeatable after evidence and verification.",
+          "supporting_evidence": ["Some organization-specific phrasing can be expressed as patterns."],
+          "limitations": ["A custom rule does not exist yet and cannot replace editorial judgment."],
+          "alternative_assessments": [
+            {
+              "relationship": "existing",
+              "catalog_asset_ids": ["catalog_languagetool_existing_families"],
+              "conclusion": "insufficient",
+              "rationale": "Built-in capability families may not encode project-specific wording policy."
+            },
+            {
+              "relationship": "configurable",
+              "catalog_asset_ids": ["catalog_languagetool_project_configuration"],
+              "conclusion": "insufficient",
+              "rationale": "Configuration can enable supported behavior but cannot create a missing project-specific pattern."
+            }
+          ]
+        }
+      ],
+      "confidence": "high",
+      "expected_improvement": "Combined metrics and evidenced style checks can reduce inconsistent review while keeping editorial judgment explicit.",
+      "supporting_evidence": ["Conciseness combines measurable length with audience- and context-dependent judgment."],
+      "limitations": [
+        "No deterministic asset can fully establish that a release note is concise, complete, and useful."
+      ]
+    }
+  ]
+}

--- a/fixtures/expected/determinization/release-notes-alpha/report.md
+++ b/fixtures/expected/determinization/release-notes-alpha/report.md
@@ -1,0 +1,87 @@
+# Determinization opportunity report
+
+schema_version: 1.0.0
+source_opportunities_sha256: bedb49f15aa080dd49bf4af59018eb5e949192f1b800a96358fa49d62a8f516a
+opportunity_ids: opp_120f5c5976237ea3fe00
+
+> Read-only analysis. Every asset below is suggested and unverified. This report does not propose, verify, adopt, apply, or modify an asset.
+
+Opportunities: 1
+
+## opp_120f5c5976237ea3fe00: Keep the output concise.
+
+- Origin: skill_guidance
+- Source references:
+  - skill/SKILL.md \[skill\] — Keep the output concise.
+- Classification (unverified analyzer analysis): partially_deterministic
+- Current automation potential (unverified analyzer analysis): medium
+- Remaining human judgment: Unverified analyzer judgment: An editor must judge whether the release note is useful, appropriately concise, and complete for its developer audience.
+- Confidence (unverified analyzer analysis): high
+- Expected improvement: Unverified analyzer estimate: Combined metrics and evidenced style checks can reduce inconsistent review while keeping editorial judgment explicit.
+- Analyzer rationale (unverified):
+  - Unverified analyzer rationale: Conciseness combines measurable length with audience- and context-dependent judgment.
+- Analyzer limitations (unverified):
+  - Unverified analyzer limitation: No deterministic asset can fully establish that a release note is concise, complete, and useful.
+
+### Suggested deterministic assets
+
+#### asset_31094d7c06cac874a50d: LanguageTool existing capability families
+
+- Lifecycle: suggested (unverified)
+- Relationship: existing
+- Asset kind: languagetool
+- Catalog reference: catalog_languagetool_existing_families
+- Contribution: LanguageTool may contribute existing grammar and style signals after later evidence identifies applicable rules.
+- Confidence (unverified analyzer analysis): medium
+- Expected improvement: Potential improvement requires later evidence and verification; catalog metadata establishes only the stated capability contribution.
+- Supporting evidence:
+  - Catalog capability evidence basis: This catalogs a capability family only; it does not assert that a specific rule satisfies an opportunity.
+- Limitations:
+  - Catalog capability limitation: A later evidence stage must establish rule availability for the selected language and version.
+  - Catalog capability limitation: No individual warning proves that text is concise, readable, or editorially correct.
+- Lower-tier alternative assessments (unverified analyzer analysis):
+  - None required for this relationship tier.
+- New-asset insufficiency justification: not applicable
+
+#### asset_3268d1e5ce88e2671304: Text metrics
+
+- Lifecycle: suggested (unverified)
+- Relationship: existing
+- Asset kind: script
+- Catalog reference: catalog_text_metrics
+- Contribution: Deterministic metrics can measure properties such as word count and sentence length as partial signals.
+- Confidence (unverified analyzer analysis): high
+- Expected improvement: Potential improvement requires later evidence and verification; catalog metadata establishes only the stated capability contribution.
+- Supporting evidence:
+  - Catalog capability evidence basis: The measurements are deterministic; useful thresholds remain project-specific and require evidence.
+- Limitations:
+  - Catalog capability limitation: Metrics are proxies and do not establish clarity, usefulness, or concision by themselves.
+  - Catalog capability limitation: Thresholds can incentivize unhelpfully terse output.
+- Lower-tier alternative assessments (unverified analyzer analysis):
+  - None required for this relationship tier.
+- New-asset insufficiency justification: not applicable
+
+#### asset_a85bb333999302e66b6c: Custom LanguageTool rules
+
+- Lifecycle: suggested (unverified)
+- Relationship: extensible
+- Asset kind: languagetool
+- Catalog reference: catalog_languagetool_custom_rules
+- Contribution: A project may extend LanguageTool with custom rules when evidence shows built-in rules and configuration are insufficient.
+- Confidence (unverified analyzer analysis): low
+- Expected improvement: Potential improvement requires later evidence and verification; catalog metadata establishes only the stated capability contribution.
+- Supporting evidence:
+  - Catalog capability evidence basis: This records an extension point only; it does not imply that a custom rule exists, is verified, or has been adopted.
+- Limitations:
+  - Catalog capability limitation: Custom-rule feasibility and false-positive behavior require later verification.
+  - Catalog capability limitation: Rules cannot fully replace judgment about audience, nuance, or overall concision.
+- Lower-tier alternative assessments (unverified analyzer analysis):
+  - existing: insufficient
+    - Catalog assets: catalog_languagetool_existing_families
+    - Rationale: Unverified analyzer rationale: Built-in capability families may not encode project-specific wording policy.
+  - configurable: insufficient
+    - Catalog assets: catalog_languagetool_project_configuration
+    - Rationale: Unverified analyzer rationale: Configuration can enable supported behavior but cannot create a missing project-specific pattern.
+- New-asset insufficiency justification: not applicable
+
+LanguageTool references describe candidate capability families only. A later evidence stage must establish whether relevant rules, versions, language variants, or configuration exist; no LanguageTool signal by itself fully establishes concision or editorial quality.

--- a/fixtures/expected/determinization/release-notes-alpha/report.md
+++ b/fixtures/expected/determinization/release-notes-alpha/report.md
@@ -1,14 +1,14 @@
 # Determinization opportunity report
 
 schema_version: 1.0.0
-source_opportunities_sha256: bedb49f15aa080dd49bf4af59018eb5e949192f1b800a96358fa49d62a8f516a
-opportunity_ids: opp_120f5c5976237ea3fe00
+source_opportunities_sha256: 52d040a1a5bfc71a8fc63dcafaaf5beba5b629f6820ee11e402f97bba131bdcd
+opportunity_ids: opp_ee93c287a4111f72d9b8
 
 > Read-only analysis. Every asset below is suggested and unverified. This report does not propose, verify, adopt, apply, or modify an asset.
 
 Opportunities: 1
 
-## opp_120f5c5976237ea3fe00: Keep the output concise.
+## opp_ee93c287a4111f72d9b8: Keep the output concise.
 
 - Origin: skill_guidance
 - Source references:
@@ -25,7 +25,7 @@ Opportunities: 1
 
 ### Suggested deterministic assets
 
-#### asset_31094d7c06cac874a50d: LanguageTool existing capability families
+#### asset_0181d919fd309da638ac: LanguageTool existing capability families
 
 - Lifecycle: suggested (unverified)
 - Relationship: existing
@@ -43,7 +43,7 @@ Opportunities: 1
   - None required for this relationship tier.
 - New-asset insufficiency justification: not applicable
 
-#### asset_3268d1e5ce88e2671304: Text metrics
+#### asset_614cb50b3e3a5532bf96: Text metrics
 
 - Lifecycle: suggested (unverified)
 - Relationship: existing
@@ -61,7 +61,7 @@ Opportunities: 1
   - None required for this relationship tier.
 - New-asset insufficiency justification: not applicable
 
-#### asset_a85bb333999302e66b6c: Custom LanguageTool rules
+#### asset_cb1e63e580dc0af0da51: Custom LanguageTool rules
 
 - Lifecycle: suggested (unverified)
 - Relationship: extensible

--- a/fixtures/projects/release-notes-alpha/config.json
+++ b/fixtures/projects/release-notes-alpha/config.json
@@ -21,6 +21,10 @@
     "researcher": {
       "provider": "anthropic",
       "name": "claude-sonnet-4-6"
+    },
+    "determinizer": {
+      "provider": "anthropic",
+      "name": "claude-sonnet-4-6"
     }
   },
   "roles": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "flue:run": "pnpm run build && node dist/src/flue-runner.js",
     "flue:build": "flue build --target node --root . --output .flue-dist",
     "alpha:smoke": "pnpm run autoresearch -- smoke --project fixtures/projects/release-notes-alpha --session alpha-smoke",
+    "alpha:determinize": "pnpm run build && node dist/src/cli.js determinize report --project fixtures/projects/release-notes-alpha --response-file fixtures/expected/determinization/release-notes-alpha/analysis-response.json --catalog-root catalog/deterministic-assets",
     "alpha:research": "pnpm run build && varlock run -- node dist/src/flue-runner.js research --project fixtures/projects/release-notes-alpha --session alpha-research",
     "env:check": "varlock load"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { AnthropicMessagesClient, ModelEvalAgent, ModelSkillResearcher } from ".
 import { orchestrateBaseline, OrchestrateOptions, RunEvent } from "./orchestrator.js";
 import { createRunLog } from "./run-log.js";
 import { normalizeRunOptions, RunOptions } from "./run-options.js";
+import { determinizationUsage, runDeterminizationCli } from "./determinization/cli.js";
 
 export interface CliOptions extends RunOptions {
   scoreDir?: string;
@@ -20,6 +21,7 @@ export interface CliOptions extends RunOptions {
 function usage(): string {
   return [
     "Usage: skills-autoresearch [options]",
+    "       skills-autoresearch determinize report [options]",
     "",
     "Options:",
     "  --project <dir>       Project root. Defaults to current directory.",
@@ -36,7 +38,10 @@ function usage(): string {
     "  --verbose             Print debug-level run events.",
     "  --no-run-log          Do not write the complete local run log.",
     "  --json                Print the full orchestrator result as JSON.",
-    "  -h, --help            Show this help."
+    "  -h, --help            Show this help.",
+    "",
+    "Determinization:",
+    "  skills-autoresearch determinize report --help"
   ].join("\n");
 }
 
@@ -126,6 +131,14 @@ function parseModelClient(value: string | boolean | undefined): "anthropic" | un
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
+  if (argv[0] === "determinize") {
+    if (argv[1] === "--help" || argv[1] === "-h") {
+      createLogger().write("log", determinizationUsage());
+      return;
+    }
+    await runDeterminizationCli(argv.slice(1));
+    return;
+  }
   const cli = parseCliArgs(argv);
   const logger = createLogger(console, { verbose: cli.verbose });
   const runLog = cli.writeRunLog ? createRunLog(cli.projectRoot, "standalone-cli") : undefined;

--- a/src/determinization/analysis-prompt.ts
+++ b/src/determinization/analysis-prompt.ts
@@ -1,0 +1,44 @@
+import type { DeterministicAssetCatalog } from "./catalog.js";
+
+export interface AnalysisPromptInput {
+  files: Array<{ path: string; contents: string }>;
+  catalog: DeterministicAssetCatalog;
+}
+
+export function buildDeterminizationAnalysisPrompt(input: AnalysisPromptInput): string {
+  const catalog = input.catalog.assets.map((asset) => ({
+    id: asset.id,
+    name: asset.name,
+    domain: asset.domain,
+    asset_kind: asset.asset_kind,
+    capability_level: asset.capability_level,
+    contribution: asset.contribution,
+    applicability: asset.applicability,
+    evidence_basis: asset.evidence_basis,
+    limitations: asset.limitations
+  }));
+  const files = input.files
+    .map(({ path, contents }) => [`### ${path}`, "", "```text", contents.replace(/```/gu, "` ` `"), "```"].join("\n"))
+    .join("\n\n");
+  return [
+    "Analyze the supplied skill guidance and evaluation evidence for deterministic opportunities.",
+    "This is read-only Stage A. Do not modify files, execute tools, research the web, produce patches, verify assets, or claim adoption.",
+    "Every recommendation is only suggested. Existing catalog entries are capability families, not proof that a concrete rule is installed, configured, useful, or verified.",
+    "Evaluate reusable assets in order: existing, configurable, extensible, then new. A configurable recommendation must assess existing; an extensible recommendation must assess existing and configurable; a new recommendation must assess all three and explain why they are insufficient or not applicable.",
+    "Preserve human editorial judgment. In particular, concision is only partially deterministic: metrics and LanguageTool capability families may contribute, custom LanguageTool rules may add value, and editorial judgment remains.",
+    "Return JSON only, with schema_version 1.0.0 and an opportunities array. Do not return IDs or lifecycle fields; the harness owns them.",
+    "Each opportunity must contain source_refs, normalized_requirement, origin, classification, current_automation_potential, remaining_human_judgment, recommendations, confidence, expected_improvement, supporting_evidence, and limitations.",
+    "Each source ref uses a listed logical path and matching evidence_kind: skill, evaluation, reference, or context. origin is skill_guidance, evaluation_evidence, or both and must agree with those refs.",
+    "Each recommendation contains relationship, asset_kind, optional catalog_asset_id, proposed_name, contribution, confidence, expected_improvement, supporting_evidence, limitations, alternative_assessments, and optional insufficiency_justification.",
+    "Allowed asset kinds: languagetool, vale, eslint, remark, tree_sitter, json_schema, typescript_check, codemod, script, ci_validation, generator, repository_validator.",
+    "Alternative assessments contain relationship, catalog_asset_ids, conclusion (insufficient or not_applicable), and rationale.",
+    "",
+    "## Reusable deterministic-asset catalog",
+    "",
+    JSON.stringify(catalog, null, 2),
+    "",
+    "## Selected read-only inputs",
+    "",
+    files
+  ].join("\n");
+}

--- a/src/determinization/catalog.ts
+++ b/src/determinization/catalog.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import * as v from "valibot";
 import type { AnalysisOpportunitiesDocument } from "./schemas.js";
@@ -8,6 +7,7 @@ import {
   NonEmptyTextSchema,
   StableIdSchema
 } from "./schemas.js";
+import { readBoundedDeterminizationFile } from "./source.js";
 
 export const CATALOG_DOMAIN_FILES = {
   javascript_typescript: "javascript-typescript.json",
@@ -103,7 +103,7 @@ function assetsFollowCatalogPriority(assets: CatalogAsset[]): boolean {
 }
 
 async function readJson(path: string, label: string): Promise<unknown> {
-  const contents = await readFile(path, "utf8");
+  const contents = (await readBoundedDeterminizationFile(path, `${label}: ${path}`)).toString("utf8");
   try {
     return JSON.parse(contents) as unknown;
   } catch (cause) {

--- a/src/determinization/cli.ts
+++ b/src/determinization/cli.ts
@@ -1,0 +1,94 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { createLogger } from "../logger.js";
+import { AnthropicMessagesClient } from "../model-agent.js";
+import { resumeDeterminizationReport, runDeterminizationReport } from "./run.js";
+import { DirectModelDeterminizationTransport, StaticDeterminizationTransport } from "./transport.js";
+
+export function determinizationUsage(): string {
+  return [
+    "Usage: skills-autoresearch determinize report [options]",
+    "",
+    "Options:",
+    "  --project <dir>        Autoresearch project root. Defaults to current directory.",
+    "  --skill <dir>          Explicit skill directory. Best scored iteration and origin skill are fallbacks.",
+    "  --context-root <dir>   Optional external repository context (read-only allowlist).",
+    "  --response-file <file> Use a recorded structured response without a model call.",
+    "  --model-client <name>  Model client for analysis. Supported: anthropic.",
+    "  --catalog-root <dir>   Deterministic-asset catalog root. Defaults to ./catalog/deterministic-assets.",
+    "  --output <dir>         Artifact root. Defaults to workspace/determinization.",
+    "  --resume               Re-render from validated immutable opportunities without a model call.",
+    "  --json                 Print the structured result as JSON.",
+    "  -h, --help             Show this help.",
+    "",
+    "This command is read-only for the selected skill, context, and catalog. It never proposes, verifies, applies, or adopts assets."
+  ].join("\n");
+}
+
+export async function runDeterminizationCli(argv: string[]): Promise<void> {
+  if (argv[0] !== "report") throw new Error("Choose the determinize command: report. Use --help for usage.");
+  const parsed = parseArgs({
+    args: argv.slice(1),
+    options: {
+      project: { type: "string" },
+      skill: { type: "string" },
+      "context-root": { type: "string" },
+      "response-file": { type: "string" },
+      "model-client": { type: "string" },
+      "catalog-root": { type: "string" },
+      output: { type: "string" },
+      resume: { type: "boolean" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" }
+    },
+    strict: true,
+    allowPositionals: false
+  });
+  if (parsed.values.help) {
+    createLogger().write("log", determinizationUsage());
+    return;
+  }
+  if (parsed.values["model-client"] && parsed.values["model-client"] !== "anthropic") {
+    throw new Error(`Unsupported determinizer model client: ${parsed.values["model-client"]}`);
+  }
+  if (parsed.values["response-file"] && parsed.values["model-client"]) {
+    throw new Error("Use either --response-file or --model-client, not both.");
+  }
+  if (parsed.values.resume && (parsed.values["response-file"] || parsed.values["model-client"])) {
+    throw new Error("--resume reuses canonical artifacts and cannot be combined with a model or response file.");
+  }
+  const transport = parsed.values["response-file"]
+    ? new StaticDeterminizationTransport(
+        JSON.parse(await readFile(resolve(parsed.values["response-file"]), "utf8")) as unknown
+      )
+    : parsed.values.resume
+      ? undefined
+      : new DirectModelDeterminizationTransport(new AnthropicMessagesClient());
+  const logger = createLogger();
+  if (!parsed.values.json) {
+    const plannedCalls = !transport || transport.name === "response-file" ? 0 : 1;
+    logger.write("log", `Determinizer model call preview: ${plannedCalls} planned call(s).`);
+  }
+  const common = {
+    projectRoot: resolve(parsed.values.project ?? process.cwd()),
+    ...(parsed.values.skill && { skillDir: parsed.values.skill }),
+    ...(parsed.values["context-root"] && { contextRoot: parsed.values["context-root"] }),
+    ...(parsed.values["catalog-root"] && { catalogRoot: parsed.values["catalog-root"] }),
+    ...(parsed.values.output && { outputRoot: parsed.values.output })
+  };
+  const result = parsed.values.resume
+    ? await resumeDeterminizationReport(common)
+    : await runDeterminizationReport({ ...common, transport: transport! });
+  if (parsed.values.json) {
+    logger.write("log", JSON.stringify(result, null, 2));
+    return;
+  }
+  logger.write("log", `Determinization report: ${resolve(result.paths.report)}`);
+  logger.write(
+    "log",
+    `Suggested opportunities: ${result.opportunityCount}; deterministic assets: ${result.recommendationCount}; model calls: ${result.cost.actualCalls}.`
+  );
+  if (result.cost.costUsd !== undefined)
+    logger.write("log", `Observed determinizer cost: $${result.cost.costUsd.toFixed(4)}`);
+}

--- a/src/determinization/cli.ts
+++ b/src/determinization/cli.ts
@@ -67,7 +67,7 @@ export async function runDeterminizationCli(argv: string[]): Promise<void> {
       : new DirectModelDeterminizationTransport(new AnthropicMessagesClient());
   const logger = createLogger();
   if (!parsed.values.json) {
-    const plannedCalls = !transport || transport.name === "response-file" ? 0 : 1;
+    const plannedCalls = transport?.makesModelCall ? 1 : 0;
     logger.write("log", `Determinizer model call preview: ${plannedCalls} planned call(s).`);
   }
   const common = {

--- a/src/determinization/run.ts
+++ b/src/determinization/run.ts
@@ -1,0 +1,329 @@
+import { lstat, readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { estimateUsageCostUsd, type ModelUsage } from "../cost.js";
+import { GENERATED_SKILL_FILES, projectLayout } from "../project-layout.js";
+import { ProjectConfigSchema, parseWithSchema, type ModelConfig, type ProjectConfig } from "../schemas.js";
+import { buildDeterminizationAnalysisPrompt } from "./analysis-prompt.js";
+import { compareCodePoints } from "./canonical.js";
+import {
+  assertAnalysisArtifactBoundary,
+  resumeAnalysisArtifacts,
+  writeAnalysisArtifacts,
+  type AnalysisArtifactResult
+} from "./artifacts.js";
+import { loadDeterministicAssetCatalog } from "./catalog.js";
+import { createSourceManifest, type SourceSelection } from "./source.js";
+import type { DeterminizationTransport } from "./transport.js";
+
+const MAX_FILE_BYTES = 256 * 1024;
+const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
+const CATALOG_FILES = ["catalog.json", "javascript-typescript.json", "language.json", "markdown.json"];
+const DETERMINIZER_SYSTEM_PROMPT = "You are the read-only determinizer for an agent-skill evaluation harness.";
+
+export interface RunDeterminizationReportOptions {
+  projectRoot: string;
+  transport: DeterminizationTransport;
+  skillDir?: string;
+  contextRoot?: string;
+  catalogRoot?: string;
+  outputRoot?: string;
+}
+
+export type ResumeDeterminizationReportOptions = Omit<RunDeterminizationReportOptions, "transport">;
+
+export interface DeterminizationRunCost {
+  plannedCalls: number;
+  actualCalls: number;
+  model: ModelConfig;
+  usage?: ModelUsage;
+  costUsd?: number;
+}
+
+export interface DeterminizationReportResult extends AnalysisArtifactResult {
+  selectedSkillDir: string;
+  selectedSkillSource: "explicit" | "best_iteration" | "origin_skill";
+  cost: DeterminizationRunCost;
+}
+
+interface SelectedSkill {
+  dir: string;
+  source: DeterminizationReportResult["selectedSkillSource"];
+}
+
+interface PreparedInputs {
+  selections: SourceSelection[];
+  files: Array<{ path: string; contents: string }>;
+}
+
+function buildAnalysisRequest(
+  prepared: PreparedInputs,
+  catalog: Awaited<ReturnType<typeof loadDeterministicAssetCatalog>>,
+  model: ModelConfig
+) {
+  return {
+    system: DETERMINIZER_SYSTEM_PROMPT,
+    prompt: buildDeterminizationAnalysisPrompt({ files: prepared.files, catalog }),
+    model
+  };
+}
+
+async function readConfig(projectRoot: string): Promise<ProjectConfig> {
+  const value = JSON.parse(await readFile(join(projectRoot, "config.json"), "utf8")) as unknown;
+  return parseWithSchema(ProjectConfigSchema, value, "config.json");
+}
+
+export function resolveDeterminizerModel(config: ProjectConfig): ModelConfig {
+  return (
+    config.models?.determinizer ??
+    config.models?.researcher ??
+    config.model ?? { provider: "anthropic", name: "claude-sonnet-4-6" }
+  );
+}
+
+async function regularFile(path: string): Promise<boolean> {
+  try {
+    const metadata = await lstat(path);
+    return metadata.isFile() && !metadata.isSymbolicLink();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function assertRegularDirectory(path: string, label: string): Promise<void> {
+  const metadata = await lstat(path);
+  if (metadata.isSymbolicLink())
+    throw new Error(`Symbolic links are not valid determinization ${label} roots: ${path}`);
+  if (!metadata.isDirectory()) throw new Error(`Determinization ${label} root must be a directory: ${path}`);
+}
+
+async function selectBestIteration(projectRoot: string): Promise<string | undefined> {
+  const iterationsDir = projectLayout(projectRoot).iterationsDir;
+  let entries;
+  try {
+    entries = await readdir(iterationsDir, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return undefined;
+    throw error;
+  }
+  const candidates: Array<{ iteration: number; score: number; dir: string }> = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) continue;
+    const iteration = Number(entry.name);
+    const dir = join(iterationsDir, entry.name, "skill");
+    if (!(await regularFile(join(dir, "SKILL.md")))) continue;
+    try {
+      const summary = JSON.parse(await readFile(join(iterationsDir, entry.name, "summary.json"), "utf8")) as {
+        overall?: { normalizedScore?: unknown };
+      };
+      const score = summary.overall?.normalizedScore;
+      if (typeof score === "number" && Number.isFinite(score)) candidates.push({ iteration, score, dir });
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+  }
+  candidates.sort((left, right) => right.score - left.score || left.iteration - right.iteration);
+  return candidates[0]?.dir;
+}
+
+async function selectSkill(projectRoot: string, config: ProjectConfig, explicit?: string): Promise<SelectedSkill> {
+  if (explicit) {
+    const dir = resolve(projectRoot, explicit);
+    if (!(await regularFile(join(dir, "SKILL.md")))) throw new Error(`Selected skill has no regular SKILL.md: ${dir}`);
+    return { dir, source: "explicit" };
+  }
+  const best = await selectBestIteration(projectRoot);
+  if (best) return { dir: best, source: "best_iteration" };
+  const configured = config.origin_skill ?? "seed-skill";
+  const dir = resolve(projectRoot, configured);
+  if (!(await regularFile(join(dir, "SKILL.md")))) {
+    throw new Error("No explicit skill, scored iteration, or configured origin skill with SKILL.md was found");
+  }
+  return { dir, source: "origin_skill" };
+}
+
+async function listRegularFiles(root: string, prefix = ""): Promise<string[]> {
+  if (!prefix) await assertRegularDirectory(root, "input");
+  const directory = join(root, prefix);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries.sort((a, b) => compareCodePoints(a.name, b.name))) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isSymbolicLink()) throw new Error(`Symbolic links are not valid determinization inputs: ${relativePath}`);
+    if (entry.isDirectory()) files.push(...(await listRegularFiles(root, relativePath)));
+    else if (entry.isFile()) files.push(relativePath);
+  }
+  return files;
+}
+
+async function optionalDirectoryFiles(root: string): Promise<string[]> {
+  try {
+    return await listRegularFiles(root);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function assertSeparateRoot(projectRoot: string, contextRoot: string): void {
+  const rel = relative(resolve(contextRoot), projectLayout(projectRoot).determinizationDir);
+  if (!rel || (rel !== ".." && !rel.startsWith(`..${sep}`))) {
+    throw new Error("--context-root must not contain the project determinization output directory");
+  }
+}
+
+async function prepareInputs(
+  projectRoot: string,
+  skillDir: string,
+  catalogRoot: string,
+  contextRoot?: string
+): Promise<PreparedInputs> {
+  const selections: SourceSelection[] = [];
+  const skillPaths = (await listRegularFiles(skillDir)).filter(
+    (path) => !GENERATED_SKILL_FILES.includes(path.split("/").at(-1) as (typeof GENERATED_SKILL_FILES)[number])
+  );
+  selections.push({ namespace: "skill", root: skillDir, paths: skillPaths });
+
+  const evalRoot = join(projectRoot, "evals");
+  const evalPaths = await optionalDirectoryFiles(evalRoot);
+  if (evalPaths.length) selections.push({ namespace: "evaluation", root: evalRoot, paths: evalPaths });
+  const projectInputRoot = join(projectRoot, "input");
+  const projectInputPaths = await optionalDirectoryFiles(projectInputRoot);
+  if (projectInputPaths.length) {
+    selections.push({ namespace: "evaluation", root: projectInputRoot, paths: projectInputPaths });
+  }
+  const referenceRoot = join(projectRoot, "reference");
+  const referencePaths = await optionalDirectoryFiles(referenceRoot);
+  if (referencePaths.length) selections.push({ namespace: "reference", root: referenceRoot, paths: referencePaths });
+  const iterationRoot = dirname(skillDir);
+  const isIteration = dirname(iterationRoot) === projectLayout(projectRoot).iterationsDir;
+  if (isIteration) {
+    const iterationPaths = (await optionalDirectoryFiles(iterationRoot)).filter(
+      (path) =>
+        path === "summary.json" ||
+        /^scores-\d+\.json$/u.test(path) ||
+        path.split("/").some((segment) => segment === "outputs" || segment === "input") ||
+        path.split("/").at(-1) === "task.md"
+    );
+    if (iterationPaths.length) {
+      selections.push({ namespace: "evaluation", root: iterationRoot, paths: iterationPaths });
+    }
+  } else {
+    const baselineRoot = projectLayout(projectRoot).baselineDir;
+    const baselinePaths = (await optionalDirectoryFiles(baselineRoot)).filter(
+      (path) =>
+        path === "summary.json" ||
+        /^scores-\d+\.json$/u.test(path) ||
+        path.split("/").some((segment) => segment === "output" || segment === "input") ||
+        path.split("/").at(-1) === "task.md"
+    );
+    if (baselinePaths.length) selections.push({ namespace: "evaluation", root: baselineRoot, paths: baselinePaths });
+  }
+
+  if (contextRoot) {
+    const resolvedContext = resolve(contextRoot);
+    assertSeparateRoot(projectRoot, resolvedContext);
+    await assertRegularDirectory(resolvedContext, "context");
+    const allowlist = ["AGENTS.md", "README.md", "package.json"];
+    const contextPaths: string[] = [];
+    for (const path of allowlist) if (await regularFile(join(resolvedContext, path))) contextPaths.push(path);
+    if (!contextPaths.length)
+      throw new Error("--context-root contains no allowlisted AGENTS.md, README.md, or package.json");
+    selections.push({ namespace: "context", root: resolvedContext, paths: contextPaths });
+  }
+  selections.push({ namespace: "catalog", root: catalogRoot, paths: [...CATALOG_FILES] });
+
+  // Validate roots, every path component, and current bytes before any selected
+  // content is placed in a model prompt.
+  await createSourceManifest(selections);
+
+  let totalBytes = 0;
+  const files: Array<{ path: string; contents: string }> = [];
+  for (const selection of selections.filter(({ namespace }) => namespace !== "catalog")) {
+    for (const path of selection.paths) {
+      const absolute = join(selection.root, ...path.split("/"));
+      const contents = await readFile(absolute, "utf8");
+      const bytes = Buffer.byteLength(contents);
+      if (bytes > MAX_FILE_BYTES) throw new Error(`Determinization input exceeds 256 KiB: ${path}`);
+      totalBytes += bytes;
+      if (totalBytes > MAX_TOTAL_BYTES) throw new Error("Determinization inputs exceed the 2 MiB total limit");
+      files.push({ path: `${selection.namespace}/${path}`, contents });
+    }
+  }
+  files.sort((a, b) => compareCodePoints(a.path, b.path));
+  return { selections, files };
+}
+
+export async function runDeterminizationReport(
+  options: RunDeterminizationReportOptions
+): Promise<DeterminizationReportResult> {
+  const projectRoot = resolve(options.projectRoot);
+  await assertRegularDirectory(projectRoot, "project");
+  const config = await readConfig(projectRoot);
+  const selected = await selectSkill(projectRoot, config, options.skillDir);
+  const catalogRoot = resolve(options.catalogRoot ?? join(process.cwd(), "catalog", "deterministic-assets"));
+  const catalogIndexPath = join(catalogRoot, "catalog.json");
+  await createSourceManifest([{ namespace: "catalog", root: catalogRoot, paths: [...CATALOG_FILES] }]);
+  const catalog = await loadDeterministicAssetCatalog(catalogIndexPath);
+  const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot);
+  await assertAnalysisArtifactBoundary(
+    options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
+    prepared.selections
+  );
+  const model = resolveDeterminizerModel(config);
+  const request = buildAnalysisRequest(prepared, catalog, model);
+  const completion = await options.transport.analyze(request);
+  const result = await writeAnalysisArtifacts({
+    outputRoot: options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
+    selections: prepared.selections,
+    catalogIndexPath,
+    analysis: {
+      role: "determinizer",
+      transport: options.transport.name,
+      model: { provider: model.provider, name: model.name }
+    },
+    analysisResponse: completion.response,
+    expectedAnalysisRequest: request,
+    transcript: completion.transcript
+  });
+  const costUsd = estimateUsageCostUsd(model, completion.usage);
+  const modelCalls = options.transport.name === "response-file" ? 0 : 1;
+  return {
+    ...result,
+    selectedSkillDir: selected.dir,
+    selectedSkillSource: selected.source,
+    cost: {
+      plannedCalls: modelCalls,
+      actualCalls: modelCalls,
+      model,
+      ...(completion.usage && { usage: completion.usage }),
+      ...(costUsd !== undefined && { costUsd })
+    }
+  };
+}
+
+export async function resumeDeterminizationReport(
+  options: ResumeDeterminizationReportOptions
+): Promise<DeterminizationReportResult> {
+  const projectRoot = resolve(options.projectRoot);
+  await assertRegularDirectory(projectRoot, "project");
+  const config = await readConfig(projectRoot);
+  const selected = await selectSkill(projectRoot, config, options.skillDir);
+  const catalogRoot = resolve(options.catalogRoot ?? join(process.cwd(), "catalog", "deterministic-assets"));
+  const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot);
+  const model = resolveDeterminizerModel(config);
+  const catalog = await loadDeterministicAssetCatalog(join(catalogRoot, "catalog.json"));
+  const result = await resumeAnalysisArtifacts({
+    outputRoot: options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
+    selections: prepared.selections,
+    catalogIndexPath: join(catalogRoot, "catalog.json"),
+    expectedModel: model,
+    expectedAnalysisRequest: buildAnalysisRequest(prepared, catalog, model)
+  });
+  return {
+    ...result,
+    selectedSkillDir: selected.dir,
+    selectedSkillSource: selected.source,
+    cost: { plannedCalls: 0, actualCalls: 0, model }
+  };
+}

--- a/src/determinization/run.ts
+++ b/src/determinization/run.ts
@@ -12,10 +12,9 @@ import {
   type AnalysisArtifactResult
 } from "./artifacts.js";
 import { loadDeterministicAssetCatalog } from "./catalog.js";
-import { createSourceManifest, type SourceSelection } from "./source.js";
+import { createSourceManifest, MAX_DETERMINIZATION_SOURCE_FILE_BYTES, type SourceSelection } from "./source.js";
 import type { DeterminizationTransport } from "./transport.js";
 
-const MAX_FILE_BYTES = 256 * 1024;
 const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
 const CATALOG_FILES = ["catalog.json", "javascript-typescript.json", "language.json", "markdown.json"];
 const DETERMINIZER_SYSTEM_PROMPT = "You are the read-only determinizer for an agent-skill evaluation harness.";
@@ -27,9 +26,10 @@ export interface RunDeterminizationReportOptions {
   contextRoot?: string;
   catalogRoot?: string;
   outputRoot?: string;
+  modelOverride?: ModelConfig;
 }
 
-export type ResumeDeterminizationReportOptions = Omit<RunDeterminizationReportOptions, "transport">;
+export type ResumeDeterminizationReportOptions = Omit<RunDeterminizationReportOptions, "transport" | "modelOverride">;
 
 export interface DeterminizationRunCost {
   plannedCalls: number;
@@ -242,9 +242,15 @@ async function prepareInputs(
   for (const selection of selections.filter(({ namespace }) => namespace !== "catalog")) {
     for (const path of selection.paths) {
       const absolute = join(selection.root, ...path.split("/"));
+      const metadata = await lstat(absolute);
+      if (metadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
+        throw new Error(`Determinization input exceeds 256 KiB: ${path}`);
+      }
       const contents = await readFile(absolute, "utf8");
       const bytes = Buffer.byteLength(contents);
-      if (bytes > MAX_FILE_BYTES) throw new Error(`Determinization input exceeds 256 KiB: ${path}`);
+      if (bytes > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
+        throw new Error(`Determinization input exceeds 256 KiB: ${path}`);
+      }
       totalBytes += bytes;
       if (totalBytes > MAX_TOTAL_BYTES) throw new Error("Determinization inputs exceed the 2 MiB total limit");
       files.push({ path: `${selection.namespace}/${path}`, contents });
@@ -270,7 +276,7 @@ export async function runDeterminizationReport(
     options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
     prepared.selections
   );
-  const model = resolveDeterminizerModel(config);
+  const model = options.modelOverride ?? resolveDeterminizerModel(config);
   const request = buildAnalysisRequest(prepared, catalog, model);
   const completion = await options.transport.analyze(request);
   const result = await writeAnalysisArtifacts({
@@ -286,8 +292,8 @@ export async function runDeterminizationReport(
     expectedAnalysisRequest: request,
     transcript: completion.transcript
   });
-  const costUsd = estimateUsageCostUsd(model, completion.usage);
-  const modelCalls = options.transport.name === "response-file" ? 0 : 1;
+  const costUsd = completion.costUsd ?? estimateUsageCostUsd(model, completion.usage);
+  const modelCalls = options.transport.makesModelCall ? 1 : 0;
   return {
     ...result,
     selectedSkillDir: selected.dir,

--- a/src/determinization/source.ts
+++ b/src/determinization/source.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { lstat, open } from "node:fs/promises";
+import { lstat, open, type FileHandle } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { compareCodePoints, serializeCanonical, sha256 } from "./canonical.js";
 import { DETERMINIZATION_SCHEMA_VERSION } from "./schemas.js";
@@ -36,6 +36,44 @@ export interface SourceManifest {
 
 const PORTABLE_IDENTITY = /^[A-Za-z0-9][A-Za-z0-9._-]{0,119}$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
+export const MAX_DETERMINIZATION_SOURCE_FILE_BYTES = 256 * 1024;
+
+function oversizedInputError(label: string): Error {
+  return new Error(`Determinization input exceeds 256 KiB: ${label}`);
+}
+
+async function readBoundedHandle(handle: FileHandle, label: string): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(MAX_DETERMINIZATION_SOURCE_FILE_BYTES + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  if (offset > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) throw oversizedInputError(label);
+  const finalMetadata = await handle.stat();
+  if (finalMetadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) throw oversizedInputError(label);
+  return buffer.subarray(0, offset);
+}
+
+export async function readBoundedDeterminizationFile(path: string, label: string): Promise<Buffer> {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`Only regular files are valid determinization inputs: ${label}`);
+  }
+  if (metadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) throw oversizedInputError(label);
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const openedMetadata = await handle.stat();
+    if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
+      throw new Error(`Source input changed during determinization: ${label}`);
+    }
+    if (openedMetadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) throw oversizedInputError(label);
+    return await readBoundedHandle(handle, label);
+  } finally {
+    await handle.close();
+  }
+}
 
 function normalizeAnalysisIdentity(identity: AnalysisIdentity | undefined): AnalysisIdentity | undefined {
   if (identity === undefined) return undefined;
@@ -135,13 +173,19 @@ export async function createSourceManifest(
         }
       }
       if (!metadata.isFile()) throw new Error(`Only regular files are valid determinization inputs: ${logicalPath}`);
+      if (metadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
+        throw oversizedInputError(logicalPath);
+      }
       const handle = await open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
       try {
         const openedMetadata = await handle.stat();
         if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
           throw new Error(`Source input changed during determinization: ${logicalPath}`);
         }
-        entries.push({ path: logicalPath, sha256: sha256(await handle.readFile()) });
+        if (openedMetadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
+          throw oversizedInputError(logicalPath);
+        }
+        entries.push({ path: logicalPath, sha256: sha256(await readBoundedHandle(handle, logicalPath)) });
       } finally {
         await handle.close();
       }

--- a/src/determinization/transport.ts
+++ b/src/determinization/transport.ts
@@ -16,10 +16,12 @@ export interface DeterminizationTransportResult {
   response: unknown;
   transcript: { request: DeterminizationTransportRequest; response: unknown };
   usage?: ModelUsage;
+  costUsd?: number;
 }
 
 export interface DeterminizationTransport {
   readonly name: string;
+  readonly makesModelCall: boolean;
   analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult>;
 }
 
@@ -35,6 +37,7 @@ function parseJsonResponse(completion: ModelCompletion): unknown {
 
 export class DirectModelDeterminizationTransport implements DeterminizationTransport {
   readonly name = "direct-model";
+  readonly makesModelCall = true;
 
   constructor(private readonly client: ModelClient) {}
 
@@ -56,24 +59,41 @@ export class DirectModelDeterminizationTransport implements DeterminizationTrans
   }
 }
 
+/**
+ * FlueSession.task has no system-prompt option, so the workflow supplies the
+ * determinizer system guidance through determinizerProfile.instructions.
+ */
 export class FlueDeterminizationTransport implements DeterminizationTransport {
   readonly name = "flue";
+  readonly makesModelCall = true;
 
   constructor(private readonly session: FlueSession) {}
 
+  /** Maps Flue's aggregate token usage and model-registry-derived cost into the transport-neutral result. */
   async analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult> {
-    const { data } = await this.session.task(request.prompt, {
+    const { data, usage } = await this.session.task(request.prompt, {
       result: v.unknown(),
       agent: "determinizer",
       model: `${request.model.provider}/${request.model.name}`,
       ...(request.cwd && { cwd: request.cwd })
     });
-    return { response: data, transcript: { request, response: data } };
+    return {
+      response: data,
+      transcript: { request, response: data },
+      usage: {
+        inputTokens: usage.input,
+        outputTokens: usage.output,
+        cacheCreationInputTokens: usage.cacheWrite,
+        cacheReadInputTokens: usage.cacheRead
+      },
+      costUsd: usage.cost.total
+    };
   }
 }
 
 export class StaticDeterminizationTransport implements DeterminizationTransport {
   readonly name = "response-file";
+  readonly makesModelCall = false;
 
   constructor(private readonly response: unknown) {}
 

--- a/src/determinization/transport.ts
+++ b/src/determinization/transport.ts
@@ -1,0 +1,83 @@
+import type { FlueSession } from "@flue/runtime";
+import * as v from "valibot";
+import type { ModelClient, ModelCompletion, ModelRequest } from "../model-agent.js";
+import { modelCompletionText, modelCompletionUsage } from "../model-agent.js";
+import type { ModelUsage } from "../cost.js";
+import type { ModelConfig } from "../schemas.js";
+
+export interface DeterminizationTransportRequest {
+  system: string;
+  prompt: string;
+  model: ModelConfig;
+  cwd?: string;
+}
+
+export interface DeterminizationTransportResult {
+  response: unknown;
+  transcript: { request: DeterminizationTransportRequest; response: unknown };
+  usage?: ModelUsage;
+}
+
+export interface DeterminizationTransport {
+  readonly name: string;
+  analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult>;
+}
+
+function parseJsonResponse(completion: ModelCompletion): unknown {
+  const text = modelCompletionText(completion).trim();
+  const unwrapped = text.startsWith("```") ? text.replace(/^```(?:json)?\s*/u, "").replace(/\s*```$/u, "") : text;
+  try {
+    return JSON.parse(unwrapped) as unknown;
+  } catch (error) {
+    throw new Error("Determinizer response was not valid JSON", { cause: error });
+  }
+}
+
+export class DirectModelDeterminizationTransport implements DeterminizationTransport {
+  readonly name = "direct-model";
+
+  constructor(private readonly client: ModelClient) {}
+
+  async analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult> {
+    const modelRequest: ModelRequest = {
+      system: request.system,
+      prompt: request.prompt,
+      model: request.model,
+      phase: "determinization analysis",
+      ...(request.cwd && { workspaceDir: request.cwd })
+    };
+    const completion = await this.client.complete(modelRequest);
+    const response = parseJsonResponse(completion);
+    return {
+      response,
+      transcript: { request, response },
+      usage: modelCompletionUsage(completion)
+    };
+  }
+}
+
+export class FlueDeterminizationTransport implements DeterminizationTransport {
+  readonly name = "flue";
+
+  constructor(private readonly session: FlueSession) {}
+
+  async analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult> {
+    const { data } = await this.session.task(request.prompt, {
+      result: v.unknown(),
+      agent: "determinizer",
+      model: `${request.model.provider}/${request.model.name}`,
+      ...(request.cwd && { cwd: request.cwd })
+    });
+    return { response: data, transcript: { request, response: data } };
+  }
+}
+
+export class StaticDeterminizationTransport implements DeterminizationTransport {
+  readonly name = "response-file";
+
+  constructor(private readonly response: unknown) {}
+
+  async analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult> {
+    return { response: this.response, transcript: { request, response: this.response } };
+  }
+}

--- a/src/flue-runner.ts
+++ b/src/flue-runner.ts
@@ -5,12 +5,13 @@ import { parseArgs } from "node:util";
 import type { FlueWorkflowResult } from "./flue-harness.js";
 import { createRunLog, RunLog } from "./run-log.js";
 
-export type RunnerMode = "smoke" | "research";
+export type RunnerMode = "smoke" | "research" | "determinize";
 
 export type RunnerOptions = {
   verbose: boolean;
   writeRunLog: boolean;
   payload: Record<string, unknown>;
+  workflow?: "autoresearch" | "determinize";
   help?: boolean;
 };
 
@@ -21,12 +22,17 @@ function usage(): string {
     "Usage:",
     "  skills-autoresearch-flue smoke [options]",
     "  skills-autoresearch-flue research [options]",
+    "  skills-autoresearch-flue determinize [options]",
     "  skills-autoresearch-flue --payload <json> [options]",
     "",
     "Config-driven options:",
     "  --project <dir>         Project root. Defaults to current directory.",
     "  --seed-skill <dir>      Override config.json origin_skill for this run.",
     "  --guidance-skill <dir>  Override config.json guidance_skill for this run.",
+    "  --skill <dir>           Explicit skill directory for determinize.",
+    "  --context-root <dir>    Optional external read-only context for determinize.",
+    "  --catalog-root <dir>    Deterministic-asset catalog root.",
+    "  --output <dir>          Determinization artifact root.",
     "  --session <name>        Override the derived project-mode session name.",
     "  --resume                Resume validated artifacts from an interrupted run.",
     "  --with-cleanup          Remove generated research artifacts before a fresh run.",
@@ -57,12 +63,14 @@ export async function runFlueCommand(argv = process.argv.slice(2)): Promise<numb
     writeRunLog: options.writeRunLog,
     ...(runLog ? { runLogPath: runLog.path } : {})
   };
-  const flueArgs = buildFlueArgs(payload);
+  const flueArgs = buildFlueArgs(payload, options.workflow ?? "autoresearch");
 
   runLog?.append("run-start", { command: "flue", args: flueArgs, projectRoot, sessionId });
   if (runLog) {
     process.stderr.write(`Run log: ${runLog.path}\n`);
   }
+  const modelCallPreview = formatFlueModelCallPreview(options.workflow ?? "autoresearch");
+  if (modelCallPreview) process.stderr.write(`${modelCallPreview}\n`);
 
   const exitCode = await spawnFlue(flueArgs, options.verbose, runLog);
   runLog?.append("run-end", { exitCode });
@@ -81,6 +89,10 @@ export function parseRunnerArgs(argv: string[]): RunnerOptions {
       project: { type: "string" },
       "seed-skill": { type: "string" },
       "guidance-skill": { type: "string" },
+      skill: { type: "string" },
+      "context-root": { type: "string" },
+      "catalog-root": { type: "string" },
+      output: { type: "string" },
       session: { type: "string" },
       resume: { type: "boolean" },
       "with-cleanup": { type: "boolean" },
@@ -105,6 +117,10 @@ export function parseRunnerArgs(argv: string[]): RunnerOptions {
     values.project,
     values["seed-skill"],
     values["guidance-skill"],
+    values.skill,
+    values["context-root"],
+    values["catalog-root"],
+    values.output,
     values.session,
     values.resume,
     values["with-cleanup"],
@@ -114,7 +130,7 @@ export function parseRunnerArgs(argv: string[]): RunnerOptions {
 
   if (values.payload !== undefined) {
     if (positionals.length > 0 || configOptionsUsed) {
-      throw new Error("Use either a smoke/research command or --payload, not both.");
+      throw new Error("Use either a config-driven command or --payload, not both.");
     }
     return {
       verbose: values.verbose ?? false,
@@ -124,17 +140,37 @@ export function parseRunnerArgs(argv: string[]): RunnerOptions {
   }
 
   if (positionals.length !== 1 || !isRunnerMode(positionals[0])) {
-    throw new Error("Choose a config-driven command: smoke or research. Use --help for usage.");
+    throw new Error("Choose a config-driven command: smoke or research, or determinize. Use --help for usage.");
   }
 
   const mode = positionals[0];
+  if (
+    mode === "determinize" &&
+    [
+      values["seed-skill"],
+      values["guidance-skill"],
+      values.resume,
+      values["with-cleanup"],
+      values["force-research"],
+      values["budget-usd"]
+    ].some((value) => value !== undefined && value !== false)
+  ) {
+    throw new Error(
+      "Determinize does not accept autoresearch-only seed, guidance, resume, cleanup, force, or budget options."
+    );
+  }
   return {
     verbose: values.verbose ?? false,
     writeRunLog: !(values["no-run-log"] ?? false),
+    ...(mode === "determinize" ? { workflow: "determinize" as const } : {}),
     payload: buildConfigDrivenPayload(mode, {
       projectRoot: values.project,
       seedSkillDir: values["seed-skill"],
       guidanceSkillDir: values["guidance-skill"],
+      skillDir: values.skill,
+      contextRoot: values["context-root"],
+      catalogRoot: values["catalog-root"],
+      outputRoot: values.output,
       sessionId: values.session,
       resume: values.resume,
       withCleanup: values["with-cleanup"],
@@ -150,6 +186,10 @@ export function buildConfigDrivenPayload(
     projectRoot?: string;
     seedSkillDir?: string;
     guidanceSkillDir?: string;
+    skillDir?: string;
+    contextRoot?: string;
+    catalogRoot?: string;
+    outputRoot?: string;
     sessionId?: string;
     resume?: boolean;
     withCleanup?: boolean;
@@ -160,11 +200,14 @@ export function buildConfigDrivenPayload(
   const projectRoot = resolve(options.projectRoot ?? process.cwd());
   return {
     projectRoot,
-    withBaseline: true,
-    runResearch: mode === "research",
+    ...(mode === "determinize" ? {} : { withBaseline: true, runResearch: mode === "research" }),
     sessionId: options.sessionId ?? `${basename(projectRoot)}-${mode}`,
     ...(options.seedSkillDir ? { seedSkillDir: options.seedSkillDir } : {}),
     ...(options.guidanceSkillDir ? { guidanceSkillDir: options.guidanceSkillDir } : {}),
+    ...(options.skillDir ? { skillDir: options.skillDir } : {}),
+    ...(options.contextRoot ? { contextRoot: options.contextRoot } : {}),
+    ...(options.catalogRoot ? { catalogRoot: options.catalogRoot } : {}),
+    ...(options.outputRoot ? { outputRoot: options.outputRoot } : {}),
     ...(options.resume ? { resume: true } : {}),
     ...(options.withCleanup ? { withCleanup: true } : {}),
     ...(options.forceResearch ? { forceResearch: true } : {}),
@@ -173,7 +216,7 @@ export function buildConfigDrivenPayload(
 }
 
 function isRunnerMode(value: string): value is RunnerMode {
-  return value === "smoke" || value === "research";
+  return value === "smoke" || value === "research" || value === "determinize";
 }
 
 function parsePayload(value: string): Record<string, unknown> {
@@ -198,19 +241,15 @@ function parseBudgetUsd(value: string | undefined): number | undefined {
   return parsed;
 }
 
-export function buildFlueArgs(payload: Record<string, unknown>): string[] {
-  return [
-    "exec",
-    "flue",
-    "run",
-    "autoresearch",
-    "--target",
-    "node",
-    "--root",
-    ".",
-    "--payload",
-    JSON.stringify(payload)
-  ];
+export function buildFlueArgs(
+  payload: Record<string, unknown>,
+  workflow: "autoresearch" | "determinize" = "autoresearch"
+): string[] {
+  return ["exec", "flue", "run", workflow, "--target", "node", "--root", ".", "--payload", JSON.stringify(payload)];
+}
+
+export function formatFlueModelCallPreview(workflow: "autoresearch" | "determinize"): string | undefined {
+  return workflow === "determinize" ? "Determinizer model call preview: 1 planned call(s)." : undefined;
 }
 
 function spawnFlue(args: string[], verbose: boolean, runLog: RunLog | undefined): Promise<number> {
@@ -286,7 +325,19 @@ export function formatQuietResult(output: string, truncated = false): string | u
       : undefined;
   }
   try {
-    const result = JSON.parse(output.slice(jsonStart)) as Partial<FlueWorkflowResult>;
+    const result = JSON.parse(output.slice(jsonStart)) as Partial<FlueWorkflowResult> & {
+      paths?: { report?: string };
+      opportunityCount?: number;
+      recommendationCount?: number;
+    };
+    if (result.paths?.report) {
+      const determinizationCost = (result as unknown as { cost?: { actualCalls?: number; costUsd?: number } }).cost;
+      return (
+        `Determinization report: ${result.paths.report}; opportunities ${result.opportunityCount ?? "unknown"}; ` +
+        `deterministic assets ${result.recommendationCount ?? "unknown"}; model calls ${determinizationCost?.actualCalls ?? "unknown"}` +
+        (determinizationCost?.costUsd === undefined ? "" : `; observed cost $${determinizationCost.costUsd.toFixed(4)}`)
+      );
+    }
     const score = result.normalizedScore?.toFixed(3) ?? "unknown";
     const iterations = result.completedIterations ?? "unknown";
     const calls = result.cost?.actual?.totalCalls ?? "unknown";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,8 @@ export * from "./model-agent.js";
 export * from "./flue-harness.js";
 export * from "./cost.js";
 export * from "./pricing.js";
+export * from "./determinization/run.js";
+export * from "./determinization/transport.js";
+export * from "./determinization/artifacts.js";
+export * from "./determinization/schemas.js";
+export * from "./determinization/catalog.js";

--- a/src/project-layout.ts
+++ b/src/project-layout.ts
@@ -23,6 +23,7 @@ export interface ProjectLayout {
   resumeBackupsDir: string;
   guidanceLedgerPath: string;
   costSummaryPath: string;
+  determinizationDir: string;
   iterationDir(iteration: number): string;
   iterationSkillDir(iteration: number): string;
   iterationOutputDir(iteration: number, evalId?: string): string;
@@ -41,6 +42,7 @@ export function projectLayout(root: string): ProjectLayout {
     resumeBackupsDir: join(workspaceDir, "resume-backups"),
     guidanceLedgerPath: join(workspaceDir, "guidance-ledger.json"),
     costSummaryPath: join(workspaceDir, "cost-summary.json"),
+    determinizationDir: join(workspaceDir, "determinization"),
     iterationDir: (iteration) => join(iterationsDir, String(iteration)),
     iterationSkillDir: (iteration) => join(iterationsDir, String(iteration), "skill"),
     iterationOutputDir: (iteration, evalId) =>

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -10,7 +10,8 @@ export const ModelConfigSchema = v.object({
 export const RoleModelsSchema = v.object({
   producer: v.optional(ModelConfigSchema),
   judge: v.optional(ModelConfigSchema),
-  researcher: v.optional(ModelConfigSchema)
+  researcher: v.optional(ModelConfigSchema),
+  determinizer: v.optional(ModelConfigSchema)
 });
 
 export const RolesConfigSchema = v.object({

--- a/tests/determinization-integration.test.ts
+++ b/tests/determinization-integration.test.ts
@@ -1,0 +1,222 @@
+import type { FlueSession } from "@flue/runtime";
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { main } from "../src/cli.js";
+import { runDeterminizationReport } from "../src/determinization/run.js";
+import {
+  DirectModelDeterminizationTransport,
+  FlueDeterminizationTransport,
+  StaticDeterminizationTransport,
+  type DeterminizationTransport
+} from "../src/determinization/transport.js";
+import type { ModelClient } from "../src/model-agent.js";
+import { tempProject, writeFixture, syntheticConfig, syntheticEvals } from "./helpers.js";
+
+const fixtureProject = resolve("fixtures/projects/release-notes-alpha");
+const fixtureResponse = resolve("fixtures/expected/determinization/release-notes-alpha/analysis-response.json");
+const fixtureReport = resolve("fixtures/expected/determinization/release-notes-alpha/report.md");
+const catalogRoot = resolve("catalog/deterministic-assets");
+
+async function response() {
+  return JSON.parse(await readFile(fixtureResponse, "utf8")) as unknown;
+}
+
+test("runs the release-notes fixture deterministically and preserves the read-only boundary", async () => {
+  const output = await tempProject("det-integration-");
+  const skillPath = join(fixtureProject, "seed-skill", "SKILL.md");
+  const catalogPath = join(catalogRoot, "language.json");
+  const before = await Promise.all([readFile(skillPath), readFile(catalogPath)]);
+  const result = await runDeterminizationReport({
+    projectRoot: fixtureProject,
+    outputRoot: output,
+    catalogRoot,
+    transport: new StaticDeterminizationTransport(await response())
+  });
+  const report = await readFile(result.paths.report, "utf8");
+  expect(result).toMatchObject({
+    selectedSkillSource: "origin_skill",
+    opportunityCount: 1,
+    recommendationCount: 3,
+    cost: { plannedCalls: 0, actualCalls: 0 }
+  });
+  expect(report).toContain("partially_deterministic");
+  expect(report).toContain("LanguageTool may contribute");
+  expect(report).toContain("Custom LanguageTool rules");
+  expect(report).toContain("editorial judgment");
+  expect(report).toContain("suggested and unverified");
+  expect(report).toBe(await readFile(fixtureReport, "utf8"));
+  const source = JSON.parse(await readFile(result.paths.source, "utf8")) as { inputs: Array<{ path: string }> };
+  expect(source.inputs.map(({ path }) => path)).toEqual(
+    expect.arrayContaining([
+      "evaluation/CHANGELOG.md",
+      "evaluation/notes-001/input/CHANGELOG.md",
+      "evaluation/notes-001/task.md"
+    ])
+  );
+  expect(await Promise.all([readFile(skillPath), readFile(catalogPath)])).toEqual(before);
+});
+
+test("rejects a symlinked input root before invoking the transport", async () => {
+  const links = await tempProject("det-symlink-root-");
+  const linkedSkill = join(links, "linked-skill");
+  await symlink(join(fixtureProject, "seed-skill"), linkedSkill);
+  let calls = 0;
+  await expect(
+    runDeterminizationReport({
+      projectRoot: fixtureProject,
+      skillDir: linkedSkill,
+      outputRoot: await tempProject("det-symlink-output-"),
+      catalogRoot,
+      transport: {
+        name: "audit-spy",
+        async analyze(request) {
+          calls += 1;
+          const response = { schema_version: "1.0.0", opportunities: [] };
+          return {
+            response,
+            transcript: { request, response }
+          };
+        }
+      }
+    })
+  ).rejects.toThrow(/Symbolic links are not valid determinization/);
+  expect(calls).toBe(0);
+});
+
+test("rejects output beneath a selected read-only root before invoking the transport", async () => {
+  let calls = 0;
+  await expect(
+    runDeterminizationReport({
+      projectRoot: fixtureProject,
+      outputRoot: join(fixtureProject, "seed-skill", "generated-report"),
+      catalogRoot,
+      transport: {
+        name: "audit-spy",
+        async analyze(request) {
+          calls += 1;
+          const response = { schema_version: "1.0.0", opportunities: [] };
+          return { response, transcript: { request, response } };
+        }
+      }
+    })
+  ).rejects.toThrow(/must not be inside/);
+  expect(calls).toBe(0);
+});
+
+test("rejects symlinked project and output roots before invoking the transport", async () => {
+  const links = await tempProject("det-root-links-");
+  const linkedProject = join(links, "project");
+  const linkedOutput = join(links, "output");
+  await symlink(fixtureProject, linkedProject);
+  await symlink(await tempProject("det-real-output-"), linkedOutput);
+  let calls = 0;
+  const transport = {
+    name: "audit-spy",
+    async analyze(request: Parameters<DeterminizationTransport["analyze"]>[0]) {
+      calls += 1;
+      const response = { schema_version: "1.0.0", opportunities: [] };
+      return { response, transcript: { request, response } };
+    }
+  } satisfies DeterminizationTransport;
+  await expect(
+    runDeterminizationReport({ projectRoot: linkedProject, outputRoot: await tempProject(), catalogRoot, transport })
+  ).rejects.toThrow(/Symbolic links are not valid determinization project roots/);
+  await expect(
+    runDeterminizationReport({ projectRoot: fixtureProject, outputRoot: linkedOutput, catalogRoot, transport })
+  ).rejects.toThrow(/output root or nearest existing parent must not be a symlink/);
+  expect(calls).toBe(0);
+});
+
+test("CLI prints an absolute inspectable path and resumes without a model call", async () => {
+  const output = await tempProject("det-cli-");
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  try {
+    await main([
+      "determinize",
+      "report",
+      "--project",
+      fixtureProject,
+      "--response-file",
+      fixtureResponse,
+      "--catalog-root",
+      catalogRoot,
+      "--output",
+      output
+    ]);
+    expect(log.mock.calls.flat().join("\n")).toContain(`Determinization report: ${join(output, "report.md")}`);
+    expect(log.mock.calls.flat().join("\n")).toContain("model calls: 0");
+    await rm(join(output, "report.md"));
+    log.mockClear();
+    await main([
+      "determinize",
+      "report",
+      "--project",
+      fixtureProject,
+      "--resume",
+      "--catalog-root",
+      catalogRoot,
+      "--output",
+      output
+    ]);
+    expect(await readFile(join(output, "report.md"), "utf8")).toContain("partially_deterministic");
+    expect(log.mock.calls.flat().join("\n")).toContain("model calls: 0");
+  } finally {
+    log.mockRestore();
+  }
+});
+
+test("post-run selection chooses the highest scored iteration with deterministic tie-breaking", async () => {
+  const root = await tempProject("det-selection-");
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  await mkdir(join(root, "seed-skill"));
+  await writeFile(join(root, "seed-skill", "SKILL.md"), "# Seed\n");
+  for (const [iteration, score] of [
+    [1, 0.9],
+    [2, 0.9]
+  ] as const) {
+    const skill = join(root, "workspace", "iterations", String(iteration), "skill");
+    await mkdir(skill, { recursive: true });
+    await writeFile(join(skill, "SKILL.md"), `# Iteration ${iteration}\n`);
+    await writeFile(
+      join(root, "workspace", "iterations", String(iteration), "summary.json"),
+      JSON.stringify({ overall: { normalizedScore: score } })
+    );
+  }
+  const output = await tempProject("det-selection-output-");
+  const result = await runDeterminizationReport({
+    projectRoot: root,
+    catalogRoot,
+    outputRoot: output,
+    transport: new StaticDeterminizationTransport({ schema_version: "1.0.0", opportunities: [] })
+  });
+  expect(result.selectedSkillSource).toBe("best_iteration");
+  expect(result.selectedSkillDir).toBe(join(root, "workspace", "iterations", "1", "skill"));
+});
+
+test("direct-model and Flue transports preserve their role boundary", async () => {
+  const model = { provider: "anthropic" as const, name: "claude-sonnet-4-6" };
+  const request = { system: "system", prompt: "prompt", model };
+  const client: ModelClient = {
+    async complete() {
+      return { text: '{"schema_version":"1.0.0","opportunities":[]}', usage: { inputTokens: 10 } };
+    }
+  };
+  const direct = await new DirectModelDeterminizationTransport(client).analyze(request);
+  expect(direct.response).toEqual({ schema_version: "1.0.0", opportunities: [] });
+  expect(direct.usage).toEqual({ inputTokens: 10 });
+
+  const tasks: unknown[] = [];
+  const session = {
+    async task(text: string, options: unknown) {
+      tasks.push({ text, options });
+      return { data: { schema_version: "1.0.0", opportunities: [] } };
+    }
+  } as unknown as FlueSession;
+  await new FlueDeterminizationTransport(session).analyze(request);
+  expect(tasks).toEqual([
+    expect.objectContaining({
+      text: "prompt",
+      options: expect.objectContaining({ agent: "determinizer", model: "anthropic/claude-sonnet-4-6" })
+    })
+  ]);
+});

--- a/tests/determinization-integration.test.ts
+++ b/tests/determinization-integration.test.ts
@@ -1,5 +1,5 @@
 import type { FlueSession } from "@flue/runtime";
-import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { main } from "../src/cli.js";
 import { runDeterminizationReport } from "../src/determinization/run.js";
@@ -56,6 +56,24 @@ test("runs the release-notes fixture deterministically and preserves the read-on
   expect(await Promise.all([readFile(skillPath), readFile(catalogPath)])).toEqual(before);
 });
 
+test("counts model calls from the transport capability rather than its name", async () => {
+  const recordedResponse = await response();
+  const result = await runDeterminizationReport({
+    projectRoot: fixtureProject,
+    outputRoot: await tempProject("det-call-capability-"),
+    catalogRoot,
+    transport: {
+      name: "custom-recording",
+      makesModelCall: false,
+      async analyze(request) {
+        return { response: recordedResponse, transcript: { request, response: recordedResponse } };
+      }
+    }
+  });
+
+  expect(result.cost).toMatchObject({ plannedCalls: 0, actualCalls: 0 });
+});
+
 test("rejects a symlinked input root before invoking the transport", async () => {
   const links = await tempProject("det-symlink-root-");
   const linkedSkill = join(links, "linked-skill");
@@ -69,6 +87,7 @@ test("rejects a symlinked input root before invoking the transport", async () =>
       catalogRoot,
       transport: {
         name: "audit-spy",
+        makesModelCall: false,
         async analyze(request) {
           calls += 1;
           const response = { schema_version: "1.0.0", opportunities: [] };
@@ -92,6 +111,7 @@ test("rejects output beneath a selected read-only root before invoking the trans
       catalogRoot,
       transport: {
         name: "audit-spy",
+        makesModelCall: false,
         async analyze(request) {
           calls += 1;
           const response = { schema_version: "1.0.0", opportunities: [] };
@@ -112,6 +132,7 @@ test("rejects symlinked project and output roots before invoking the transport",
   let calls = 0;
   const transport = {
     name: "audit-spy",
+    makesModelCall: false,
     async analyze(request: Parameters<DeterminizationTransport["analyze"]>[0]) {
       calls += 1;
       const response = { schema_version: "1.0.0", opportunities: [] };
@@ -125,6 +146,29 @@ test("rejects symlinked project and output roots before invoking the transport",
     runDeterminizationReport({ projectRoot: fixtureProject, outputRoot: linkedOutput, catalogRoot, transport })
   ).rejects.toThrow(/output root or nearest existing parent must not be a symlink/);
   expect(calls).toBe(0);
+});
+
+test("rejects an oversized input before attempting to read it", async () => {
+  const root = await tempProject("det-oversized-input-");
+  await writeFixture(root, syntheticConfig, syntheticEvals);
+  await mkdir(join(root, "seed-skill"));
+  await writeFile(join(root, "seed-skill", "SKILL.md"), "# Seed\n");
+  const oversized = join(root, "evals", "oversized.txt");
+  await writeFile(oversized, "");
+  await truncate(oversized, 256 * 1024 + 1);
+  await chmod(oversized, 0);
+  try {
+    await expect(
+      runDeterminizationReport({
+        projectRoot: root,
+        outputRoot: await tempProject("det-oversized-output-"),
+        catalogRoot,
+        transport: new StaticDeterminizationTransport(await response())
+      })
+    ).rejects.toThrow(/Determinization input exceeds 256 KiB: .*oversized\.txt/);
+  } finally {
+    await chmod(oversized, 0o600);
+  }
 });
 
 test("CLI prints an absolute inspectable path and resumes without a model call", async () => {
@@ -209,14 +253,34 @@ test("direct-model and Flue transports preserve their role boundary", async () =
   const session = {
     async task(text: string, options: unknown) {
       tasks.push({ text, options });
-      return { data: { schema_version: "1.0.0", opportunities: [] } };
+      return {
+        data: { schema_version: "1.0.0", opportunities: [] },
+        usage: {
+          input: 10,
+          output: 5,
+          cacheRead: 3,
+          cacheWrite: 2,
+          totalTokens: 20,
+          cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0.0002, total: 0.0033 }
+        },
+        model: { provider: "anthropic", id: "claude-sonnet-4-6" }
+      };
     }
   } as unknown as FlueSession;
-  await new FlueDeterminizationTransport(session).analyze(request);
+  const flue = await new FlueDeterminizationTransport(session).analyze(request);
   expect(tasks).toEqual([
     expect.objectContaining({
       text: "prompt",
       options: expect.objectContaining({ agent: "determinizer", model: "anthropic/claude-sonnet-4-6" })
     })
   ]);
+  expect(flue).toMatchObject({
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheCreationInputTokens: 2,
+      cacheReadInputTokens: 3
+    },
+    costUsd: 0.0033
+  });
 });

--- a/tests/determinization-source.test.ts
+++ b/tests/determinization-source.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, symlink, truncate, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -129,6 +129,21 @@ test("source selection rejects traversal, symlinks, and special files", async ()
     ])
   ).rejects.toThrow(/Duplicate selected source path/);
   expect(await readFile(outside, "utf8")).toBe("outside");
+});
+
+test("source manifests reject oversized files before reading their contents", async () => {
+  const root = await mkdtemp(join(tmpdir(), "det-source-oversized-"));
+  const oversized = join(root, "oversized.md");
+  await writeFile(oversized, "");
+  await truncate(oversized, 256 * 1024 + 1);
+  await chmod(oversized, 0);
+  try {
+    await expect(createSourceManifest([{ namespace: "catalog", root, paths: ["oversized.md"] }])).rejects.toThrow(
+      "Determinization input exceeds 256 KiB: catalog/oversized.md"
+    );
+  } finally {
+    await chmod(oversized, 0o600);
+  }
 });
 
 test("source manifest entries use Unicode code-point ordering", async () => {

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -4,6 +4,7 @@ import {
   appendQuietStdout,
   buildConfigDrivenPayload,
   buildFlueArgs,
+  formatFlueModelCallPreview,
   formatQuietResult,
   parseRunnerArgs,
   shouldPrintQuietLine
@@ -85,6 +86,41 @@ test("config-driven commands default to the current project and derive a stable 
   });
 });
 
+test("Flue runner builds the determinize workflow payload without autoresearch flags", () => {
+  expect(
+    parseRunnerArgs([
+      "determinize",
+      "--project",
+      "/tmp/project",
+      "--skill",
+      "/tmp/skill",
+      "--context-root",
+      "/tmp/context",
+      "--catalog-root",
+      "/tmp/catalog",
+      "--output",
+      "/tmp/output"
+    ])
+  ).toEqual({
+    verbose: false,
+    writeRunLog: true,
+    workflow: "determinize",
+    payload: {
+      projectRoot: "/tmp/project",
+      sessionId: "project-determinize",
+      skillDir: "/tmp/skill",
+      contextRoot: "/tmp/context",
+      catalogRoot: "/tmp/catalog",
+      outputRoot: "/tmp/output"
+    }
+  });
+  expect(buildFlueArgs({ projectRoot: "/tmp/project" }, "determinize")).toContain("determinize");
+  expect(formatFlueModelCallPreview("determinize")).toBe("Determinizer model call preview: 1 planned call(s).");
+  expect(formatFlueModelCallPreview("autoresearch")).toBeUndefined();
+  expect(() => parseRunnerArgs(["determinize", "--resume"])).toThrow(/does not accept autoresearch-only/);
+  expect(() => parseRunnerArgs(["determinize", "--budget-usd", "1"])).toThrow(/does not accept autoresearch-only/);
+});
+
 test("Flue runner keeps direct payload invocation as an advanced path", () => {
   expect(parseRunnerArgs(["--payload", '{"projectRoot":"/tmp/project","runResearch":false}'])).toMatchObject({
     payload: { projectRoot: "/tmp/project", runResearch: false }
@@ -130,6 +166,21 @@ test("quiet Flue output replaces the full result with a compact summary", () => 
     )
   ).toBe(
     "Run complete: score 0.900; iterations 2; model calls 8; best skill /tmp/project/workspace/iterations/2/skill"
+  );
+});
+
+test("quiet Flue output summarizes determinization results", () => {
+  expect(
+    formatQuietResult(
+      JSON.stringify({
+        paths: { report: "/tmp/project/workspace/determinization/report.md" },
+        opportunityCount: 2,
+        recommendationCount: 4,
+        cost: { actualCalls: 1, costUsd: 0.0123 }
+      })
+    )
+  ).toBe(
+    "Determinization report: /tmp/project/workspace/determinization/report.md; opportunities 2; deterministic assets 4; model calls 1; observed cost $0.0123"
   );
 });
 

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -1,5 +1,9 @@
+import type { FlueContext, FlueSession } from "@flue/runtime";
 import { readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { run as runDeterminizeWorkflow } from "../.flue/workflows/determinize.js";
 import {
   appendQuietStdout,
   buildConfigDrivenPayload,
@@ -9,6 +13,13 @@ import {
   parseRunnerArgs,
   shouldPrintQuietLine
 } from "../src/flue-runner.js";
+import { tempProject } from "./helpers.js";
+
+const fixtureProject = fileURLToPath(new URL("../fixtures/projects/release-notes-alpha", import.meta.url));
+const fixtureResponse = fileURLToPath(
+  new URL("../fixtures/expected/determinization/release-notes-alpha/analysis-response.json", import.meta.url)
+);
+const catalogRoot = fileURLToPath(new URL("../catalog/deterministic-assets", import.meta.url));
 
 test("Flue runner parses verbose and run-log opt-out flags without forwarding them", () => {
   expect(
@@ -119,6 +130,78 @@ test("Flue runner builds the determinize workflow payload without autoresearch f
   expect(formatFlueModelCallPreview("autoresearch")).toBeUndefined();
   expect(() => parseRunnerArgs(["determinize", "--resume"])).toThrow(/does not accept autoresearch-only/);
   expect(() => parseRunnerArgs(["determinize", "--budget-usd", "1"])).toThrow(/does not accept autoresearch-only/);
+});
+
+test("determinize workflow produces the report through a Flue session", async () => {
+  const outputRoot = await tempProject("det-flue-workflow-");
+  const response = JSON.parse(readFileSync(fixtureResponse, "utf8")) as unknown;
+  const task = vi.fn(async () => ({
+    data: response,
+    usage: {
+      input: 120,
+      output: 30,
+      cacheRead: 20,
+      cacheWrite: 10,
+      totalTokens: 180,
+      cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0.0002, total: 0.0033 }
+    },
+    model: { provider: "anthropic", id: "claude-haiku-4-5" }
+  }));
+  const session = {
+    task
+  } as unknown as FlueSession;
+  const sessionFactory = vi.fn(async () => session);
+  const init = vi.fn(async () => ({ session: sessionFactory }));
+
+  const result = await runDeterminizeWorkflow({
+    init,
+    payload: {
+      projectRoot: fixtureProject,
+      catalogRoot,
+      outputRoot,
+      sessionId: "workflow-test",
+      model: "anthropic/claude-haiku-4-5"
+    },
+    env: {}
+  } as unknown as FlueContext);
+
+  expect(init).toHaveBeenCalledOnce();
+  expect(sessionFactory).toHaveBeenCalledWith("workflow-test");
+  expect(task).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({ agent: "determinizer", model: "anthropic/claude-haiku-4-5" })
+  );
+  expect(result.paths.report).toBe(join(outputRoot, "report.md"));
+  expect(result.cost).toMatchObject({
+    model: { provider: "anthropic", name: "claude-haiku-4-5" },
+    usage: {
+      inputTokens: 120,
+      outputTokens: 30,
+      cacheCreationInputTokens: 10,
+      cacheReadInputTokens: 20
+    },
+    costUsd: 0.0033
+  });
+  expect(await readFile(result.paths.report, "utf8")).toContain("# Determinization opportunity report");
+});
+
+test.each(["openai/gpt-5", "anthropic/", "anthropic/claude/extra", "anthropic/claude sonnet"])(
+  "determinize workflow rejects invalid model override %j before initialization",
+  async (model) => {
+    const init = vi.fn();
+    await expect(
+      runDeterminizeWorkflow({ init, payload: { model }, env: {} } as unknown as FlueContext)
+    ).rejects.toThrow(/anthropic\/<non-empty-model>/);
+    expect(init).not.toHaveBeenCalled();
+  }
+);
+
+test("determinize workflow rejects an invalid environment model override before initialization", async () => {
+  const init = vi.fn();
+  await expect(
+    runDeterminizeWorkflow({ init, payload: {}, env: { FLUE_MODEL: "openai/gpt-5" } } as unknown as FlueContext)
+  ).rejects.toThrow(/anthropic\/<non-empty-model>/);
+  expect(init).not.toHaveBeenCalled();
 });
 
 test("Flue runner keeps direct payload invocation as an advanced path", () => {

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -1,6 +1,7 @@
 import { validateConfiguredFlueRoles } from "../src/flue-roles.js";
 import { loadProject, trackForEval } from "../src/project.js";
 import { resolveModel } from "../src/model.js";
+import { resolveDeterminizerModel } from "../src/determinization/run.js";
 import {
   securityConfig,
   securityEvals,
@@ -34,6 +35,24 @@ test("resolves default model and rejects unsupported providers", async () => {
   });
   expect(resolveModel(project.config, { name: "claude-opus-4-6" }).name).toBe("claude-opus-4-6");
   expect(() => resolveModel(project.config, { provider: "openai" })).toThrow(/Unsupported model provider/);
+});
+
+test("resolves the determinizer model before researcher and default fallbacks", () => {
+  expect(
+    resolveDeterminizerModel({
+      ...syntheticConfig,
+      models: {
+        researcher: { provider: "anthropic", name: "researcher-model" },
+        determinizer: { provider: "anthropic", name: "determinizer-model" }
+      }
+    })
+  ).toEqual({ provider: "anthropic", name: "determinizer-model" });
+  expect(
+    resolveDeterminizerModel({
+      ...syntheticConfig,
+      models: { researcher: { provider: "anthropic", name: "researcher-model" } }
+    })
+  ).toEqual({ provider: "anthropic", name: "researcher-model" });
 });
 
 test("requires judge and skill builder role keys", async () => {


### PR DESCRIPTION
## Summary

Integrates the read-only deterministic-extraction report as the final layer of Delivery Phase 1.

Stack position: 3/3  
Parent: #117  
Child: none  
Current base: `codex/determinization-analysis-artifacts`  
Required merge order: #116 → #117 → this PR

Closes #99  
Refs #115

## Scope unique to this PR

- Adds `determinize report` to the local CLI.
- Adds direct-model, response-file, and Flue determinizer transports.
- Adds the dedicated Flue determinizer profile/workflow.
- Selects an explicit skill, then best scored iteration, then origin skill.
- Fingerprints skill guidance, eval definitions, project inputs, reference context, and baseline/iteration evidence.
- Adds model fallback, call/cost preview and summary, validated zero-call resume, canonical project layout, and public exports.
- Adds the inspectable `release-notes-alpha` response/report fixture.
- Documents commands, artifacts, lineage, LanguageTool caveats, and read-only boundaries.

## Verification

- `pnpm run check`
- Direct built CLI determinization fixture run
- 22 test files / 170 tests
- Flue build discovers `autoresearch` and `determinize`
- Byte-for-byte regenerated fixture report comparison
- Validated zero-model-call resume
- Independent adversarial audit: clean pass
- GitHub CI and CodeQL rerun after each stacked branch update

## Phase-wide exclusions

- No evidence-gathered lifecycle transition.
- No asset proposal or verification.
- No skill, context, or catalog mutation.
- No apply or adoption behavior.
- No Flue 2 production migration.

## Validation note

No credential-backed model run was performed because `ANTHROPIC_API_KEY` was not present. The committed response fixture exercises the complete artifact path deterministically without credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only determinization workflow for identifying opportunities to make skill guidance more consistent.
  * Added CLI support for generating, viewing, and resuming determinization reports.
  * Reports include evidence, suggested assets, confidence, limitations, and human-judgment requirements.
  * Added support for direct model calls, recorded responses, and Flue-backed analysis.
  * Added model configuration and concise output summaries with report paths, opportunity counts, and usage details.

* **Documentation**
  * Documented commands, generated artifacts, resume behavior, supported inputs, and read-only safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->