### PR TITLE
Make installed runtime resources portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pnpm run typecheck
 pnpm run build
 pnpm run autoresearch -- smoke --project path/to/project
 varlock run -- pnpm run autoresearch -- research --project path/to/project
-node packages/skills-autoresearch/dist/cli.js determinize report --project path/to/project --response-file path/to/analysis-response.json
+node packages/skills-autoresearch/dist/bin/skills-autoresearch.js determinize report --project path/to/project --response-file path/to/analysis-response.json
 pnpm run alpha:smoke
 pnpm run alpha:research
 pnpm run alpha:determinize

--- a/docs/alpha-run.md
+++ b/docs/alpha-run.md
@@ -88,14 +88,14 @@ For a live Flue-backed analysis with Anthropic credentials, build and run:
 
 ```bash
 pnpm run build
-varlock run -- node packages/skills-autoresearch/dist/flue-runner.js determinize \
+varlock run -- node packages/skills-autoresearch/dist/bin/skills-autoresearch-flue.js determinize \
   --project fixtures/projects/release-notes-alpha
 ```
 
 Determinization resume is available only through the direct `determinize report` CLI, not the Flue-backed `determinize` command. It validates current inputs and re-renders the existing immutable `opportunities.json` without another model call:
 
 ```bash
-node packages/skills-autoresearch/dist/cli.js determinize report \
+node packages/skills-autoresearch/dist/bin/skills-autoresearch.js determinize report \
   --project fixtures/projects/release-notes-alpha \
   --resume
 ```

--- a/docs/using-the-harness.md
+++ b/docs/using-the-harness.md
@@ -165,11 +165,11 @@ Build the CLI, then analyze the project with either a recorded structured respon
 
 ```bash
 pnpm run build
-node packages/skills-autoresearch/dist/cli.js determinize report \
+node packages/skills-autoresearch/dist/bin/skills-autoresearch.js determinize report \
   --project path/to/my-autoresearch-project \
   --response-file path/to/analysis-response.json
 
-varlock run -- node packages/skills-autoresearch/dist/cli.js determinize report \
+varlock run -- node packages/skills-autoresearch/dist/bin/skills-autoresearch.js determinize report \
   --project path/to/my-autoresearch-project \
   --model-client anthropic
 ```
@@ -204,7 +204,7 @@ The application CLI provides the same read-only analysis through the Flue 2 dete
 
 ```bash
 pnpm run build
-node packages/skills-autoresearch/dist/flue-runner.js determinize --project path/to/my-autoresearch-project
+node packages/skills-autoresearch/dist/bin/skills-autoresearch-flue.js determinize --project path/to/my-autoresearch-project
 ```
 
 The Flue path is model-backed and requires the configured Anthropic credentials. The direct CLI's `--response-file` mode is the repeatable credential-free inspection path.

--- a/fixtures/projects/release-notes-alpha/roles/eval-judge.md
+++ b/fixtures/projects/release-notes-alpha/roles/eval-judge.md
@@ -1,0 +1,11 @@
+---
+name: eval-judge
+description: Scores eval outputs against the eval case, expectations, rubric, and reference material.
+model: anthropic/claude-sonnet-4-6
+---
+
+You are an independent evaluator. Score only the producer output files against the eval case, expectations, and reference material.
+
+Do not give credit for requirements stated in a skill file unless the producer output actually satisfies them.
+
+Be specific in rationales. Penalize omissions, invented facts, regressions, unsafe assumptions, and unsupported claims.

--- a/fixtures/projects/release-notes-alpha/roles/skill-builder.md
+++ b/fixtures/projects/release-notes-alpha/roles/skill-builder.md
@@ -1,0 +1,9 @@
+---
+name: skill-builder
+description: Improves skill instructions based on score feedback and previous outputs.
+model: anthropic/claude-sonnet-4-6
+---
+
+You improve skill instructions based on evaluation results.
+
+Make the smallest effective change that addresses the observed score gap. Preserve the skill's intended scope and avoid overfitting to a single fixture.

