### PR TITLE
Test portable runtime review gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Generated research output lands under `workspace/iterations/<n>/`. Do not commit
 - Preserve auditability: output files, score JSON, summaries, and transcripts matter.
 - Keep fixtures small and deterministic.
 - Update docs and tests when config shape, artifact layout, commands, or model flow changes.
+- Treat CI constraints as part of test design, not a final check. Account for slower shared runners, parallel test files, clean builds, and default timeouts; keep expensive setup outside assertion timeouts with an explicit bounded setup timeout, and require comfortable timing headroom rather than accepting a local run that only narrowly passes.
 - Never commit `.env`, resolved API keys, provider secrets, or transcripts containing secrets.
 - Score and summary writes often use exclusive file creation; rerun failures may indicate existing artifacts rather than logic failure.
 - Enforce bounded reads before allocation: when a file has a size limit, use `lstat`/`stat` and reject an oversized file before `readFile`. Keep a post-read byte check for races and encoding differences; checking only after a full read does not protect memory.

--- a/fixtures/projects/release-notes-alpha/roles/eval-judge.md
+++ b/fixtures/projects/release-notes-alpha/roles/eval-judge.md
@@ -1,7 +1,7 @@
 ---
 name: eval-judge
 description: Scores eval outputs against the eval case, expectations, rubric, and reference material.
-model: anthropic/claude-sonnet-4-6
+model: anthropic/claude-sonnet-5
 ---
 
 You are an independent evaluator. Score only the producer output files against the eval case, expectations, and reference material.

--- a/fixtures/projects/release-notes-alpha/roles/skill-builder.md
+++ b/fixtures/projects/release-notes-alpha/roles/skill-builder.md
@@ -1,7 +1,7 @@
 ---
 name: skill-builder
 description: Improves skill instructions based on score feedback and previous outputs.
-model: anthropic/claude-sonnet-4-6
+model: anthropic/claude-sonnet-5
 ---
 
 You improve skill instructions based on evaluation results.

--- a/fixtures/projects/release-notes-alpha/roles/task-producer.md
+++ b/fixtures/projects/release-notes-alpha/roles/task-producer.md
@@ -1,7 +1,7 @@
 ---
 name: task-producer
 description: Produces eval output files by following the mounted skill and eval task.
-model: anthropic/claude-haiku-4-5
+model: anthropic/claude-sonnet-5
 ---
 
 You produce concrete output files for the current eval task.

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -17,11 +17,28 @@ export async function writeFixture(root: string, config: unknown, evals: unknown
   await writeFile(join(root, "evals", "eval-cases.json"), `${JSON.stringify(evals, null, 2)}\n`);
   await writeFile(join(root, "evals", "rubric.md"), "# Rubric\n\nScore the configured dimensions.\n");
   await writeFile(join(root, "reference", "context.md"), "Reference material\n");
-  await Promise.all(
-    ["eval-judge", "skill-builder", "task-producer"].map((role) =>
-      writeFile(join(root, "roles", `${role}.md`), `# ${role}\n`)
-    )
-  );
+  const configuredRoles = referencedRoles(config);
+  await Promise.all(configuredRoles.map((role) => writeFile(join(root, "roles", `${role}.md`), `# ${role}\n`)));
+}
+
+function referencedRoles(config: unknown): string[] {
+  if (config === null || typeof config !== "object" || Array.isArray(config)) return [];
+  const value = config as Record<string, unknown>;
+  const roles = value.roles;
+  const tracks = value.tracks;
+  const names = [
+    ...(roles !== null && typeof roles === "object" && !Array.isArray(roles)
+      ? Object.values(roles).filter((role): role is string => typeof role === "string")
+      : []),
+    ...(Array.isArray(tracks)
+      ? tracks.flatMap((track) =>
+          track !== null && typeof track === "object" && !Array.isArray(track) && typeof track.role === "string"
+            ? [track.role]
+            : []
+        )
+      : [])
+  ];
+  return [...new Set(names)].sort();
 }
 
 export const securityConfig = {

--- a/tests/package-runtime-contract.test.ts
+++ b/tests/package-runtime-contract.test.ts
@@ -1,12 +1,11 @@
+import { execFile } from "node:child_process";
 import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { vi } from "vitest";
-import { main } from "../packages/skills-autoresearch/src/cli.js";
+import { promisify } from "node:util";
 import { runDeterminizationReport } from "../packages/skills-autoresearch/src/determinization/run.js";
 import { StaticDeterminizationTransport } from "../packages/skills-autoresearch/src/determinization/transport.js";
 import { loadAvailableFlueRoles } from "../packages/skills-autoresearch/src/flue-roles.js";
-import { runFlueCommand } from "../packages/skills-autoresearch/src/flue-runner.js";
 import { orchestrateBaseline } from "../packages/skills-autoresearch/src/orchestrator.js";
 import type { EvalAgent } from "../packages/skills-autoresearch/src/runner.js";
 import { score, syntheticConfig, syntheticEvals, tempProject, writeFixture } from "./helpers.js";
@@ -23,6 +22,7 @@ const fixtureResponse = join(
   "release-notes-alpha",
   "analysis-response.json"
 );
+const execFileAsync = promisify(execFile);
 
 type PackageManifest = {
   version: string;
@@ -57,15 +57,32 @@ test("the bundled catalog is used outside the checkout and an explicit override 
 
   const overrideRoot = join(await tempProject("skills autoresearch catalog override-"), "catalog with spaces");
   await cp(catalogRoot, overrideRoot, { recursive: true });
+  const overrideCatalogPath = join(overrideRoot, "language.json");
+  const overrideCatalog = JSON.parse(await readFile(overrideCatalogPath, "utf8")) as {
+    assets: Array<{ contribution: string }>;
+  };
+  const overrideMarker = "override-catalog-marker";
+  overrideCatalog.assets[0].contribution = overrideMarker;
+  await writeFile(overrideCatalogPath, `${JSON.stringify(overrideCatalog, null, 2)}\n`, "utf8");
+  let observedPrompt = "";
+  const recordedTransport = new StaticDeterminizationTransport(await recordedResponse());
   const overrideResult = await fromUnrelatedDirectory(async () =>
     runDeterminizationReport({
       projectRoot: fixtureProject,
       outputRoot: await tempProject("skills autoresearch override output-"),
       catalogRoot: overrideRoot,
-      transport: new StaticDeterminizationTransport(await recordedResponse())
+      transport: {
+        name: recordedTransport.name,
+        makesModelCall: recordedTransport.makesModelCall,
+        analyze(request) {
+          observedPrompt = request.prompt;
+          return recordedTransport.analyze(request);
+        }
+      }
     })
   );
   expect(overrideResult).toMatchObject({ opportunityCount: 1, recommendationCount: 3, cost: { actualCalls: 0 } });
+  expect(observedPrompt).toContain(overrideMarker);
 });
 
 test("role validation reads the selected project rather than the caller's working directory", async () => {
@@ -108,17 +125,24 @@ test("the release-notes fixture carries every Flue role named by its configurati
 test("both public CLI entrypoints report the package version from a directory with spaces", async () => {
   const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as PackageManifest;
   expect(Object.keys(manifest.bin).sort()).toEqual(["skills-autoresearch", "skills-autoresearch-flue"]);
-  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-  const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-  try {
-    await fromUnrelatedDirectory(async () => {
-      await expect(main(["--version"])).resolves.toBeUndefined();
-      await expect(runFlueCommand(["--version"])).resolves.toBe(0);
+  await execFileAsync(process.execPath, [
+    join(repositoryRoot, "node_modules", "typescript", "bin", "tsc"),
+    "-p",
+    join(packageRoot, "tsconfig.json")
+  ]);
+
+  for (const [name, binary] of Object.entries(manifest.bin)) {
+    const binaryPath = join(packageRoot, binary);
+    const version = await fromUnrelatedDirectory(() => execFileAsync(process.execPath, [binaryPath, "--version"]));
+    expect(version).toMatchObject({ stdout: `${manifest.version}\n`, stderr: "" });
+
+    await expect(
+      fromUnrelatedDirectory(() => execFileAsync(process.execPath, [binaryPath, "--version", "smoke"]))
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining(
+        name === "skills-autoresearch" ? "Unknown option '--version'" : "--version must be used on its own."
+      )
     });
-    expect(log.mock.calls.flat()).toEqual([manifest.version]);
-    expect(stdout.mock.calls.flat()).toEqual([`${manifest.version}\n`]);
-  } finally {
-    log.mockRestore();
-    stdout.mockRestore();
   }
 });

--- a/tests/package-runtime-contract.test.ts
+++ b/tests/package-runtime-contract.test.ts
@@ -3,6 +3,7 @@ import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { beforeAll } from "vitest";
 import { runDeterminizationReport } from "../packages/skills-autoresearch/src/determinization/run.js";
 import { StaticDeterminizationTransport } from "../packages/skills-autoresearch/src/determinization/transport.js";
 import { loadAvailableFlueRoles } from "../packages/skills-autoresearch/src/flue-roles.js";
@@ -23,6 +24,14 @@ const fixtureResponse = join(
   "analysis-response.json"
 );
 const execFileAsync = promisify(execFile);
+
+beforeAll(async () => {
+  await execFileAsync(process.execPath, [
+    join(repositoryRoot, "node_modules", "typescript", "bin", "tsc"),
+    "-p",
+    join(packageRoot, "tsconfig.json")
+  ]);
+}, 15_000);
 
 type PackageManifest = {
   version: string;
@@ -125,11 +134,6 @@ test("the release-notes fixture carries every Flue role named by its configurati
 test("both public CLI entrypoints report the package version from a directory with spaces", async () => {
   const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as PackageManifest;
   expect(Object.keys(manifest.bin).sort()).toEqual(["skills-autoresearch", "skills-autoresearch-flue"]);
-  await execFileAsync(process.execPath, [
-    join(repositoryRoot, "node_modules", "typescript", "bin", "tsc"),
-    "-p",
-    join(packageRoot, "tsconfig.json")
-  ]);
 
   for (const [name, binary] of Object.entries(manifest.bin)) {
     const binaryPath = join(packageRoot, binary);

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createEvalSandbox } from "../packages/skills-autoresearch/src/sandbox.js";
 import { runEval, runWithConcurrency, EvalAgent } from "../packages/skills-autoresearch/src/runner.js";
@@ -147,13 +147,14 @@ test("orchestrator rejects missing configured judge role before baseline work", 
     },
     syntheticEvals
   );
+  await rm(join(root, "roles", "release-notes-judge.md"));
 
   await expect(orchestrateBaseline({ projectRoot: root, withBaseline: true })).rejects.toThrow(
     new RegExp(
       [
         "Configured Flue roles are not registered.",
         "release-notes-judge: roles.judge",
-        "Available roles: eval-judge, skill-builder, task-producer",
+        "Available roles: skill-builder, task-producer",
         "Define roles as markdown files in roles/ or .flue/roles/."
       ].join("(.|\n)*")
     )
@@ -178,6 +179,7 @@ test("orchestrator rejects missing producer track role before running evals", as
     },
     syntheticEvals
   );
+  await rm(join(root, "roles", "release-editor.md"));
   let agentRuns = 0;
   const agent: EvalAgent = {
     async run(request) {


### PR DESCRIPTION
## Summary

- generate fixture role files from every role referenced by each test configuration
- make the catalog override contract observable in the determinization prompt
- exercise both built CLI binaries for standalone and mixed `--version` behavior
- upgrade the release-notes fixture roles to the documented `anthropic/claude-sonnet-5` API model

## Why

These gaps were identified during review of #137. The previous tests could pass while ignoring a catalog override, bypassed the installed binary wrappers, and generated incomplete role fixtures for configurations with custom tracks.

## Validation

- Prettier
- ESLint
- Knip
- TypeScript typecheck
- Vitest: 27 files, 189 tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated evaluation, skill-building, and task-production roles to use newer Claude Sonnet models.

- **Tests**
  - Improved fixture generation to reflect configured roles and avoid duplicate files.
  - Expanded runtime checks for catalog overrides, command-line versions, and invalid arguments.
  - Improved missing-role orchestration coverage and validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->