--- a/fixtures/projects/release-notes-alpha/roles/task-producer.md
+++ b/fixtures/projects/release-notes-alpha/roles/task-producer.md
@@ -1,0 +1,9 @@
+---
+name: task-producer
+description: Produces eval output files by following the mounted skill and eval task.
+model: anthropic/claude-haiku-4-5
+---
+
+You produce concrete output files for the current eval task.
+
+Follow the mounted skill instructions closely. Produce concrete output files only; do not score your own work.

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "compat:flue2": "pnpm --filter flue2-role-boundary-compatibility run check",
     "check": "pnpm run format:check && pnpm run lint && pnpm run knip && pnpm run typecheck && pnpm test && pnpm run compat:flue2 && pnpm run build && pnpm run alpha:smoke",
     "build": "pnpm --filter @schalkneethling/skills-autoresearch run build",
-    "autoresearch": "pnpm run build && node packages/skills-autoresearch/dist/flue-runner.js",
-    "flue:run": "pnpm run build && node packages/skills-autoresearch/dist/flue-runner.js",
+    "autoresearch": "pnpm run build && node packages/skills-autoresearch/dist/bin/skills-autoresearch-flue.js",
+    "flue:run": "pnpm run build && node packages/skills-autoresearch/dist/bin/skills-autoresearch-flue.js",
     "alpha:smoke": "pnpm run autoresearch -- smoke --project fixtures/projects/release-notes-alpha --session alpha-smoke",
-    "alpha:determinize": "pnpm run build && node packages/skills-autoresearch/dist/cli.js determinize report --project fixtures/projects/release-notes-alpha --response-file fixtures/expected/determinization/release-notes-alpha/analysis-response.json --catalog-root packages/skills-autoresearch/catalog/deterministic-assets",
-    "alpha:research": "pnpm run build && varlock run -- node packages/skills-autoresearch/dist/flue-runner.js research --project fixtures/projects/release-notes-alpha --session alpha-research",
+    "alpha:determinize": "pnpm run build && node packages/skills-autoresearch/dist/bin/skills-autoresearch.js determinize report --project fixtures/projects/release-notes-alpha --response-file fixtures/expected/determinization/release-notes-alpha/analysis-response.json",
+    "alpha:research": "pnpm run build && varlock run -- node packages/skills-autoresearch/dist/bin/skills-autoresearch-flue.js research --project fixtures/projects/release-notes-alpha --session alpha-research",
     "env:check": "varlock load"
   },
   "devDependencies": {

--- a/packages/skills-autoresearch/README.md
+++ b/packages/skills-autoresearch/README.md
@@ -9,4 +9,6 @@ The package provides two commands:
 
 Run either command with `--help` for its complete options. Skills Autoresearch requires Node.js 24 or newer. Model-backed commands use locally supplied model credentials; credential-free smoke and recorded-response workflows do not require them.
 
+Determinization uses the package's bundled deterministic-asset catalog by default. Use `--catalog-root` only to supply an explicit alternative.
+
 Repository development, fixture authoring, and contributor documentation remain in the [Skills Autoresearch repository](https://github.com/schalkneethling/skills-autoresearch-flue).

--- a/packages/skills-autoresearch/package.json
+++ b/packages/skills-autoresearch/package.json
@@ -23,8 +23,8 @@
   "type": "module",
   "exports": {},
   "bin": {
-    "skills-autoresearch": "./dist/cli.js",
-    "skills-autoresearch-flue": "./dist/flue-runner.js"
+    "skills-autoresearch": "./dist/bin/skills-autoresearch.js",
+    "skills-autoresearch-flue": "./dist/bin/skills-autoresearch-flue.js"
   },
   "files": [
     "dist",

--- a/packages/skills-autoresearch/src/bin/skills-autoresearch-flue.ts
+++ b/packages/skills-autoresearch/src/bin/skills-autoresearch-flue.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { runFlueCommand } from "../flue-runner.js";
+
+runFlueCommand()
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  })
+  .catch((error: unknown) => {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exitCode = 1;
+  });

--- a/packages/skills-autoresearch/src/bin/skills-autoresearch.ts
+++ b/packages/skills-autoresearch/src/bin/skills-autoresearch.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { main } from "../cli.js";
+import { createLogger } from "../logger.js";
+
+main().catch((error: unknown) => {
+  createLogger().write("error", (error as Error).message);
+  process.exitCode = 1;
+});

--- a/packages/skills-autoresearch/src/cli.ts
+++ b/packages/skills-autoresearch/src/cli.ts
@@ -8,6 +8,7 @@ import { orchestrateBaseline, OrchestrateOptions, RunEvent } from "./orchestrato
 import { createRunLog } from "./run-log.js";
 import { normalizeRunOptions, RunOptions } from "./run-options.js";
 import { determinizationUsage, runDeterminizationCli } from "./determinization/cli.js";
+import { readPackageVersion } from "./package-resources.js";
 
 export interface CliOptions extends RunOptions {
   scoreDir?: string;
@@ -38,6 +39,7 @@ function usage(): string {
     "  --verbose             Print debug-level run events.",
     "  --no-run-log          Do not write the complete local run log.",
     "  --json                Print the full orchestrator result as JSON.",
+    "  --version             Show the installed package version.",
     "  -h, --help            Show this help.",
     "",
     "Determinization:",
@@ -131,6 +133,10 @@ function parseModelClient(value: string | boolean | undefined): "anthropic" | un
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
+  if (argv.length === 1 && argv[0] === "--version") {
+    console.log(await readPackageVersion());
+    return;
+  }
   if (argv[0] === "determinize") {
     if (argv[1] === "--help" || argv[1] === "-h") {
       createLogger().write("log", determinizationUsage());
@@ -327,11 +333,4 @@ export function formatEvent(event: RunEvent): { level: LogLevel; message: string
         message: `Budget reached after ${event.completedIterations} iteration(s): $${event.actualCostUsd.toFixed(4)} >= $${event.budgetUsd.toFixed(4)}`
       };
   }
-}
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error: unknown) => {
-    createLogger().write("error", (error as Error).message);
-    process.exitCode = 1;
-  });
 }

--- a/packages/skills-autoresearch/src/determinization/cli.ts
+++ b/packages/skills-autoresearch/src/determinization/cli.ts
@@ -16,7 +16,7 @@ export function determinizationUsage(): string {
     "  --context-root <dir>   Optional external repository context (read-only allowlist).",
     "  --response-file <file> Use a recorded structured response without a model call.",
     "  --model-client <name>  Model client for analysis. Supported: anthropic.",
-    "  --catalog-root <dir>   Deterministic-asset catalog root. Defaults to ./catalog/deterministic-assets.",
+    "  --catalog-root <dir>   Override the bundled deterministic-asset catalog root.",
     "  --output <dir>         Artifact root. Defaults to workspace/determinization.",
     "  --resume               Re-render from validated immutable opportunities without a model call.",
     "  --json                 Print the structured result as JSON.",

--- a/packages/skills-autoresearch/src/determinization/run.ts
+++ b/packages/skills-autoresearch/src/determinization/run.ts
@@ -1,6 +1,7 @@
 import { lstat, readdir, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { estimateUsageCostUsd, type ModelUsage } from "../cost.js";
+import { resolveBundledCatalogRoot } from "../package-resources.js";
 import { GENERATED_SKILL_FILES, projectLayout } from "../project-layout.js";
 import { ProjectConfigSchema, parseWithSchema, type ModelConfig, type ProjectConfig } from "../schemas.js";
 import { buildDeterminizationAnalysisPrompt } from "./analysis-prompt.js";
@@ -267,7 +268,7 @@ export async function runDeterminizationReport(
   await assertRegularDirectory(projectRoot, "project");
   const config = await readConfig(projectRoot);
   const selected = await selectSkill(projectRoot, config, options.skillDir);
-  const catalogRoot = resolve(options.catalogRoot ?? join(process.cwd(), "catalog", "deterministic-assets"));
+  const catalogRoot = resolve(options.catalogRoot ?? resolveBundledCatalogRoot());
   const catalogIndexPath = join(catalogRoot, "catalog.json");
   await createSourceManifest([{ namespace: "catalog", root: catalogRoot, paths: [...CATALOG_FILES] }]);
   const catalog = await loadDeterministicAssetCatalog(catalogIndexPath);
@@ -315,7 +316,7 @@ export async function resumeDeterminizationReport(
   await assertRegularDirectory(projectRoot, "project");
   const config = await readConfig(projectRoot);
   const selected = await selectSkill(projectRoot, config, options.skillDir);
-  const catalogRoot = resolve(options.catalogRoot ?? join(process.cwd(), "catalog", "deterministic-assets"));
+  const catalogRoot = resolve(options.catalogRoot ?? resolveBundledCatalogRoot());
   const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot);
   const model = resolveDeterminizerModel(config);
   const catalog = await loadDeterministicAssetCatalog(join(catalogRoot, "catalog.json"));

--- a/packages/skills-autoresearch/src/flue-runner.ts
+++ b/packages/skills-autoresearch/src/flue-runner.ts
@@ -9,6 +9,7 @@ import { withFlueRoleRuntime } from "./flue-runtime.js";
 import { orchestrateBaseline, type OrchestratorResult, type RunEvent } from "./orchestrator.js";
 import { createRunLog } from "./run-log.js";
 import { normalizeRunOptions } from "./run-options.js";
+import { readPackageVersion } from "./package-resources.js";
 
 export type RunnerMode = "smoke" | "research" | "determinize";
 
@@ -18,6 +19,7 @@ export type RunnerOptions = {
   payload: Record<string, unknown>;
   workflow?: "autoresearch" | "determinize";
   help?: boolean;
+  version?: boolean;
 };
 
 export interface FlueRunnerDependencies {
@@ -38,7 +40,7 @@ function usage(): string {
     "  --guidance-skill <dir>  Override config.json guidance_skill for this run.",
     "  --skill <dir>           Explicit skill directory for determinize.",
     "  --context-root <dir>    Optional external read-only context for determinize.",
-    "  --catalog-root <dir>    Deterministic-asset catalog root.",
+    "  --catalog-root <dir>    Override the bundled deterministic-asset catalog root.",
     "  --output <dir>          Determinization artifact root.",
     "  --session <name>        Override the derived project-mode session name.",
     "  --resume                Resume validated artifacts from an interrupted run.",
@@ -50,6 +52,7 @@ function usage(): string {
     "  --payload <json>        Advanced: pass a complete Flue payload directly.",
     "  --verbose               Print debug events and the structured result.",
     "  --no-run-log            Do not write the local event and result log.",
+    "  --version               Show the installed package version.",
     "  -h, --help              Show this help."
   ].join("\n");
 }
@@ -59,6 +62,10 @@ export async function runFlueCommand(
   dependencies: FlueRunnerDependencies = {}
 ): Promise<number> {
   const options = parseRunnerArgs(argv);
+  if (options.version) {
+    process.stdout.write(`${await readPackageVersion()}\n`);
+    return 0;
+  }
   if (options.help) {
     process.stdout.write(`${usage()}\n`);
     return 0;
@@ -225,11 +232,24 @@ export function parseRunnerArgs(argv: string[]): RunnerOptions {
       "with-cleanup": { type: "boolean" },
       "force-research": { type: "boolean" },
       "budget-usd": { type: "string" },
+      version: { type: "boolean" },
       help: { type: "boolean", short: "h" }
     },
     strict: true,
     allowPositionals: true
   });
+
+  if (values.version) {
+    if (runnerArgv.length !== 1 || runnerArgv[0] !== "--version") {
+      throw new Error("--version must be used on its own.");
+    }
+    return {
+      verbose: values.verbose ?? false,
+      writeRunLog: !(values["no-run-log"] ?? false),
+      payload: {},
+      version: true
+    };
+  }
 
   if (values.help) {
     return {
@@ -405,15 +425,4 @@ export function formatQuietResult(output: string, truncated = false): string | u
       ? "Run completed, but its structured result exceeded the 1 MiB quiet-mode buffer; inspect the run log or rerun with --verbose."
       : undefined;
   }
-}
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  runFlueCommand()
-    .then((exitCode) => {
-      process.exitCode = exitCode;
-    })
-    .catch((error: unknown) => {
-      process.stderr.write(`${(error as Error).message}\n`);
-      process.exitCode = 1;
-    });
 }

--- a/packages/skills-autoresearch/src/orchestrator.ts
+++ b/packages/skills-autoresearch/src/orchestrator.ts
@@ -130,7 +130,7 @@ export async function orchestrateBaseline(options: OrchestrateOptions): Promise<
   const emit = createEventSink(events, options.onEvent);
   const project = await loadProject(runOptions.projectRoot);
   emit({ type: "project-loaded", root: project.root });
-  validateConfiguredFlueRoles(project.config, await loadAvailableFlueRoles());
+  validateConfiguredFlueRoles(project.config, await loadAvailableFlueRoles(project.root));
   const costTracker = new ModelRunCostTracker(
     createModelCallPreview(project, {
       withBaseline: runOptions.withBaseline,

--- a/packages/skills-autoresearch/src/package-resources.ts
+++ b/packages/skills-autoresearch/src/package-resources.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+
+export function resolvePackageResource(...segments: string[]): string {
+  return join(packageRoot, ...segments);
+}
+
+export function resolveBundledCatalogRoot(): string {
+  return resolvePackageResource("catalog", "deterministic-assets");
+}
+
+export async function readPackageVersion(): Promise<string> {
+  const manifest = JSON.parse(await readFile(resolvePackageResource("package.json"), "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof manifest.version !== "string" || manifest.version.length === 0) {
+    throw new Error("The installed Skills Autoresearch package has no valid version.");
+  }
+  return manifest.version;
+}

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -39,7 +39,7 @@ test("package scripts keep model-free smoke credential-free and remove the beta 
   };
 
   expect(packageJson.scripts.autoresearch).toBe(
-    "pnpm run build && node packages/skills-autoresearch/dist/flue-runner.js"
+    "pnpm run build && node packages/skills-autoresearch/dist/bin/skills-autoresearch-flue.js"
   );
   expect(packageJson.scripts["alpha:smoke"]).toContain("pnpm run autoresearch");
   expect(packageJson.scripts["alpha:research"]).toContain("varlock run --");
@@ -134,6 +134,7 @@ test("Flue runner rejects ambiguous modes and invalid concise overrides", () => 
   expect(() => parseRunnerArgs(["research", "--payload", "{}"])).toThrow(/either/u);
   expect(() => parseRunnerArgs(["research", "--budget-usd=-1"])).toThrow(/non-negative/u);
   expect(() => parseRunnerArgs(["research", "--budget-usd", ""])).toThrow(/non-negative/u);
+  expect(() => parseRunnerArgs(["research", "--version"])).toThrow(/must be used on its own/u);
   expect(() => parseRunnerArgs(["--payload", "[]"])).toThrow(/JSON object/u);
   expect(() => parseRunnerArgs(["determinize", "--resume"])).toThrow(/autoresearch-only/u);
   expect(() => parseRunnerArgs(["determinize", "--budget-usd", "1"])).toThrow(/autoresearch-only/u);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -12,10 +12,16 @@ export async function writeFixture(root: string, config: unknown, evals: unknown
   await mkdir(join(root, "evals"), { recursive: true });
   await mkdir(join(root, "reference"), { recursive: true });
   await mkdir(join(root, "input"), { recursive: true });
+  await mkdir(join(root, "roles"), { recursive: true });
   await writeFile(join(root, "config.json"), `${JSON.stringify(config, null, 2)}\n`);
   await writeFile(join(root, "evals", "eval-cases.json"), `${JSON.stringify(evals, null, 2)}\n`);
   await writeFile(join(root, "evals", "rubric.md"), "# Rubric\n\nScore the configured dimensions.\n");
   await writeFile(join(root, "reference", "context.md"), "Reference material\n");
+  await Promise.all(
+    ["eval-judge", "skill-builder", "task-producer"].map((role) =>
+      writeFile(join(root, "roles", `${role}.md`), `# ${role}\n`)
+    )
+  );
 }
 
 export const securityConfig = {

--- a/tests/package-runtime-contract.test.ts
+++ b/tests/package-runtime-contract.test.ts
@@ -80,7 +80,7 @@ test("role validation reads the selected project rather than the caller's workin
     },
     syntheticEvals
   );
-  await mkdir(join(projectRoot, "roles"));
+  await mkdir(join(projectRoot, "roles"), { recursive: true });
   await Promise.all(
     Object.values(roles).map((role) => writeFile(join(projectRoot, "roles", `${role}.md`), `# ${role}\n`))
   );

--- a/tests/package-runtime-contract.test.ts
+++ b/tests/package-runtime-contract.test.ts
@@ -1,0 +1,124 @@
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { vi } from "vitest";
+import { main } from "../packages/skills-autoresearch/src/cli.js";
+import { runDeterminizationReport } from "../packages/skills-autoresearch/src/determinization/run.js";
+import { StaticDeterminizationTransport } from "../packages/skills-autoresearch/src/determinization/transport.js";
+import { loadAvailableFlueRoles } from "../packages/skills-autoresearch/src/flue-roles.js";
+import { runFlueCommand } from "../packages/skills-autoresearch/src/flue-runner.js";
+import { orchestrateBaseline } from "../packages/skills-autoresearch/src/orchestrator.js";
+import type { EvalAgent } from "../packages/skills-autoresearch/src/runner.js";
+import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } from "./helpers.js";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const packageRoot = join(repositoryRoot, "packages", "skills-autoresearch");
+const catalogRoot = join(packageRoot, "catalog", "deterministic-assets");
+const fixtureProject = join(repositoryRoot, "fixtures", "projects", "release-notes-alpha");
+const fixtureResponse = join(
+  repositoryRoot,
+  "fixtures",
+  "expected",
+  "determinization",
+  "release-notes-alpha",
+  "analysis-response.json"
+);
+
+type PackageManifest = {
+  version: string;
+  bin: Record<"skills-autoresearch" | "skills-autoresearch-flue", string>;
+};
+
+async function recordedResponse(): Promise<unknown> {
+  return JSON.parse(await readFile(fixtureResponse, "utf8")) as unknown;
+}
+
+async function fromUnrelatedDirectory<T>(run: () => Promise<T>): Promise<T> {
+  const original = process.cwd();
+  const unrelated = await tempProject("skills autoresearch unrelated cwd-");
+  try {
+    process.chdir(unrelated);
+    return await run();
+  } finally {
+    process.chdir(original);
+  }
+}
+
+test("the bundled catalog is used outside the checkout and an explicit override remains supported", async () => {
+  const outputRoot = await tempProject("skills autoresearch default catalog output-");
+  const defaultResult = await fromUnrelatedDirectory(async () =>
+    runDeterminizationReport({
+      projectRoot: fixtureProject,
+      outputRoot,
+      transport: new StaticDeterminizationTransport(await recordedResponse())
+    })
+  );
+  expect(defaultResult).toMatchObject({ opportunityCount: 1, recommendationCount: 3, cost: { actualCalls: 0 } });
+
+  const overrideRoot = join(await tempProject("skills autoresearch catalog override-"), "catalog with spaces");
+  await cp(catalogRoot, overrideRoot, { recursive: true });
+  const overrideResult = await fromUnrelatedDirectory(async () =>
+    runDeterminizationReport({
+      projectRoot: fixtureProject,
+      outputRoot: await tempProject("skills autoresearch override output-"),
+      catalogRoot: overrideRoot,
+      transport: new StaticDeterminizationTransport(await recordedResponse())
+    })
+  );
+  expect(overrideResult).toMatchObject({ opportunityCount: 1, recommendationCount: 3, cost: { actualCalls: 0 } });
+});
+
+test("role validation reads the selected project rather than the caller's working directory", async () => {
+  const projectRoot = await tempProject("skills autoresearch project with spaces-");
+  const roles = { judge: "project-judge", skill_builder: "project-builder", producer: "project-producer" };
+  await writeFixture(
+    projectRoot,
+    {
+      ...syntheticConfig,
+      roles: { judge: roles.judge, skill_builder: roles.skill_builder },
+      tracks: [{ ...syntheticConfig.tracks[0], role: roles.producer }]
+    },
+    syntheticEvals
+  );
+  await mkdir(join(projectRoot, "roles"));
+  await Promise.all(
+    Object.values(roles).map((role) => writeFile(join(projectRoot, "roles", `${role}.md`), `# ${role}\n`))
+  );
+  const agent: EvalAgent = {
+    async run(request) {
+      return score(request.evalCase.id, request.evalCase.eval_type, request.track.id);
+    }
+  };
+
+  const result = await fromUnrelatedDirectory(() => orchestrateBaseline({ projectRoot, agent }));
+  expect(result.aggregate.overall.normalizedScore).toBe(1);
+});
+
+test("the release-notes fixture carries every Flue role named by its configuration", async () => {
+  const config = JSON.parse(await readFile(join(fixtureProject, "config.json"), "utf8")) as {
+    roles: { judge: string; skill_builder: string };
+    tracks: Array<{ role: string }>;
+  };
+
+  expect(await loadAvailableFlueRoles(fixtureProject)).toEqual(
+    [config.roles.judge, config.roles.skill_builder, ...config.tracks.map((track) => track.role)].sort()
+  );
+});
+
+test("both public CLI entrypoints report the package version from a directory with spaces", async () => {
+  const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as PackageManifest;
+  expect(Object.keys(manifest.bin).sort()).toEqual(["skills-autoresearch", "skills-autoresearch-flue"]);
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  try {
+    await fromUnrelatedDirectory(async () => {
+      await expect(main(["--version"])).resolves.toBeUndefined();
+      await expect(runFlueCommand(["--version"])).resolves.toBe(0);
+    });
+    expect(log.mock.calls.flat()).toEqual([manifest.version]);
+    expect(stdout.mock.calls.flat()).toEqual([`${manifest.version}\n`]);
+  } finally {
+    log.mockRestore();
+    stdout.mockRestore();
+  }
+});

--- a/tests/package-workspace-contract.test.ts
+++ b/tests/package-workspace-contract.test.ts
@@ -78,8 +78,8 @@ test("the package manifest defines the CLI-only publication contract", async () 
     bugs: { url: "https://github.com/schalkneethling/skills-autoresearch-flue/issues" },
     publishConfig: { access: "public", provenance: true },
     bin: {
-      "skills-autoresearch": "./dist/cli.js",
-      "skills-autoresearch-flue": "./dist/flue-runner.js"
+      "skills-autoresearch": "./dist/bin/skills-autoresearch.js",
+      "skills-autoresearch-flue": "./dist/bin/skills-autoresearch-flue.js"
     }
   });
   expect(manifest.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);


### PR DESCRIPTION
## Stack

- Stack position: 2/3
- Base: `codex/installable-package-workspace`
- Parent: #136
- Child: #142
- Merge order: #136, then #137, then #142

## Scope

- Resolve the bundled deterministic-asset catalog relative to the installed package while preserving `--catalog-root` overrides.
- Validate configured Flue roles from the selected project rather than the caller's working directory.
- Make `release-notes-alpha` self-contained with its configured role files.
- Add thin executable wrappers and consistent standalone `--version` behavior for both public binaries.
- Correct installed help, root scripts, and current user documentation for the portable runtime paths.

## Tests

- Red runtime contract preserved in commit `76dbde4`.
- `pnpm run check` (181 repository tests, Flue compatibility, build, and credential-free smoke)
- Focused runtime, CLI, Flue runner, orchestration, and determinization tests
- Recorded-response determinization from an unrelated working directory without `--catalog-root`
- Compiled wrapper shebang, version, help, fixture-role identity, and package dry-run inventory checks

## Root-review corrections

- Rejected mixed `--version` invocations instead of silently overriding a requested workflow.
- Replaced stale checkout-relative catalog help with the bundled-catalog contract on both CLI surfaces.
- Updated synthetic test fixtures to own the default roles they previously inherited from repository cwd.

## Phase-wide exclusions

- Authoritative tarball production, `publint`, offline clean-room installation, demo, and progress post are PR #142.
- Changesets, Fledgling, and OIDC publishing remain Phase 2.
- Template creation, public TypeScript APIs, CLI consolidation, AI-assisted eval bootstrap, and Agent Plugin delivery remain deferred.

Refs #135



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` support to both command-line interfaces.
  * Added bundled catalog support by default, with an option to use a custom catalog.
  * Added standard CLI entry points with improved error handling.
  * Added default evaluation roles for judging, skill building, and task production.

* **Documentation**
  * Updated usage examples and help text for the new CLI paths, version option, and catalog behavior.

* **Tests**
  * Expanded coverage for version reporting, catalog resolution, role validation, and CLI execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->