### PR TITLE
Land remaining review fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,10 +230,11 @@ pnpm run format
 pnpm run format:check
 ```
 
-Linting is ESLint with TypeScript support.
+The standard lint command runs ESLint with TypeScript support and the ast-grep scan and rule tests through `lint:ast`.
 
 ```bash
 pnpm run lint
+pnpm run lint:ast # run ast-grep scan and rule tests directly
 ```
 
 Run these before pushing.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "lint": "eslint .",
+    "lint": "eslint . && pnpm run lint:ast",
+    "lint:ast": "ast-grep scan && ast-grep test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "knip": "knip",
@@ -26,6 +27,7 @@
     "env:check": "varlock load"
   },
   "devDependencies": {
+    "@ast-grep/cli": "0.45.1",
     "@earendil-works/pi-ai": "0.83.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.2",

--- a/packages/skills-autoresearch/src/aggregate.ts
+++ b/packages/skills-autoresearch/src/aggregate.ts
@@ -21,12 +21,14 @@ export interface AggregateReport {
 }
 
 export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): AggregateReport {
+  const matchedScores = new Set<EvalScore>();
   const tracks = config.tracks.map((track) => {
     const trackScores = scores.filter(
       (score) =>
         score.track_id === track.id ||
         ((score.track_id === null || score.track_id === undefined) && score.eval_type === track.eval_type)
     );
+    trackScores.forEach((item) => matchedScores.add(item));
     const score = trackScores.reduce((sum, item) => sum + item.total_score, 0);
     const maxScore = trackScores.reduce((sum, item) => sum + item.max_score, 0);
     return {
@@ -39,6 +41,15 @@ export function aggregateScores(config: ProjectConfig, scores: EvalScore[]): Agg
       evalCount: trackScores.length
     };
   });
+
+  const unmatchedScores = scores.filter((item) => !matchedScores.has(item));
+  if (unmatchedScores.length > 0) {
+    throw new Error(
+      `Cannot aggregate scores without a configured track: ${unmatchedScores
+        .map((item) => `${item.eval_id} (${item.track_id ?? item.eval_type})`)
+        .join(", ")}`
+    );
+  }
 
   const score = tracks.reduce((sum, track) => sum + track.score, 0);
   const maxScore = tracks.reduce((sum, track) => sum + track.maxScore, 0);

--- a/packages/skills-autoresearch/src/baseline.ts
+++ b/packages/skills-autoresearch/src/baseline.ts
@@ -57,8 +57,16 @@ function parseScoreFile(raw: unknown, filePath: string): EvalScore[] {
 function parseBaselineScore(raw: unknown, filePath: string): EvalScore {
   try {
     return parseWithSchema(EvalScoreSchema, raw, filePath);
-  } catch {
-    return normalizeLegacyBaselineScore(raw, filePath);
+  } catch (schemaError) {
+    try {
+      return normalizeLegacyBaselineScore(raw, filePath);
+    } catch (legacyError) {
+      throw new AggregateError(
+        [schemaError, legacyError],
+        `Invalid baseline score ${filePath}: neither current nor legacy validation succeeded`,
+        { cause: legacyError }
+      );
+    }
   }
 }
 
@@ -79,13 +87,15 @@ function normalizeLegacyBaselineScore(raw: unknown, filePath: string): EvalScore
     throw new Error(`Invalid baseline score ${filePath}: missing eval_type or scores`);
   }
 
+  const evaluationNumberOffset = 1;
+  const filenameMatch = filePath.match(/scores-(\d+)\.json$/);
   const evalId =
     typeof score.eval_id === "number"
       ? `eval-${score.eval_id}`
       : typeof score.eval_id === "string"
         ? score.eval_id
-        : filePath.match(/scores-(\d+)\.json$/)
-          ? `eval-${Number(filePath.match(/scores-(\d+)\.json$/)?.[1]) + 1}`
+        : filenameMatch
+          ? `eval-${Number(filenameMatch[1]) + evaluationNumberOffset}`
           : "";
 
   if (!evalId) {

--- a/packages/skills-autoresearch/src/bounded-file.ts
+++ b/packages/skills-autoresearch/src/bounded-file.ts
@@ -1,0 +1,30 @@
+import type { FileHandle } from "node:fs/promises";
+
+type FileMetadata = Awaited<ReturnType<FileHandle["stat"]>>;
+
+export async function readBoundedFileHandle(
+  handle: Pick<FileHandle, "read" | "stat">,
+  openedMetadata: FileMetadata,
+  limit: number,
+  errors: { changed: () => Error; oversized: () => Error }
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(limit + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  if (offset > limit) throw errors.oversized();
+  const finalMetadata = await handle.stat();
+  if (
+    !finalMetadata.isFile() ||
+    finalMetadata.dev !== openedMetadata.dev ||
+    finalMetadata.ino !== openedMetadata.ino ||
+    finalMetadata.size !== openedMetadata.size ||
+    finalMetadata.size > limit
+  ) {
+    throw errors.changed();
+  }
+  return buffer.subarray(0, offset);
+}

--- a/packages/skills-autoresearch/src/cli.ts
+++ b/packages/skills-autoresearch/src/cli.ts
@@ -72,6 +72,16 @@ export function parseCliArgs(argv: string[]): CliOptions {
     allowPositionals: false
   });
 
+  if (parsed.values.help) {
+    return {
+      ...normalizeRunOptions({}),
+      json: false,
+      verbose: false,
+      writeRunLog: true,
+      help: true
+    };
+  }
+
   const options: CliOptions = {
     ...normalizeRunOptions({
       projectRoot: parsed.values.project,
@@ -91,8 +101,6 @@ export function parseCliArgs(argv: string[]): CliOptions {
     writeRunLog: !(parsed.values["no-run-log"] ?? false),
     help: parsed.values.help ?? false
   };
-
-  if (options.help) return options;
 
   if (options.scoreDir && options.modelClient) {
     throw new Error("Use either --score-dir or --model-client, not both.");

--- a/packages/skills-autoresearch/src/cli.ts
+++ b/packages/skills-autoresearch/src/cli.ts
@@ -6,7 +6,7 @@ import { createLogger, Logger, LogLevel } from "./logger.js";
 import { AnthropicMessagesClient, ModelEvalAgent, ModelSkillResearcher } from "./model-agent.js";
 import { orchestrateBaseline, OrchestrateOptions, RunEvent } from "./orchestrator.js";
 import { createRunLog } from "./run-log.js";
-import { normalizeRunOptions, RunOptions } from "./run-options.js";
+import { normalizeRunOptions, parseBudgetUsd, RunOptions } from "./run-options.js";
 import { determinizationUsage, runDeterminizationCli } from "./determinization/cli.js";
 import { readPackageVersion } from "./package-resources.js";
 
@@ -17,6 +17,7 @@ export interface CliOptions extends RunOptions {
   json: boolean;
   verbose: boolean;
   writeRunLog: boolean;
+  help: boolean;
 }
 
 function usage(): string {
@@ -71,11 +72,6 @@ export function parseCliArgs(argv: string[]): CliOptions {
     allowPositionals: false
   });
 
-  if (parsed.values.help) {
-    createLogger().write("log", usage());
-    process.exit(0);
-  }
-
   const options: CliOptions = {
     ...normalizeRunOptions({
       projectRoot: parsed.values.project,
@@ -92,8 +88,11 @@ export function parseCliArgs(argv: string[]): CliOptions {
     modelClient: parseModelClient(parsed.values["model-client"]),
     json: parsed.values.json ?? false,
     verbose: parsed.values.verbose ?? false,
-    writeRunLog: !(parsed.values["no-run-log"] ?? false)
+    writeRunLog: !(parsed.values["no-run-log"] ?? false),
+    help: parsed.values.help ?? false
   };
+
+  if (options.help) return options;
 
   if (options.scoreDir && options.modelClient) {
     throw new Error("Use either --score-dir or --model-client, not both.");
@@ -106,20 +105,6 @@ export function parseCliArgs(argv: string[]): CliOptions {
   }
 
   return options;
-}
-
-function parseBudgetUsd(value: string | boolean | undefined): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string") {
-    throw new Error("--budget-usd must be a non-negative number.");
-  }
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error("--budget-usd must be a non-negative number.");
-  }
-  return parsed;
 }
 
 function parseModelClient(value: string | boolean | undefined): "anthropic" | undefined {
@@ -146,6 +131,10 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
   const cli = parseCliArgs(argv);
+  if (cli.help) {
+    createLogger().write("log", usage());
+    return;
+  }
   const logger = createLogger(console, { verbose: cli.verbose });
   const runLog = cli.writeRunLog ? createRunLog(cli.projectRoot, "standalone-cli") : undefined;
   if (runLog) {

--- a/packages/skills-autoresearch/src/contained-path.ts
+++ b/packages/skills-autoresearch/src/contained-path.ts
@@ -1,0 +1,14 @@
+import { isAbsolute, relative, resolve } from "node:path";
+
+export function resolveContainedPath(
+  rootDir: string,
+  path: string,
+  messages: { absolute: (path: string) => string; outside: (path: string) => string }
+): string {
+  if (isAbsolute(path)) throw new Error(messages.absolute(path));
+  const root = resolve(rootDir);
+  const destination = resolve(root, path);
+  const rel = relative(root, destination);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) throw new Error(messages.outside(path));
+  return destination;
+}

--- a/packages/skills-autoresearch/src/contained-path.ts
+++ b/packages/skills-autoresearch/src/contained-path.ts
@@ -1,4 +1,25 @@
-import { isAbsolute, relative, resolve } from "node:path";
+import { lstatSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+export function assertNoSymlinkPathComponents(rootDir: string, destination: string): void {
+  const root = resolve(rootDir);
+  const rel = relative(root, resolve(destination));
+  const components = [
+    root,
+    ...rel
+      .split(sep)
+      .filter(Boolean)
+      .map((_, index, parts) => join(root, ...parts.slice(0, index + 1)))
+  ];
+  for (const component of components) {
+    try {
+      if (lstatSync(component).isSymbolicLink()) throw new Error(`Path component must not be a symlink: ${component}`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+  }
+}
 
 export function resolveContainedPath(
   rootDir: string,
@@ -9,6 +30,9 @@ export function resolveContainedPath(
   const root = resolve(rootDir);
   const destination = resolve(root, path);
   const rel = relative(root, destination);
-  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) throw new Error(messages.outside(path));
+  if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(messages.outside(path));
+  }
+  assertNoSymlinkPathComponents(root, destination);
   return destination;
 }

--- a/packages/skills-autoresearch/src/determinization/analyzer.ts
+++ b/packages/skills-autoresearch/src/determinization/analyzer.ts
@@ -72,7 +72,7 @@ function normalizeSourceReferences(value: unknown[], opportunityIndex: number) {
       }
       return {
         path: reference.path.normalize("NFC"),
-        ...(reference.locator !== undefined && { locator: reference.locator }),
+        ...(reference.locator !== undefined && { locator: reference.locator.normalize("NFC") }),
         evidence_kind: reference.evidence_kind
       };
     })
@@ -84,7 +84,7 @@ function normalizeSourceReferences(value: unknown[], opportunityIndex: number) {
     );
 }
 
-function assertOpportunityProvenance(document: AnalysisOpportunitiesDocument): void {
+export function assertOpportunityProvenance(document: AnalysisOpportunitiesDocument): void {
   for (const opportunity of document.opportunities) {
     for (const reference of opportunity.source_refs) {
       const namespace = reference.path.split("/", 1)[0];

--- a/packages/skills-autoresearch/src/determinization/artifacts.ts
+++ b/packages/skills-autoresearch/src/determinization/artifacts.ts
@@ -1,4 +1,5 @@
-import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import * as v from "valibot";
 import { normalizeAnalysisResponse } from "./analyzer.js";
@@ -225,11 +226,29 @@ async function readBoundedArtifactFile(path: string): Promise<string> {
   if (metadata.size > MAX_DETERMINIZATION_ARTIFACT_BYTES) {
     throw new Error(`Determinization artifact exceeds 4 MiB: ${path}`);
   }
-  const contents = await readFile(path, "utf8");
-  if (Buffer.byteLength(contents) > MAX_DETERMINIZATION_ARTIFACT_BYTES) {
-    throw new Error(`Determinization artifact exceeds 4 MiB: ${path}`);
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const openedMetadata = await handle.stat();
+    if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
+      throw new Error(`Determinization artifact changed while opening: ${path}`);
+    }
+    const buffer = Buffer.alloc(MAX_DETERMINIZATION_ARTIFACT_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > MAX_DETERMINIZATION_ARTIFACT_BYTES) {
+      throw new Error(`Determinization artifact exceeds 4 MiB: ${path}`);
+    }
+    const finalMetadata = await handle.stat();
+    if (
+      finalMetadata.dev !== openedMetadata.dev ||
+      finalMetadata.ino !== openedMetadata.ino ||
+      finalMetadata.size > MAX_DETERMINIZATION_ARTIFACT_BYTES
+    ) {
+      throw new Error(`Determinization artifact changed while reading or exceeds 4 MiB: ${path}`);
+    }
+    return buffer.toString("utf8", 0, bytesRead);
+  } finally {
+    await handle.close();
   }
-  return contents;
 }
 
 async function readResumeJson(path: string): Promise<{ bytes: string; value: unknown }> {

--- a/packages/skills-autoresearch/src/determinization/artifacts.ts
+++ b/packages/skills-autoresearch/src/determinization/artifacts.ts
@@ -34,6 +34,8 @@ export interface DeterminizationArtifactPaths {
   transcript: string;
 }
 
+const MAX_DETERMINIZATION_ARTIFACT_BYTES = 4 * 1024 * 1024;
+
 export interface WriteAnalysisArtifactsOptions {
   outputRoot: string;
   selections: SourceSelection[];
@@ -217,6 +219,28 @@ async function assertSafeArtifactFile(path: string): Promise<void> {
   }
 }
 
+async function readBoundedArtifactFile(path: string): Promise<string> {
+  await assertSafeArtifactFile(path);
+  const metadata = await lstat(path);
+  if (metadata.size > MAX_DETERMINIZATION_ARTIFACT_BYTES) {
+    throw new Error(`Determinization artifact exceeds 4 MiB: ${path}`);
+  }
+  const contents = await readFile(path, "utf8");
+  if (Buffer.byteLength(contents) > MAX_DETERMINIZATION_ARTIFACT_BYTES) {
+    throw new Error(`Determinization artifact exceeds 4 MiB: ${path}`);
+  }
+  return contents;
+}
+
+async function readResumeJson(path: string): Promise<{ bytes: string; value: unknown }> {
+  try {
+    const bytes = await readBoundedArtifactFile(path);
+    return { bytes, value: JSON.parse(bytes) as unknown };
+  } catch (error) {
+    throw new Error(`Cannot resume determinization: failed to read or parse ${path}`, { cause: error });
+  }
+}
+
 function assertKnownSourceReferences(
   document: ReturnType<typeof orderAnalysisOpportunities>,
   manifest: SourceManifest
@@ -242,7 +266,7 @@ async function ensureExactFile(outputRoot: string, path: string, contents: strin
     if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
     await assertSafeDirectoryChain(outputRoot, parent, true);
     await assertSafeArtifactFile(path);
-    const existing = await readFile(path, "utf8");
+    const existing = await readBoundedArtifactFile(path);
     if (existing !== contents) {
       throw new Error(`Existing determinization artifact does not match canonical bytes: ${path}`, { cause: error });
     }
@@ -413,8 +437,9 @@ export async function resumeAnalysisArtifacts(
   await assertOutputSeparate(options.outputRoot, options.selections);
   return withReadOnlyInputs(options.selections, async () => {
     const artifactPaths = paths(options.outputRoot);
-    const existingSource = await readFile(artifactPaths.source, "utf8");
-    const recordedSource = JSON.parse(existingSource) as { analysis?: AnalysisIdentity };
+    const sourceArtifact = await readResumeJson(artifactPaths.source);
+    const existingSource = sourceArtifact.bytes;
+    const recordedSource = sourceArtifact.value as { analysis?: AnalysisIdentity };
     if (
       options.expectedModel &&
       (recordedSource.analysis?.model?.provider !== options.expectedModel.provider ||
@@ -427,10 +452,9 @@ export async function resumeAnalysisArtifacts(
       throw new Error("Cannot resume determinization: source or catalog manifest is stale");
     }
     const catalog = await loadDeterministicAssetCatalog(options.catalogIndexPath);
-    const opportunitiesBytes = await readFile(artifactPaths.opportunities, "utf8");
-    const analysis = orderAnalysisOpportunities(
-      validateCanonicalAnalysis(JSON.parse(opportunitiesBytes) as unknown, catalog)
-    );
+    const opportunitiesArtifact = await readResumeJson(artifactPaths.opportunities);
+    const opportunitiesBytes = opportunitiesArtifact.bytes;
+    const analysis = orderAnalysisOpportunities(validateCanonicalAnalysis(opportunitiesArtifact.value, catalog));
     if (serializeAnalysisOpportunities(analysis) !== opportunitiesBytes) {
       throw new Error("Cannot resume determinization: opportunities.json is not canonical or was modified");
     }
@@ -441,8 +465,9 @@ export async function resumeAnalysisArtifacts(
       source_opportunities_sha256: opportunitiesHash,
       opportunity_ids: analysis.opportunities.map(({ id }) => id)
     };
-    const transcriptBytes = await readFile(artifactPaths.transcript, "utf8");
-    const transcript = parseAnalysisTranscript(JSON.parse(transcriptBytes) as unknown);
+    const transcriptArtifact = await readResumeJson(artifactPaths.transcript);
+    const transcriptBytes = transcriptArtifact.bytes;
+    const transcript = parseAnalysisTranscript(transcriptArtifact.value);
     const expectedRequest = JSON.parse(JSON.stringify(options.expectedAnalysisRequest)) as unknown;
     if (
       transcript.schema_version !== DETERMINIZATION_SCHEMA_VERSION ||

--- a/packages/skills-autoresearch/src/determinization/artifacts.ts
+++ b/packages/skills-autoresearch/src/determinization/artifacts.ts
@@ -2,6 +2,7 @@ import { constants } from "node:fs";
 import { lstat, mkdir, open, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import * as v from "valibot";
+import { readBoundedFileHandle } from "../bounded-file.js";
 import { normalizeAnalysisResponse } from "./analyzer.js";
 import { serializeCanonical, sha256 } from "./canonical.js";
 import { loadDeterministicAssetCatalog } from "./catalog.js";
@@ -232,20 +233,11 @@ async function readBoundedArtifactFile(path: string): Promise<string> {
     if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
       throw new Error(`Determinization artifact changed while opening: ${path}`);
     }
-    const buffer = Buffer.alloc(MAX_DETERMINIZATION_ARTIFACT_BYTES + 1);
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
-    if (bytesRead > MAX_DETERMINIZATION_ARTIFACT_BYTES) {
-      throw new Error(`Determinization artifact exceeds 4 MiB: ${path}`);
-    }
-    const finalMetadata = await handle.stat();
-    if (
-      finalMetadata.dev !== openedMetadata.dev ||
-      finalMetadata.ino !== openedMetadata.ino ||
-      finalMetadata.size > MAX_DETERMINIZATION_ARTIFACT_BYTES
-    ) {
-      throw new Error(`Determinization artifact changed while reading or exceeds 4 MiB: ${path}`);
-    }
-    return buffer.toString("utf8", 0, bytesRead);
+    const buffer = await readBoundedFileHandle(handle, openedMetadata, MAX_DETERMINIZATION_ARTIFACT_BYTES, {
+      changed: () => new Error(`Determinization artifact changed while reading or exceeds 4 MiB: ${path}`),
+      oversized: () => new Error(`Determinization artifact exceeds 4 MiB: ${path}`)
+    });
+    return buffer.toString("utf8");
   } finally {
     await handle.close();
   }

--- a/packages/skills-autoresearch/src/determinization/cli.ts
+++ b/packages/skills-autoresearch/src/determinization/cli.ts
@@ -58,10 +58,11 @@ export async function runDeterminizationCli(argv: string[]): Promise<void> {
   if (parsed.values.resume && (parsed.values["response-file"] || parsed.values["model-client"])) {
     throw new Error("--resume reuses canonical artifacts and cannot be combined with a model or response file.");
   }
+  if (!parsed.values.resume && !parsed.values["response-file"] && !parsed.values["model-client"]) {
+    throw new Error("Choose a determinization transport: --response-file, --resume, or --model-client anthropic.");
+  }
   const transport = parsed.values["response-file"]
-    ? new StaticDeterminizationTransport(
-        JSON.parse(await readFile(resolve(parsed.values["response-file"]), "utf8")) as unknown
-      )
+    ? new StaticDeterminizationTransport(await readRecordedResponse(parsed.values["response-file"]))
     : parsed.values.resume
       ? undefined
       : new DirectModelDeterminizationTransport(new AnthropicMessagesClient());
@@ -91,4 +92,13 @@ export async function runDeterminizationCli(argv: string[]): Promise<void> {
   );
   if (result.cost.costUsd !== undefined)
     logger.write("log", `Observed determinizer cost: $${result.cost.costUsd.toFixed(4)}`);
+}
+
+async function readRecordedResponse(path: string): Promise<unknown> {
+  const resolvedPath = resolve(path);
+  try {
+    return JSON.parse(await readFile(resolvedPath, "utf8")) as unknown;
+  } catch (error) {
+    throw new Error(`Cannot read --response-file JSON: ${resolvedPath}`, { cause: error });
+  }
 }

--- a/packages/skills-autoresearch/src/determinization/ids.ts
+++ b/packages/skills-autoresearch/src/determinization/ids.ts
@@ -17,14 +17,18 @@ function normalizeIdentityText(value: string): string {
   return value.replace(/\r\n?/g, "\n").normalize("NFC").trim().replace(/\s+/gu, " ");
 }
 
+export function isPortableSourcePath(path: string): boolean {
+  return !(
+    path.startsWith("/") ||
+    path.startsWith("\\") ||
+    /^[A-Za-z]:[\\/]/u.test(path) ||
+    path.includes("\\") ||
+    path.split("/").some((segment) => !segment || segment === "." || segment === "..")
+  );
+}
+
 function sourceIdentity(source: { path: string; locator?: string }): string {
-  if (
-    source.path.startsWith("/") ||
-    source.path.startsWith("\\") ||
-    /^[A-Za-z]:[\\/]/u.test(source.path) ||
-    source.path.includes("\\") ||
-    source.path.split("/").some((segment) => !segment || segment === "." || segment === "..")
-  ) {
+  if (!isPortableSourcePath(source.path)) {
     throw new Error(`Stable IDs require a normalized source-relative POSIX path: ${source.path}`);
   }
   return JSON.stringify([source.path.normalize("NFC"), normalizeIdentityText(source.locator ?? "")]);

--- a/packages/skills-autoresearch/src/determinization/research-request.ts
+++ b/packages/skills-autoresearch/src/determinization/research-request.ts
@@ -1,15 +1,19 @@
 import { serializeCanonical } from "./canonical.js";
-import type { AnalysisOpportunitiesDocument } from "./schemas.js";
+import {
+  DETERMINIZATION_SCHEMA_VERSION,
+  type AnalysisOpportunitiesDocument,
+  type AssetRelationship
+} from "./schemas.js";
 
 export interface DerivativeLineage {
-  schema_version: "1.0.0";
+  schema_version: typeof DETERMINIZATION_SCHEMA_VERSION;
   source_opportunities_sha256: string;
   opportunity_ids: string[];
 }
 
 export interface ResearchAssetRequest {
   asset_id: string;
-  relationship: string;
+  relationship: AssetRelationship;
   asset_kind: string;
   catalog_asset_id?: string;
   contribution: string;
@@ -32,7 +36,11 @@ export interface ResearchRequest extends DerivativeLineage {
   constraints: string[];
 }
 
-function evidenceQuestions(relationship: string, assetName: string, catalogAssetId: string | undefined): string[] {
+function evidenceQuestions(
+  relationship: AssetRelationship,
+  assetName: string,
+  catalogAssetId: string | undefined
+): string[] {
   const identity = catalogAssetId ? `${assetName} (${catalogAssetId})` : assetName;
   const questions = [
     `Which authoritative sources establish whether ${identity} can contribute to this requirement?`,

--- a/packages/skills-autoresearch/src/determinization/run.ts
+++ b/packages/skills-autoresearch/src/determinization/run.ts
@@ -17,7 +17,6 @@ import { createSourceManifest, MAX_DETERMINIZATION_SOURCE_FILE_BYTES, type Sourc
 import type { DeterminizationTransport } from "./transport.js";
 
 const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
-const CATALOG_FILES = ["catalog.json", "javascript-typescript.json", "language.json", "markdown.json"];
 const DETERMINIZER_SYSTEM_PROMPT = "You are the read-only determinizer for an agent-skill evaluation harness.";
 
 export interface RunDeterminizationReportOptions {
@@ -177,7 +176,8 @@ async function prepareInputs(
   projectRoot: string,
   skillDir: string,
   catalogRoot: string,
-  contextRoot?: string
+  contextRoot: string | undefined,
+  catalogFiles: string[]
 ): Promise<PreparedInputs> {
   const selections: SourceSelection[] = [];
   const skillPaths = (await listRegularFiles(skillDir)).filter(
@@ -232,7 +232,7 @@ async function prepareInputs(
       throw new Error("--context-root contains no allowlisted AGENTS.md, README.md, or package.json");
     selections.push({ namespace: "context", root: resolvedContext, paths: contextPaths });
   }
-  selections.push({ namespace: "catalog", root: catalogRoot, paths: [...CATALOG_FILES] });
+  selections.push({ namespace: "catalog", root: catalogRoot, paths: catalogFiles });
 
   // Validate roots, every path component, and current bytes before any selected
   // content is placed in a model prompt.
@@ -270,9 +270,10 @@ export async function runDeterminizationReport(
   const selected = await selectSkill(projectRoot, config, options.skillDir);
   const catalogRoot = resolve(options.catalogRoot ?? resolveBundledCatalogRoot());
   const catalogIndexPath = join(catalogRoot, "catalog.json");
-  await createSourceManifest([{ namespace: "catalog", root: catalogRoot, paths: [...CATALOG_FILES] }]);
   const catalog = await loadDeterministicAssetCatalog(catalogIndexPath);
-  const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot);
+  const catalogFiles = ["catalog.json", ...catalog.files];
+  await createSourceManifest([{ namespace: "catalog", root: catalogRoot, paths: catalogFiles }]);
+  const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot, catalogFiles);
   await assertAnalysisArtifactBoundary(
     options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
     prepared.selections
@@ -280,6 +281,7 @@ export async function runDeterminizationReport(
   const model = options.modelOverride ?? resolveDeterminizerModel(config);
   const request = buildAnalysisRequest(prepared, catalog, model);
   const completion = await options.transport.analyze(request);
+  const expectedAnalysisRequest = buildAnalysisRequest(prepared, catalog, model);
   const result = await writeAnalysisArtifacts({
     outputRoot: options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
     selections: prepared.selections,
@@ -290,7 +292,7 @@ export async function runDeterminizationReport(
       model: { provider: model.provider, name: model.name }
     },
     analysisResponse: completion.response,
-    expectedAnalysisRequest: request,
+    expectedAnalysisRequest,
     transcript: completion.transcript
   });
   const costUsd = completion.costUsd ?? estimateUsageCostUsd(model, completion.usage);
@@ -317,9 +319,10 @@ export async function resumeDeterminizationReport(
   const config = await readConfig(projectRoot);
   const selected = await selectSkill(projectRoot, config, options.skillDir);
   const catalogRoot = resolve(options.catalogRoot ?? resolveBundledCatalogRoot());
-  const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot);
   const model = resolveDeterminizerModel(config);
   const catalog = await loadDeterministicAssetCatalog(join(catalogRoot, "catalog.json"));
+  const catalogFiles = ["catalog.json", ...catalog.files];
+  const prepared = await prepareInputs(projectRoot, selected.dir, catalogRoot, options.contextRoot, catalogFiles);
   const result = await resumeAnalysisArtifacts({
     outputRoot: options.outputRoot ?? projectLayout(projectRoot).determinizationDir,
     selections: prepared.selections,

--- a/packages/skills-autoresearch/src/determinization/run.ts
+++ b/packages/skills-autoresearch/src/determinization/run.ts
@@ -13,7 +13,7 @@ import {
   type AnalysisArtifactResult
 } from "./artifacts.js";
 import { loadDeterministicAssetCatalog } from "./catalog.js";
-import { createSourceManifest, MAX_DETERMINIZATION_SOURCE_FILE_BYTES, type SourceSelection } from "./source.js";
+import { createSourceManifest, readBoundedDeterminizationFile, type SourceSelection } from "./source.js";
 import type { DeterminizationTransport } from "./transport.js";
 
 const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
@@ -243,15 +243,8 @@ async function prepareInputs(
   for (const selection of selections.filter(({ namespace }) => namespace !== "catalog")) {
     for (const path of selection.paths) {
       const absolute = join(selection.root, ...path.split("/"));
-      const metadata = await lstat(absolute);
-      if (metadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
-        throw new Error(`Determinization input exceeds 256 KiB: ${path}`);
-      }
-      const contents = await readFile(absolute, "utf8");
+      const contents = (await readBoundedDeterminizationFile(absolute, path)).toString("utf8");
       const bytes = Buffer.byteLength(contents);
-      if (bytes > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
-        throw new Error(`Determinization input exceeds 256 KiB: ${path}`);
-      }
       totalBytes += bytes;
       if (totalBytes > MAX_TOTAL_BYTES) throw new Error("Determinization inputs exceed the 2 MiB total limit");
       files.push({ path: `${selection.namespace}/${path}`, contents });

--- a/packages/skills-autoresearch/src/determinization/schemas.ts
+++ b/packages/skills-autoresearch/src/determinization/schemas.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 import { compareCanonicalIds, serializeCanonical, sha256 } from "./canonical.js";
-import { createOpportunityId, createRecommendationId } from "./ids.js";
+import { createOpportunityId, createRecommendationId, isPortableSourcePath } from "./ids.js";
 
 export const DETERMINIZATION_SCHEMA_VERSION = "1.0.0" as const;
 export const DeterminizationSchemaVersionSchema = v.literal(DETERMINIZATION_SCHEMA_VERSION);
@@ -25,12 +25,7 @@ export const LIFECYCLE_STATUS_BY_STAGE = {
 const PortablePathSchema = v.pipe(
   v.string(),
   v.minLength(1),
-  v.check((path) => {
-    if (path.startsWith("/") || path.startsWith("\\") || /^[A-Za-z]:[\\/]/u.test(path)) return false;
-    if (path.includes("\\")) return false;
-    const segments = path.split("/");
-    return segments.every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
-  }, "Expected a normalized, source-relative POSIX path")
+  v.check(isPortableSourcePath, "Expected a normalized, source-relative POSIX path")
 );
 
 export const NonEmptyTextSchema = v.pipe(
@@ -48,6 +43,7 @@ export const SourceReferenceSchema = v.strictObject({
 });
 
 export const AssetRelationshipSchema = v.picklist(["existing", "configurable", "extensible", "new"]);
+export type AssetRelationship = v.InferOutput<typeof AssetRelationshipSchema>;
 export const DeterministicAssetKindSchema = v.picklist([
   "languagetool",
   "vale",

--- a/packages/skills-autoresearch/src/determinization/source.ts
+++ b/packages/skills-autoresearch/src/determinization/source.ts
@@ -58,6 +58,14 @@ async function readBoundedHandle(handle: FileHandle, label: string): Promise<Buf
 
 export async function readBoundedDeterminizationFile(path: string, label: string): Promise<Buffer> {
   const metadata = await lstat(path);
+  return readBoundedRegularFile(path, label, metadata);
+}
+
+async function readBoundedRegularFile(
+  path: string,
+  label: string,
+  metadata: Awaited<ReturnType<typeof lstat>>
+): Promise<Buffer> {
   if (!metadata.isFile() || metadata.isSymbolicLink()) {
     throw new Error(`Only regular files are valid determinization inputs: ${label}`);
   }
@@ -172,23 +180,11 @@ export async function createSourceManifest(
           throw new Error(`Symbolic links are not valid determinization inputs: ${logicalPath}`);
         }
       }
-      if (!metadata.isFile()) throw new Error(`Only regular files are valid determinization inputs: ${logicalPath}`);
-      if (metadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
-        throw oversizedInputError(logicalPath);
-      }
-      const handle = await open(target, constants.O_RDONLY | constants.O_NOFOLLOW);
-      try {
-        const openedMetadata = await handle.stat();
-        if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
-          throw new Error(`Source input changed during determinization: ${logicalPath}`);
-        }
-        if (openedMetadata.size > MAX_DETERMINIZATION_SOURCE_FILE_BYTES) {
-          throw oversizedInputError(logicalPath);
-        }
-        entries.push({ path: logicalPath, sha256: sha256(await readBoundedHandle(handle, logicalPath)) });
-      } finally {
-        await handle.close();
-      }
+      // Directory components can be replaced between lstat and open; Node has no openat-style
+      // resolution to close that race. This is limited to local writes inside the project tree,
+      // and O_NOFOLLOW below protects only the final component.
+      const contents = await readBoundedRegularFile(target, logicalPath, metadata);
+      entries.push({ path: logicalPath, sha256: sha256(contents) });
     }
   }
   entries.sort((left, right) => compareCodePoints(left.path, right.path));

--- a/packages/skills-autoresearch/src/determinization/transport.ts
+++ b/packages/skills-autoresearch/src/determinization/transport.ts
@@ -38,17 +38,36 @@ export class DirectModelDeterminizationTransport implements DeterminizationTrans
   readonly name = "direct-model";
   readonly makesModelCall = true;
 
-  constructor(private readonly client: ModelClient) {}
+  constructor(
+    private readonly client: ModelClient,
+    private readonly timeoutMs = 60_000
+  ) {}
 
   async analyze(request: DeterminizationTransportRequest): Promise<DeterminizationTransportResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error("Determinization model request timed out")),
+      this.timeoutMs
+    );
     const modelRequest: ModelRequest = {
       system: request.system,
       prompt: request.prompt,
       model: request.model,
       phase: "determinization analysis",
-      ...(request.cwd && { workspaceDir: request.cwd })
+      ...(request.cwd && { workspaceDir: request.cwd }),
+      signal: controller.signal
     };
-    const completion = await this.client.complete(modelRequest);
+    let completion: ModelCompletion;
+    try {
+      completion = await Promise.race([
+        this.client.complete(modelRequest),
+        new Promise<never>((_, reject) =>
+          controller.signal.addEventListener("abort", () => reject(controller.signal.reason), { once: true })
+        )
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
     const response = parseJsonResponse(completion);
     return {
       response,

--- a/packages/skills-autoresearch/src/determinization/validation.ts
+++ b/packages/skills-autoresearch/src/determinization/validation.ts
@@ -1,6 +1,7 @@
 import type { DeterministicAssetCatalog } from "./catalog.js";
 import { validateCatalogReferences } from "./catalog.js";
 import { canonicalAnalysisSha256, parseAnalysisOpportunities, type AnalysisOpportunitiesDocument } from "./schemas.js";
+import { assertOpportunityProvenance } from "./analyzer.js";
 
 export function validateCanonicalAnalysis(
   value: unknown,
@@ -9,6 +10,7 @@ export function validateCanonicalAnalysis(
 ): AnalysisOpportunitiesDocument {
   const document = parseAnalysisOpportunities(value);
   validateCatalogReferences(document, catalog);
+  assertOpportunityProvenance(document);
   if (expectedSha256 !== undefined && canonicalAnalysisSha256(document) !== expectedSha256) {
     throw new Error("Canonical opportunities hash mismatch");
   }

--- a/packages/skills-autoresearch/src/flue-agents.ts
+++ b/packages/skills-autoresearch/src/flue-agents.ts
@@ -66,34 +66,7 @@ const RawAnalysisOpportunitySchema = v.strictObject({
   limitations: NonEmptyTextListSchema
 });
 
-type RawDeterministicAssetRecommendation = {
-  relationship: v.InferOutput<typeof AssetRelationshipSchema>;
-  asset_kind: v.InferOutput<typeof DeterministicAssetKindSchema>;
-  catalog_asset_id?: string;
-  proposed_name?: string;
-  contribution: string;
-  confidence: "low" | "medium" | "high";
-  expected_improvement: string;
-  supporting_evidence: string[];
-  limitations: string[];
-  alternative_assessments: v.InferOutput<typeof AlternativeAssessmentSchema>[];
-  insufficiency_justification?: string;
-};
-
-type RawAnalysisOpportunity = {
-  source_refs: v.InferOutput<typeof SourceReferenceSchema>[];
-  normalized_requirement: string;
-  origin: "skill_guidance" | "evaluation_evidence" | "both";
-  classification:
-    "fully_deterministic" | "partially_deterministic" | "human_judgment_required" | "missing_prerequisite";
-  current_automation_potential: "none" | "low" | "medium" | "high";
-  remaining_human_judgment: string;
-  recommendations: RawDeterministicAssetRecommendation[];
-  confidence: "low" | "medium" | "high";
-  expected_improvement: string;
-  supporting_evidence: string[];
-  limitations: string[];
-};
+type RawAnalysisOpportunity = v.InferOutput<typeof RawAnalysisOpportunitySchema>;
 
 export type RawDeterminizationAnalysis = {
   schema_version: typeof DETERMINIZATION_SCHEMA_VERSION;

--- a/packages/skills-autoresearch/src/flue-harness.ts
+++ b/packages/skills-autoresearch/src/flue-harness.ts
@@ -6,7 +6,7 @@ import {
   buildJudgeModelRequest,
   buildProduceModelRequest,
   buildResearchModelRequest,
-  parseModelJudgeResponse,
+  validateModelJudgeResponse,
   researchArtifactOperations
 } from "./model-agent.js";
 import { persistResearchArtifact, persistTranscript } from "./artifact-lifecycle.js";
@@ -68,7 +68,7 @@ export class FlueEvalAgent implements EvalAgent {
       judgeRequest,
       scoreResult
     );
-    const validated = parseModelJudgeResponse(JSON.stringify(score), request.evalCase, request.track);
+    const validated = validateModelJudgeResponse(score, request.evalCase, request.track);
     await persistTranscript(join(request.sandbox.outputDir, "judge-flue-transcript.json"), judgeRequest, validated);
     return validated;
   }

--- a/packages/skills-autoresearch/src/flue-runner.ts
+++ b/packages/skills-autoresearch/src/flue-runner.ts
@@ -8,7 +8,7 @@ import { runFlueAutoresearch, type FlueWorkflowResult } from "./flue-harness.js"
 import { withFlueRoleRuntime } from "./flue-runtime.js";
 import { orchestrateBaseline, type OrchestratorResult, type RunEvent } from "./orchestrator.js";
 import { createRunLog } from "./run-log.js";
-import { normalizeRunOptions } from "./run-options.js";
+import { normalizeRunOptions, parseBudgetUsd } from "./run-options.js";
 import { readPackageVersion } from "./package-resources.js";
 
 export type RunnerMode = "smoke" | "research" | "determinize";
@@ -287,7 +287,7 @@ export function parseRunnerArgs(argv: string[]): RunnerOptions {
   }
 
   if (positionals.length !== 1 || !isRunnerMode(positionals[0])) {
-    throw new Error("Choose a config-driven command: smoke or research, or determinize. Use --help for usage.");
+    throw new Error("Choose a config-driven command: smoke, research, or determinize. Use --help for usage.");
   }
 
   const mode = positionals[0];
@@ -374,39 +374,32 @@ function parsePayload(value: string): Record<string, unknown> {
   return payload as Record<string, unknown>;
 }
 
-function parseBudgetUsd(value: string | undefined): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (value.trim() === "") {
-    throw new Error("--budget-usd must be a non-negative number.");
-  }
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error("--budget-usd must be a non-negative number.");
-  }
-  return parsed;
-}
-
 export function formatFlueModelCallPreview(workflow: "autoresearch" | "determinize"): string | undefined {
   return workflow === "determinize" ? "Determinizer model call preview: 1 planned call(s)." : undefined;
 }
 
-export function formatQuietResult(output: string, truncated = false): string | undefined {
+type QuietDeterminizationResult = {
+  paths: { report: string };
+  opportunityCount?: number;
+  recommendationCount?: number;
+  cost?: { actualCalls?: number; costUsd?: number };
+};
+
+type QuietAutoresearchResult = Partial<FlueWorkflowResult>;
+
+function isQuietDeterminizationResult(
+  result: QuietAutoresearchResult | QuietDeterminizationResult
+): result is QuietDeterminizationResult {
+  return "paths" in result;
+}
+
+export function formatQuietResult(output: string): string | undefined {
   const jsonStart = output.indexOf("{");
-  if (jsonStart === -1) {
-    return truncated
-      ? "Run completed, but its structured result exceeded the 1 MiB quiet-mode buffer; inspect the run log or rerun with --verbose."
-      : undefined;
-  }
+  if (jsonStart === -1) return undefined;
   try {
-    const result = JSON.parse(output.slice(jsonStart)) as Partial<FlueWorkflowResult> & {
-      paths?: { report?: string };
-      opportunityCount?: number;
-      recommendationCount?: number;
-    };
-    if (result.paths?.report) {
-      const determinizationCost = (result as unknown as { cost?: { actualCalls?: number; costUsd?: number } }).cost;
+    const result = JSON.parse(output.slice(jsonStart)) as QuietAutoresearchResult | QuietDeterminizationResult;
+    if (isQuietDeterminizationResult(result)) {
+      const determinizationCost = result.cost;
       return (
         `Determinization report: ${result.paths.report}; opportunities ${result.opportunityCount ?? "unknown"}; ` +
         `deterministic assets ${result.recommendationCount ?? "unknown"}; model calls ${determinizationCost?.actualCalls ?? "unknown"}` +
@@ -421,8 +414,6 @@ export function formatQuietResult(output: string, truncated = false): string | u
       (result.bestSkillDir ? `; best skill ${result.bestSkillDir}` : "")
     );
   } catch {
-    return truncated
-      ? "Run completed, but its structured result exceeded the 1 MiB quiet-mode buffer; inspect the run log or rerun with --verbose."
-      : undefined;
+    return undefined;
   }
 }

--- a/packages/skills-autoresearch/src/model-agent.ts
+++ b/packages/skills-autoresearch/src/model-agent.ts
@@ -1,5 +1,6 @@
 import { execFile, type ExecFileException } from "node:child_process";
-import { cp, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { cp, lstat, mkdir, open, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, relative } from "node:path";
 import { ModelCallRole, ModelUsage } from "./cost.js";
 import { SkillResearcher, SkillResearchRequest } from "./orchestrator.js";
@@ -97,6 +98,7 @@ export class AnthropicMessagesClient implements ModelClient {
     let response: Response | undefined;
     let finalError: Error | undefined;
     for (let attempt = 0; attempt < this.#maxAttempts; attempt++) {
+      request.signal?.throwIfAborted();
       const controller = new AbortController();
       const onAbort = () => controller.abort(request.signal?.reason);
       request.signal?.addEventListener("abort", onAbort, { once: true });
@@ -133,7 +135,7 @@ export class AnthropicMessagesClient implements ModelClient {
       if (attempt + 1 < this.#maxAttempts) {
         const retryAfter = Number(response?.headers.get("retry-after"));
         const delayMs = Number.isFinite(retryAfter) && retryAfter >= 0 ? retryAfter * 1000 : 250 * 2 ** attempt;
-        await new Promise((resolveDelay) => setTimeout(resolveDelay, Math.min(delayMs, 5_000)));
+        await abortableDelay(Math.min(delayMs, 5_000), request.signal);
       }
     }
     if (!response?.ok) throw finalError ?? new Error("Anthropic request failed");
@@ -164,6 +166,21 @@ export class AnthropicMessagesClient implements ModelClient {
       }
     };
   }
+}
+
+function abortableDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolveDelay, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolveDelay();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export class ModelEvalAgent implements EvalAgent {
@@ -693,9 +710,28 @@ async function readFilesFromMount(root: string | undefined): Promise<Array<{ pat
       if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.size > 1024 * 1024) {
         throw new Error(`Mounted file exceeds the 1 MiB limit or is not a regular file: ${path}`);
       }
-      const contents = await readFile(path, "utf8");
-      if (Buffer.byteLength(contents) > 1024 * 1024) throw new Error(`Mounted file exceeds the 1 MiB limit: ${path}`);
-      return { path: relative(root, path), contents };
+      const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+      try {
+        const openedMetadata = await handle.stat();
+        if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
+          throw new Error(`Mounted file changed while opening or is not a regular file: ${path}`);
+        }
+        const buffer = Buffer.alloc(1024 * 1024 + 1);
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+        if (bytesRead > 1024 * 1024) throw new Error(`Mounted file exceeds the 1 MiB limit: ${path}`);
+        const finalMetadata = await handle.stat();
+        if (
+          !finalMetadata.isFile() ||
+          finalMetadata.dev !== openedMetadata.dev ||
+          finalMetadata.ino !== openedMetadata.ino ||
+          finalMetadata.size > 1024 * 1024
+        ) {
+          throw new Error(`Mounted file changed while reading or exceeds the 1 MiB limit: ${path}`);
+        }
+        return { path: relative(root, path), contents: buffer.toString("utf8", 0, bytesRead) };
+      } finally {
+        await handle.close();
+      }
     })
   );
 }

--- a/packages/skills-autoresearch/src/model-agent.ts
+++ b/packages/skills-autoresearch/src/model-agent.ts
@@ -13,6 +13,7 @@ import { EvalAgent, EvalAgentRequest } from "./runner.js";
 import { buildJudgePrompt } from "./prompts/judge-prompt.js";
 import { buildProducePrompt } from "./prompts/produce-prompt.js";
 import { buildResearchPrompt } from "./prompts/research-prompt.js";
+import { readBoundedFileHandle } from "./bounded-file.js";
 import {
   EvalCase,
   EvalScore,
@@ -716,19 +717,11 @@ async function readFilesFromMount(root: string | undefined): Promise<Array<{ pat
         if (!openedMetadata.isFile() || openedMetadata.dev !== metadata.dev || openedMetadata.ino !== metadata.ino) {
           throw new Error(`Mounted file changed while opening or is not a regular file: ${path}`);
         }
-        const buffer = Buffer.alloc(1024 * 1024 + 1);
-        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
-        if (bytesRead > 1024 * 1024) throw new Error(`Mounted file exceeds the 1 MiB limit: ${path}`);
-        const finalMetadata = await handle.stat();
-        if (
-          !finalMetadata.isFile() ||
-          finalMetadata.dev !== openedMetadata.dev ||
-          finalMetadata.ino !== openedMetadata.ino ||
-          finalMetadata.size > 1024 * 1024
-        ) {
-          throw new Error(`Mounted file changed while reading or exceeds the 1 MiB limit: ${path}`);
-        }
-        return { path: relative(root, path), contents: buffer.toString("utf8", 0, bytesRead) };
+        const buffer = await readBoundedFileHandle(handle, openedMetadata, 1024 * 1024, {
+          changed: () => new Error(`Mounted file changed while reading or exceeds the 1 MiB limit: ${path}`),
+          oversized: () => new Error(`Mounted file exceeds the 1 MiB limit: ${path}`)
+        });
+        return { path: relative(root, path), contents: buffer.toString("utf8") };
       } finally {
         await handle.close();
       }

--- a/packages/skills-autoresearch/src/model-agent.ts
+++ b/packages/skills-autoresearch/src/model-agent.ts
@@ -1,10 +1,13 @@
 import { execFile, type ExecFileException } from "node:child_process";
-import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { cp, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join, relative } from "node:path";
 import { ModelCallRole, ModelUsage } from "./cost.js";
 import { SkillResearcher, SkillResearchRequest } from "./orchestrator.js";
 import { persistResearchArtifact, persistTranscript, withArtifactStage } from "./artifact-lifecycle.js";
 import { projectLayout } from "./project-layout.js";
+import { DEFAULT_MODEL } from "./model.js";
+import { resolveContainedPath as resolveContained } from "./contained-path.js";
+import { extractScoreJson, validateEvalScore } from "./score.js";
 import { EvalAgent, EvalAgentRequest } from "./runner.js";
 import { buildJudgePrompt } from "./prompts/judge-prompt.js";
 import { buildProducePrompt } from "./prompts/produce-prompt.js";
@@ -42,6 +45,7 @@ export interface ModelRequest {
   model: ModelConfig;
   phase?: string;
   workspaceDir?: string;
+  signal?: AbortSignal;
 }
 
 export interface ModelCompletionResponse {
@@ -60,6 +64,8 @@ export interface AnthropicMessagesClientOptions {
   version?: string;
   maxTokens?: number;
   fetch?: typeof fetch;
+  timeoutMs?: number;
+  maxAttempts?: number;
 }
 
 export class AnthropicMessagesClient implements ModelClient {
@@ -67,6 +73,8 @@ export class AnthropicMessagesClient implements ModelClient {
   readonly #version: string;
   readonly #maxTokens: number;
   readonly #fetch: typeof fetch;
+  readonly #timeoutMs: number;
+  readonly #maxAttempts: number;
 
   constructor(options: AnthropicMessagesClientOptions = {}) {
     const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
@@ -77,6 +85,8 @@ export class AnthropicMessagesClient implements ModelClient {
     this.#version = options.version ?? "2023-06-01";
     this.#maxTokens = options.maxTokens ?? 4096;
     this.#fetch = options.fetch ?? fetch;
+    this.#timeoutMs = options.timeoutMs ?? 60_000;
+    this.#maxAttempts = options.maxAttempts ?? 3;
   }
 
   async complete(request: ModelRequest): Promise<ModelCompletion> {
@@ -84,24 +94,49 @@ export class AnthropicMessagesClient implements ModelClient {
       throw new Error(`AnthropicMessagesClient cannot run provider "${request.model.provider}"`);
     }
 
-    const response = await this.#fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": this.#apiKey,
-        "anthropic-version": this.#version
-      },
-      body: JSON.stringify({
-        model: request.model.name,
-        max_tokens: this.#maxTokens,
-        system: request.system,
-        messages: [{ role: "user", content: request.prompt }]
-      })
-    });
-
-    if (!response.ok) {
-      throw new Error(`Anthropic request failed with ${response.status}: ${await response.text()}`);
+    let response: Response | undefined;
+    let finalError: Error | undefined;
+    for (let attempt = 0; attempt < this.#maxAttempts; attempt++) {
+      const controller = new AbortController();
+      const onAbort = () => controller.abort(request.signal?.reason);
+      request.signal?.addEventListener("abort", onAbort, { once: true });
+      const timeout = setTimeout(() => controller.abort(new Error("Anthropic request timed out")), this.#timeoutMs);
+      try {
+        response = await this.#fetch("https://api.anthropic.com/v1/messages", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": this.#apiKey,
+            "anthropic-version": this.#version
+          },
+          signal: controller.signal,
+          body: JSON.stringify({
+            model: request.model.name,
+            max_tokens: this.#maxTokens,
+            system: request.system,
+            messages: [{ role: "user", content: request.prompt }]
+          })
+        });
+      } catch (error) {
+        finalError = error instanceof Error ? error : new Error(String(error));
+        if (attempt + 1 >= this.#maxAttempts || controller.signal.aborted) throw finalError;
+      } finally {
+        clearTimeout(timeout);
+        request.signal?.removeEventListener("abort", onAbort);
+      }
+      if (response?.ok) break;
+      if (response && response.status !== 429 && response.status !== 503) {
+        throw new Error(`Anthropic request failed with ${response.status}: ${await response.text()}`);
+      }
+      if (response)
+        finalError = new Error(`Anthropic request failed with ${response.status}: ${await response.text()}`);
+      if (attempt + 1 < this.#maxAttempts) {
+        const retryAfter = Number(response?.headers.get("retry-after"));
+        const delayMs = Number.isFinite(retryAfter) && retryAfter >= 0 ? retryAfter * 1000 : 250 * 2 ** attempt;
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, Math.min(delayMs, 5_000)));
+      }
     }
+    if (!response?.ok) throw finalError ?? new Error("Anthropic request failed");
 
     const body = (await response.json()) as {
       content?: Array<{ type?: string; text?: string }>;
@@ -305,13 +340,13 @@ export function parseModelProduceResponse(response: string): ModelProduceRespons
 }
 
 export function parseModelJudgeResponse(response: string, evalCase: EvalCase, track: Track): EvalScore {
-  const score = parseWithSchema(EvalScoreSchema, parseJson(response, "Model judge response"), "model judge response");
-  validateEvalScore(score, evalCase, track);
-  return score;
+  return validateModelJudgeResponse(extractScoreJson(response), evalCase, track);
 }
 
-export function validateModelProduceResponse(response: ModelProduceResponse): ModelProduceResponse {
-  return response;
+export function validateModelJudgeResponse(response: unknown, evalCase: EvalCase, track: Track): EvalScore {
+  const score = parseWithSchema(EvalScoreSchema, response, "model judge response");
+  validateEvalScore(score, evalCase, track);
+  return score;
 }
 
 export async function applyOutputFiles(outputDir: string, files: OutputFile[]): Promise<void> {
@@ -330,8 +365,7 @@ export async function buildResearchModelRequest(request: SkillResearchRequest): 
   const evalFiles = await readFilesFromMount(join(workspaceDir, "evals"));
   const guidanceLedger = await readGuidanceLedger(request.guidanceLedgerPath);
   return checkedModelRequest({
-    model: request.project.config.models?.researcher ??
-      request.project.config.model ?? { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: request.project.config.models?.researcher ?? request.project.config.model ?? DEFAULT_MODEL,
     system: request.project.config.roles.skill_builder,
     phase: `research iteration ${request.iteration}`,
     workspaceDir,
@@ -493,31 +527,10 @@ function resolveSkillPath(skillDir: string, path: string): string {
 }
 
 function resolveContainedPath(rootDir: string, path: string, label: string): string {
-  const root = resolve(rootDir);
-  const destination = resolve(root, path);
-  const rel = relative(root, destination);
-  if (rel === "" || rel.startsWith("..") || rel.startsWith("/")) {
-    throw new Error(`${label} escapes target directory: ${path}`);
-  }
-  return destination;
-}
-
-function validateEvalScore(score: EvalScore, evalCase: EvalCase, track: Track): void {
-  const knownDimensions = new Set(evalCase.scoring_dimensions.map((dimension) => dimension.id));
-  const unknown = score.dimensions.filter((dimension) => !knownDimensions.has(dimension.id));
-
-  if (score.eval_id !== evalCase.id) {
-    throw new Error(`Judge score eval_id "${score.eval_id}" does not match "${evalCase.id}"`);
-  }
-  if (score.eval_type !== evalCase.eval_type) {
-    throw new Error(`Judge score eval_type "${score.eval_type}" does not match "${evalCase.eval_type}"`);
-  }
-  if (score.track_id !== track.id) {
-    throw new Error(`Judge score track_id "${score.track_id}" does not match "${track.id}"`);
-  }
-  if (unknown.length > 0) {
-    throw new Error(`Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`);
-  }
+  return resolveContained(rootDir, path, {
+    absolute: (value) => `${label} escapes target directory: ${value}`,
+    outside: (value) => `${label} escapes target directory: ${value}`
+  });
 }
 
 export function formatResearchSummary(
@@ -571,7 +584,7 @@ export async function validateChangedScripts(
           return runScriptValidation(change.path, path, "javascript", "node --check");
         }
         if ([".ts", ".mts", ".cts"].includes(extension)) {
-          return runScriptValidation(change.path, path, "typescript", "node --experimental-strip-types --check");
+          return runScriptValidation(change.path, path, "typescript", "TypeScript parser");
         }
         if ([".sh", ".bash"].includes(extension)) {
           return runScriptValidation(change.path, path, "shell", "/bin/bash -n");
@@ -634,7 +647,17 @@ function executeScriptValidator(validator: ScriptValidator, absolutePath: string
         execFile("node", ["--check", absolutePath], options, complete);
         break;
       case "typescript":
-        execFile("node", ["--experimental-strip-types", "--check", absolutePath], options, complete);
+        execFile(
+          process.execPath,
+          [
+            "--input-type=module",
+            "--eval",
+            "import ts from 'typescript'; import fs from 'node:fs'; const p=process.argv[1]; const s=fs.readFileSync(p,'utf8'); const k=p.endsWith('.tsx')?ts.ScriptKind.TSX:ts.ScriptKind.TS; const d=ts.createSourceFile(p,s,ts.ScriptTarget.Latest,true,k).parseDiagnostics; if(d.length){console.error(d.map(x=>ts.flattenDiagnosticMessageText(x.messageText,'\\n')).join('\\n'));process.exitCode=1;}",
+            absolutePath
+          ],
+          options,
+          complete
+        );
         break;
       case "shell":
         execFile("/bin/bash", ["-n", absolutePath], options, complete);
@@ -665,10 +688,15 @@ async function readFilesFromMount(root: string | undefined): Promise<Array<{ pat
   }
   const files = await listTextFiles(root);
   return Promise.all(
-    files.map(async (path) => ({
-      path: relative(root, path),
-      contents: await readFile(path, "utf8")
-    }))
+    files.map(async (path) => {
+      const metadata = await lstat(path);
+      if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.size > 1024 * 1024) {
+        throw new Error(`Mounted file exceeds the 1 MiB limit or is not a regular file: ${path}`);
+      }
+      const contents = await readFile(path, "utf8");
+      if (Buffer.byteLength(contents) > 1024 * 1024) throw new Error(`Mounted file exceeds the 1 MiB limit: ${path}`);
+      return { path: relative(root, path), contents };
+    })
   );
 }
 

--- a/packages/skills-autoresearch/src/orchestrator.ts
+++ b/packages/skills-autoresearch/src/orchestrator.ts
@@ -435,8 +435,7 @@ async function runResearchIterations(
         if (iteration === 1) {
           previousSkillDir = await prepareInitialResearchSkillDir(project, seedSkillDir);
         }
-        await improveSkill(
-          options.researcher,
+        await improveSkill(options.researcher, {
           project,
           iteration,
           previousSkillDir,
@@ -447,7 +446,7 @@ async function runResearchIterations(
           previousScores,
           previousAggregate,
           costTracker
-        );
+        });
         emit({ type: "iteration-generated", iteration, candidateSkillDir });
       }
     } else {
@@ -457,8 +456,7 @@ async function runResearchIterations(
       if (iteration === 1) {
         previousSkillDir = await prepareInitialResearchSkillDir(project, seedSkillDir);
       }
-      await improveSkill(
-        options.researcher,
+      await improveSkill(options.researcher, {
         project,
         iteration,
         previousSkillDir,
@@ -469,7 +467,7 @@ async function runResearchIterations(
         previousScores,
         previousAggregate,
         costTracker
-      );
+      });
       emit({ type: "iteration-generated", iteration, candidateSkillDir });
     }
 
@@ -554,34 +552,11 @@ async function runResearchIterations(
   return { iterations, bestIteration };
 }
 
-async function improveSkill(
-  researcher: SkillResearcher,
-  project: ProjectInputs,
-  iteration: number,
-  previousSkillDir: string,
-  candidateSkillDir: string,
-  guidanceSkillDir: string | undefined,
-  guidanceLedgerPath: string | undefined,
-  baselineScores: EvalScore[],
-  previousScores: EvalScore[],
-  previousAggregate: AggregateReport,
-  costTracker: ModelRunCostTracker
-): Promise<void> {
-  await researcher.improve({
-    project,
-    iteration,
-    previousSkillDir,
-    candidateSkillDir,
-    guidanceSkillDir,
-    guidanceLedgerPath,
-    baselineScores,
-    previousScores,
-    previousAggregate,
-    costTracker
-  });
+async function improveSkill(researcher: SkillResearcher, request: SkillResearchRequest): Promise<void> {
+  await researcher.improve(request);
   await assertExists(
-    candidateSkillDir,
-    `Researcher did not create candidate skill directory for iteration ${iteration}`
+    request.candidateSkillDir,
+    `Researcher did not create candidate skill directory for iteration ${request.iteration}`
   );
 }
 
@@ -936,8 +911,8 @@ function resolveProjectConfigPath(project: ProjectInputs, path: string): string 
 async function assertExists(path: string, message: string): Promise<void> {
   try {
     await stat(path);
-  } catch {
-    throw new Error(message);
+  } catch (error) {
+    throw new Error(message, { cause: error });
   }
 }
 

--- a/packages/skills-autoresearch/src/prompts/research-prompt.ts
+++ b/packages/skills-autoresearch/src/prompts/research-prompt.ts
@@ -125,6 +125,7 @@ function formatRegressionContext(
 }
 
 function scoreRegressions(baselineScores: EvalScore[], previousScores: EvalScore[]) {
+  // Prompt context walks every baseline eval; a missing previous score is a 0/0 regression.
   const previousByEval = new Map(previousScores.map((score) => [score.eval_id, score]));
   return baselineScores
     .map((baseline) => {

--- a/packages/skills-autoresearch/src/prompts/shared.ts
+++ b/packages/skills-autoresearch/src/prompts/shared.ts
@@ -29,9 +29,13 @@ export function formatFileSet(files: MountedFile[], label: string): string {
   }
 
   if (omittedFiles > 0) {
-    formatted.push(
-      `[${omittedFiles} file(s) omitted from ${label}; ${MAX_FILE_SET_CHARS} char file-set budget exhausted.]`
-    );
+    let notice = `[${omittedFiles} file(s) omitted from ${label}; ${MAX_FILE_SET_CHARS} char file-set budget exhausted.]`;
+    while (formatted.length > 0 && [...formatted, notice].join("\n\n").length > MAX_FILE_SET_CHARS) {
+      formatted.pop();
+      omittedFiles++;
+      notice = `[${omittedFiles} file(s) omitted from ${label}; ${MAX_FILE_SET_CHARS} char file-set budget exhausted.]`;
+    }
+    formatted.push(notice);
   }
 
   return formatted.join("\n\n");

--- a/packages/skills-autoresearch/src/resume.ts
+++ b/packages/skills-autoresearch/src/resume.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import { readFile, readdir, stat } from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { join, relative } from "node:path";
+import { resolveContainedPath } from "./contained-path.js";
 import { AggregateReport } from "./aggregate.js";
 import { JUDGE_TRANSCRIPTS, PRODUCER_TRANSCRIPTS, RESEARCH_TRANSCRIPTS } from "./project-layout.js";
 import {
@@ -385,15 +386,10 @@ function parseSnapshotManifest(value: unknown, markerPath: string, candidateSkil
 }
 
 function resolveContainedCandidatePath(root: string, path: string, markerPath: string): string {
-  if (isAbsolute(path)) {
-    throw new Error(`${markerPath} declares an absolute candidate path: ${path}`);
-  }
-  const destination = resolve(root, path);
-  const rel = relative(resolve(root), destination);
-  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
-    throw new Error(`${markerPath} declares a candidate path outside its directory: ${path}`);
-  }
-  return destination;
+  return resolveContainedPath(root, path, {
+    absolute: (value) => `${markerPath} declares an absolute candidate path: ${value}`,
+    outside: (value) => `${markerPath} declares a candidate path outside its directory: ${value}`
+  });
 }
 
 function parseProducerTranscript(transcriptPath: string, contents: string, expectedEvalId: string): OutputFile[] {
@@ -410,15 +406,10 @@ async function validateOutputFiles(
 ): Promise<ArtifactInspection<never> | undefined> {
   const seen = new Set<string>();
   for (const outputFile of outputFiles) {
-    if (isAbsolute(outputFile.path)) {
-      throw new Error(`declares an absolute output path: ${outputFile.path}`);
-    }
-
-    const destination = resolve(outputDir, outputFile.path);
-    const rel = relative(resolve(outputDir), destination);
-    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
-      throw new Error(`declares an output path outside its eval directory: ${outputFile.path}`);
-    }
+    const destination = resolveContainedPath(outputDir, outputFile.path, {
+      absolute: (value) => `declares an absolute output path: ${value}`,
+      outside: (value) => `declares an output path outside its eval directory: ${value}`
+    });
     if (seen.has(destination)) {
       throw new Error(`declares the output path more than once: ${outputFile.path}`);
     }

--- a/packages/skills-autoresearch/src/run-log.ts
+++ b/packages/skills-autoresearch/src/run-log.ts
@@ -37,9 +37,10 @@ export function createRunLog(projectRoot: string, sessionId = "autoresearch"): R
   };
 }
 
-const SENSITIVE_KEY = /(?:api[-_]?key|authorization|cookie|password|secret|token|transcript|payload|response)/iu;
+const SENSITIVE_KEY =
+  /(?:api[-_]?key|authorization|cookie|password|private[-_]?key|secret|token|transcript|payload|response)/iu;
 const SECRET_VALUE =
-  /(?:sk-(?:ant-)?[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|xox[baprs]-[A-Za-z0-9-]+|AKIA[A-Z0-9]{16}|Bearer\s+\S+)/gu;
+  /(?:-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----|sk-(?:ant-)?[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|xox[baprs]-[A-Za-z0-9-]+|AKIA[A-Z0-9]{16}|Bearer\s+\S+)/gu;
 const RUN_START_KEYS = new Set(["command", "workflow", "projectRoot", "sessionId"]);
 const RUN_RESULT_KEYS = new Set([
   "completedIterations",

--- a/packages/skills-autoresearch/src/run-log.ts
+++ b/packages/skills-autoresearch/src/run-log.ts
@@ -12,7 +12,7 @@ export function createRunLog(projectRoot: string, sessionId = "autoresearch"): R
   const directory = join(resolve(projectRoot), "workspace", "run-logs");
   mkdirSync(directory, { recursive: true });
   const timestamp = new Date().toISOString().replaceAll(":", "-");
-  const safeSessionId = sessionId.replaceAll(/[^a-zA-Z0-9._-]/g, "-") || "autoresearch";
+  const safeSessionId = (sessionId.replaceAll(/[^a-zA-Z0-9._-]/g, "-") || "autoresearch").slice(0, 96);
   const path = join(directory, `${timestamp}-${safeSessionId}-${randomUUID()}.ndjson`);
   const descriptor = openSync(path, "wx");
   let closed = false;
@@ -23,7 +23,10 @@ export function createRunLog(projectRoot: string, sessionId = "autoresearch"): R
       if (closed) {
         return;
       }
-      writeSync(descriptor, `${JSON.stringify({ timestamp: new Date().toISOString(), type, data })}\n`);
+      writeSync(
+        descriptor,
+        `${JSON.stringify({ timestamp: new Date().toISOString(), type, data: sanitizeRecord(type, data) })}\n`
+      );
     },
     close() {
       if (!closed) {
@@ -32,4 +35,41 @@ export function createRunLog(projectRoot: string, sessionId = "autoresearch"): R
       }
     }
   };
+}
+
+const SENSITIVE_KEY = /(?:api[-_]?key|authorization|cookie|password|secret|token|transcript|payload|response)/iu;
+const SECRET_VALUE =
+  /(?:sk-(?:ant-)?[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+|xox[baprs]-[A-Za-z0-9-]+|AKIA[A-Z0-9]{16}|Bearer\s+\S+)/gu;
+const RUN_START_KEYS = new Set(["command", "workflow", "projectRoot", "sessionId"]);
+const RUN_RESULT_KEYS = new Set([
+  "completedIterations",
+  "normalizedScore",
+  "bestSkillDir",
+  "selectedSkillDir",
+  "selectedSkillSource",
+  "opportunityCount",
+  "recommendationCount",
+  "paths",
+  "cost"
+]);
+
+function sanitizeRecord(type: string, value: unknown): unknown {
+  const allowlist = type === "run-start" ? RUN_START_KEYS : type === "run-result" ? RUN_RESULT_KEYS : undefined;
+  if (!allowlist || value === null || typeof value !== "object" || Array.isArray(value)) return redact(value);
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => allowlist.has(key))
+      .map(([key, item]) => [key, redact(item)])
+  );
+}
+
+function redact(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === "string") return value.replaceAll(SECRET_VALUE, "[REDACTED]");
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((item) => redact(item, seen));
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, SENSITIVE_KEY.test(key) ? "[REDACTED]" : redact(item, seen)])
+  );
 }

--- a/packages/skills-autoresearch/src/run-options.ts
+++ b/packages/skills-autoresearch/src/run-options.ts
@@ -12,6 +12,16 @@ export interface RunOptions {
 
 export type RunOptionInput = Partial<RunOptions>;
 
+export function parseBudgetUsd(value: string | boolean | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error("--budget-usd must be a non-negative number.");
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) throw new Error("--budget-usd must be a non-negative number.");
+  return parsed;
+}
+
 export function normalizeRunOptions(input: RunOptionInput, defaultProjectRoot = process.cwd()): RunOptions {
   const options: RunOptions = {
     projectRoot: input.projectRoot ?? defaultProjectRoot,

--- a/packages/skills-autoresearch/src/sandbox.ts
+++ b/packages/skills-autoresearch/src/sandbox.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
+import { appendFile, chmod, cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 
 export interface SandboxMount {
   source: string;
@@ -31,7 +31,7 @@ export interface CreateEvalSandboxOptions {
 
 function isWithin(parent: string, child: string): boolean {
   const rel = relative(resolve(parent), resolve(child));
-  return rel === "" || (!!rel && !rel.startsWith("..") && !rel.startsWith("/"));
+  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
 }
 
 function erofs(path: string): NodeJS.ErrnoException {
@@ -76,7 +76,6 @@ export function createEvalSandbox(options: CreateEvalSandboxOptions): EvalSandbo
     },
     async appendFile(path, contents) {
       assertWritable(path);
-      const { appendFile } = await import("node:fs/promises");
       await mkdir(dirname(path), { recursive: true });
       await appendFile(path, contents, "utf8");
     },
@@ -86,18 +85,15 @@ export function createEvalSandbox(options: CreateEvalSandboxOptions): EvalSandbo
     },
     async rm(path) {
       assertWritable(path);
-      const { rm } = await import("node:fs/promises");
       await rm(path, { recursive: true, force: true });
     },
     async cp(from, to) {
       assertWritable(to);
-      const { cp } = await import("node:fs/promises");
       await mkdir(dirname(to), { recursive: true });
       await cp(from, to, { recursive: true });
     },
     async chmod(path, mode) {
       assertWritable(path);
-      const { chmod } = await import("node:fs/promises");
       await chmod(path, mode);
     }
   };

--- a/packages/skills-autoresearch/src/sandbox.ts
+++ b/packages/skills-autoresearch/src/sandbox.ts
@@ -1,5 +1,6 @@
 import { appendFile, chmod, cp, mkdir, rm, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { assertNoSymlinkPathComponents } from "./contained-path.js";
 
 export interface SandboxMount {
   source: string;
@@ -31,7 +32,7 @@ export interface CreateEvalSandboxOptions {
 
 function isWithin(parent: string, child: string): boolean {
   const rel = relative(resolve(parent), resolve(child));
-  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+  return rel === "" || (!!rel && rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
 }
 
 function erofs(path: string): NodeJS.ErrnoException {
@@ -60,6 +61,11 @@ export function createEvalSandbox(options: CreateEvalSandboxOptions): EvalSandbo
       throw erofs(path);
     }
     if (!isWithin(outputDir, absolute)) {
+      throw erofs(path);
+    }
+    try {
+      assertNoSymlinkPathComponents(outputDir, absolute);
+    } catch {
       throw erofs(path);
     }
   };

--- a/packages/skills-autoresearch/src/schemas.ts
+++ b/packages/skills-autoresearch/src/schemas.ts
@@ -33,7 +33,7 @@ export const ProjectConfigSchema = v.object({
   origin_skill: v.optional(v.pipe(v.string(), v.minLength(1))),
   research_start: v.optional(v.picklist(["seed", "empty"])),
   guidance_skill: v.optional(v.pipe(v.string(), v.minLength(1))),
-  target_score: v.pipe(v.number(), v.minValue(0)),
+  target_score: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
   max_iterations: v.pipe(v.number(), v.integer(), v.minValue(1)),
   max_concurrency: v.pipe(v.number(), v.integer(), v.minValue(1)),
   budget_usd: v.optional(v.pipe(v.number(), v.minValue(0))),

--- a/packages/skills-autoresearch/src/score.ts
+++ b/packages/skills-autoresearch/src/score.ts
@@ -12,6 +12,11 @@ export function extractScoreJson(response: string): unknown {
 
 export function parseEvalScore(response: string, evalCase: EvalCase, track: Track): EvalScore {
   const score = parseWithSchema(EvalScoreSchema, extractScoreJson(response), "judge score");
+  validateEvalScore(score, evalCase, track);
+  return score;
+}
+
+export function validateEvalScore(score: EvalScore, evalCase: EvalCase, track: Track): void {
   const knownDimensions = new Set(evalCase.scoring_dimensions.map((dimension) => dimension.id));
   const unknown = score.dimensions.filter((dimension) => !knownDimensions.has(dimension.id));
 
@@ -27,6 +32,4 @@ export function parseEvalScore(response: string, evalCase: EvalCase, track: Trac
   if (unknown.length > 0) {
     throw new Error(`Judge score included unknown dimensions: ${unknown.map((dimension) => dimension.id).join(", ")}`);
   }
-
-  return score;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@ast-grep/cli':
+        specifier: 0.45.1
+        version: 0.45.1
       '@earendil-works/pi-ai':
         specifier: 0.83.0
         version: 0.83.0(ws@8.21.1)(zod@4.4.3)
@@ -92,6 +95,55 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@ast-grep/cli-darwin-arm64@0.45.1':
+    resolution: {integrity: sha512-hN/TDTvfry106SWn0pxepxFpAOvibuZJ80J5xU80WmY97Vjdc0cSKd49GBz2F+V8bzqn0SXchnoPXKLSJHB9kA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.45.1':
+    resolution: {integrity: sha512-wyQ8hXqNwTC6+4KYf4LvmemNyq+iKXfimXVKS9ZDJ8mE7/3VOuynPVuCFB7h+C5rVErzDJ9tZWwLLpSLnpYuhQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.45.1':
+    resolution: {integrity: sha512-yhIGIXDcvI7v4hLicA1dtvkf+QJ8WA8f/b/066gVhqhimiBgbdONkavrE3P5iOjwMLhfyTF0cQV9rkiKg93fvQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-linux-x64-gnu@0.45.1':
+    resolution: {integrity: sha512-vL6zdHagU3znogJN5KuZWECdTw9dTUf6/e5G5k9bNpvI+0gcrfuJj8hH8o/Wqyb5Qd4tuNdgJMwbHDTFbhtYvg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.45.1':
+    resolution: {integrity: sha512-JzOFnMAk+Wd6ApnP96Fam7eJX5JiV5/V09akzc/p129Ko1tmym7w/1oALuyVMV+unRTepj9XRrtfrF3XZG64lQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.45.1':
+    resolution: {integrity: sha512-uwgCUOq6B8//u+LhicTjg3CfA9mcpCgajfv5AWNxHE1Qw8F2wLRszDXK03+l/l8biaE13uHE2857mr6x6m/F+A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.45.1':
+    resolution: {integrity: sha512-fDYXALDte7yt44Jmhu7kjPZFCmHOPN6SrtMAYqKlYgkxPtSC/UfTe2XpDNxyTgBV3rMLkw/61bj6KQkwXwuBNg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.45.1':
+    resolution: {integrity: sha512-Bt9Vuqd+gmtwERy1kzj5R9yq96Ws1d2ZukEXy0mzLcJ+S0pU9uaJhETUSTmaHro1LNu9G4GeJ3YOXL1gQRQySA==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2143,6 +2195,39 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@ast-grep/cli-darwin-arm64@0.45.1':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.45.1':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.45.1':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.45.1':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.45.1':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.45.1':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.45.1':
+    optional: true
+
+  '@ast-grep/cli@0.45.1':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.45.1
+      '@ast-grep/cli-darwin-x64': 0.45.1
+      '@ast-grep/cli-linux-arm64-gnu': 0.45.1
+      '@ast-grep/cli-linux-x64-gnu': 0.45.1
+      '@ast-grep/cli-win32-arm64-msvc': 0.45.1
+      '@ast-grep/cli-win32-ia32-msvc': 0.45.1
+      '@ast-grep/cli-win32-x64-msvc': 0.45.1
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "compat/flue2-role-boundary"
 
 allowBuilds:
+  "@ast-grep/cli": false
   "@google/genai": true
   "@mongodb-js/zstd": true
   esbuild: true

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - tooling/ast-grep/rules
+testConfigs:
+  - testDir: tooling/ast-grep/tests

--- a/tests/baseline-aggregate-score.test.ts
+++ b/tests/baseline-aggregate-score.test.ts
@@ -103,6 +103,17 @@ test("normalizes legacy baseline score totals and summaries", async () => {
   ]);
 });
 
+test("reports both current and legacy schema failures for malformed baseline scores", async () => {
+  const baseline = join(await tempProject(), "workspace", "baseline");
+  await mkdir(baseline, { recursive: true });
+  await writeFile(join(baseline, "scores-7.json"), JSON.stringify({ eval_id: false, scores: "invalid" }));
+
+  await expect(importBaselineArtefacts(baseline, [])).rejects.toMatchObject({
+    name: "AggregateError",
+    errors: expect.arrayContaining([expect.any(Error), expect.any(Error)])
+  });
+});
+
 test("aggregates arbitrary configured tracks", () => {
   const report = aggregateScores(securityConfig, [
     score("xss-001", "detect-and-fix", "audit", 2, 2),
@@ -114,11 +125,15 @@ test("aggregates arbitrary configured tracks", () => {
 });
 
 test("aggregates by track id before falling back to eval type", () => {
-  const report = aggregateScores(securityConfig, [
+  const scores = [
     score("audit-001", "detect-and-fix", "audit", 2, 2),
     score("legacy-001", "detect-and-fix", undefined as unknown as string, 1, 2),
     score("other-001", "detect-and-fix", "other", 2, 2)
-  ]);
+  ];
+  expect(() => aggregateScores(securityConfig, scores)).toThrow(
+    "Cannot aggregate scores without a configured track: other-001 (other)"
+  );
+  const report = aggregateScores(securityConfig, scores.slice(0, 2));
 
   expect(report.tracks.find((track) => track.trackId === "audit")).toMatchObject({
     score: 3,

--- a/tests/baseline-aggregate-score.test.ts
+++ b/tests/baseline-aggregate-score.test.ts
@@ -110,8 +110,14 @@ test("reports both current and legacy schema failures for malformed baseline sco
 
   await expect(importBaselineArtefacts(baseline, [])).rejects.toMatchObject({
     name: "AggregateError",
-    errors: expect.arrayContaining([expect.any(Error), expect.any(Error)])
+    errors: expect.any(Array)
   });
+  const error = (await importBaselineArtefacts(baseline, []).catch((cause: unknown) => cause)) as AggregateError;
+  expect(error.errors).toHaveLength(2);
+  expect(error.errors[0]).toBeInstanceOf(Error);
+  expect(String((error.errors[0] as Error).message)).toContain("scores-7.json");
+  expect(error.errors[1]).toBeInstanceOf(Error);
+  expect(String((error.errors[1] as Error).message)).toMatch(/eval_id|scores/u);
 });
 
 test("aggregates arbitrary configured tracks", () => {

--- a/tests/bounded-file.test.ts
+++ b/tests/bounded-file.test.ts
@@ -1,0 +1,52 @@
+import type { FileHandle } from "node:fs/promises";
+import { readBoundedFileHandle } from "../packages/skills-autoresearch/src/bounded-file.js";
+
+type FileMetadata = Awaited<ReturnType<FileHandle["stat"]>>;
+
+function metadata(size: number): FileMetadata {
+  return { dev: 1, ino: 2, size, isFile: () => true } as FileMetadata;
+}
+
+test("bounded descriptor reads accumulate short reads until EOF", async () => {
+  const source = Buffer.from("short reads");
+  const openedMetadata = metadata(source.length);
+  const handle = {
+    async read(buffer: Buffer, offset: number, length: number, position: number) {
+      const bytesRead = Math.min(2, length, source.length - position);
+      if (bytesRead > 0) source.copy(buffer, offset, position, position + bytesRead);
+      return { bytesRead, buffer };
+    },
+    async stat() {
+      return openedMetadata;
+    }
+  } as Pick<FileHandle, "read" | "stat">;
+
+  await expect(
+    readBoundedFileHandle(handle, openedMetadata, 32, {
+      changed: () => new Error("changed"),
+      oversized: () => new Error("oversized")
+    })
+  ).resolves.toEqual(source);
+});
+
+test("bounded descriptor reads reject same-inode growth during the read window", async () => {
+  const source = Buffer.from("safe");
+  const openedMetadata = metadata(source.length);
+  const handle = {
+    async read(buffer: Buffer, offset: number, length: number, position: number) {
+      const bytesRead = Math.min(length, source.length - position);
+      if (bytesRead > 0) source.copy(buffer, offset, position, position + bytesRead);
+      return { bytesRead, buffer };
+    },
+    async stat() {
+      return metadata(source.length + 1);
+    }
+  } as Pick<FileHandle, "read" | "stat">;
+
+  await expect(
+    readBoundedFileHandle(handle, openedMetadata, 32, {
+      changed: () => new Error("changed"),
+      oversized: () => new Error("oversized")
+    })
+  ).rejects.toThrow("changed");
+});

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -15,6 +15,9 @@ import {
 
 test("parseCliArgs validates currently required adapters", () => {
   expect(parseCliArgs(["--help"])).toMatchObject({ help: true });
+  expect(parseCliArgs(["--help", "--budget-usd", "invalid", "--model-client", "unknown"])).toMatchObject({
+    help: true
+  });
   expect(parseCliArgs(["--project", "/tmp/project", "--with-baseline"])).toMatchObject({
     projectRoot: "/tmp/project",
     withBaseline: true,

--- a/tests/cli-adapters.test.ts
+++ b/tests/cli-adapters.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./helpers.js";
 
 test("parseCliArgs validates currently required adapters", () => {
+  expect(parseCliArgs(["--help"])).toMatchObject({ help: true });
   expect(parseCliArgs(["--project", "/tmp/project", "--with-baseline"])).toMatchObject({
     projectRoot: "/tmp/project",
     withBaseline: true,
@@ -61,6 +62,16 @@ test("parseCliArgs validates currently required adapters", () => {
   expect(() => parseCliArgs(["--model-client", "anthropic", "--budget-usd=-1"])).toThrow(/non-negative/);
   expect(() => parseCliArgs(["--model-client", "anthropic", "--budget-usd", "nope"])).toThrow(/non-negative/);
   expect(() => parseCliArgs(["--project"])).toThrow(/argument missing/);
+});
+
+test("main prints help and returns without requiring an adapter", async () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  try {
+    await expect(main(["--help"])).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Usage: skills-autoresearch"));
+  } finally {
+    log.mockRestore();
+  }
 });
 
 test("JSON mode emits only JSON and includes the run-log path conditionally", async () => {

--- a/tests/determinization-analyzer.test.ts
+++ b/tests/determinization-analyzer.test.ts
@@ -143,17 +143,20 @@ test("sorts source references canonically and preserves the same bytes and hash"
   expect(canonicalAnalysisSha256(normalizedForward)).toBe(canonicalAnalysisSha256(normalizedReversed));
 });
 
-test("normalizes composed and decomposed source-reference paths to the same canonical identity", async () => {
+test("normalizes composed and decomposed source-reference paths and locators to the same canonical identity", async () => {
   const catalog = await loadDeterministicAssetCatalog(catalogPath);
   const composed = conciseResponse();
   composed.opportunities[0].source_refs[0].path = "skill/caf\u00e9.md";
+  composed.opportunities[0].source_refs[0].locator = "section:caf\u00e9";
   const decomposed = structuredClone(composed);
   decomposed.opportunities[0].source_refs[0].path = "skill/cafe\u0301.md";
+  decomposed.opportunities[0].source_refs[0].locator = "section:cafe\u0301";
 
   const normalizedComposed = normalizeAnalysisResponse(composed, catalog);
   const normalizedDecomposed = normalizeAnalysisResponse(decomposed, catalog);
 
   expect(normalizedDecomposed.opportunities[0].source_refs[0].path).toBe("skill/caf\u00e9.md");
+  expect(normalizedDecomposed.opportunities[0].source_refs[0].locator).toBe("section:caf\u00e9");
   expect(serializeAnalysisOpportunities(normalizedDecomposed)).toBe(serializeAnalysisOpportunities(normalizedComposed));
   expect(normalizedDecomposed.opportunities[0].id).toBe(normalizedComposed.opportunities[0].id);
 });

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -265,6 +265,19 @@ test("quiet result formatting preserves autoresearch and determinization summari
     "Determinization report: /tmp/project/workspace/determinization/report.md; opportunities 2; " +
       "deterministic assets 3; model calls 1; observed cost $0.0042"
   );
+  expect(
+    formatQuietResult(
+      JSON.stringify({
+        paths: { report: "/tmp/project/workspace/determinization/report.md" },
+        opportunityCount: 2,
+        recommendationCount: 3,
+        cost: { actualCalls: 1 }
+      })
+    )
+  ).toBe(
+    "Determinization report: /tmp/project/workspace/determinization/report.md; opportunities 2; " +
+      "deterministic assets 3; model calls 1"
+  );
 });
 
 function createRuntime(overrides: Partial<FlueRoleDispatcher>): FlueRoleRuntime {

--- a/tests/flue-runner.test.ts
+++ b/tests/flue-runner.test.ts
@@ -129,8 +129,8 @@ test("Flue runner builds config-driven smoke, research, and determinize payloads
 });
 
 test("Flue runner rejects ambiguous modes and invalid concise overrides", () => {
-  expect(() => parseRunnerArgs([])).toThrow(/smoke or research/u);
-  expect(() => parseRunnerArgs(["unknown"])).toThrow(/smoke or research/u);
+  expect(() => parseRunnerArgs([])).toThrow(/smoke, research, or determinize/u);
+  expect(() => parseRunnerArgs(["unknown"])).toThrow(/smoke, research, or determinize/u);
   expect(() => parseRunnerArgs(["research", "--payload", "{}"])).toThrow(/either/u);
   expect(() => parseRunnerArgs(["research", "--budget-usd=-1"])).toThrow(/non-negative/u);
   expect(() => parseRunnerArgs(["research", "--budget-usd", ""])).toThrow(/non-negative/u);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -45,7 +45,7 @@ export const securityConfig = {
   skill_name: "frontend-security",
   topic_group: "frontend-injection-and-defence",
   origin_skill: "~/dev/claude-toolkit/skills/frontend-security",
-  target_score: 2.7,
+  target_score: 0.9,
   max_iterations: 5,
   max_concurrency: 2,
   model: {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -101,7 +101,7 @@ test("formatEvent reports compact eval progress and artifact paths", () => {
 test("run logs append structured records without overwriting earlier entries", async () => {
   const root = await tempProject();
   const runLog = createRunLog(root, "test run");
-  runLog.append("run-start", { value: 1 });
+  runLog.append("run-start", { command: "smoke" });
   const firstRecord = await readFile(runLog.path, "utf8");
   runLog.append("run-event", { value: 2 });
   runLog.close();
@@ -112,9 +112,33 @@ test("run logs append structured records without overwriting earlier entries", a
   const records = completedLog
     .trim()
     .split("\n")
-    .map((line) => JSON.parse(line) as { type: string; data: { value: number } });
-  expect(records.map(({ type, data }) => [type, data.value])).toEqual([
-    ["run-start", 1],
+    .map((line) => JSON.parse(line) as { type: string; data: { command?: string; value?: number } });
+  expect(records.map(({ type, data }) => [type, data.command ?? data.value])).toEqual([
+    ["run-start", "smoke"],
     ["run-event", 2]
   ]);
+});
+
+test("run logs allowlist lifecycle metadata, redact secrets, and bound session filenames", async () => {
+  const root = await tempProject();
+  const runLog = createRunLog(root, `session-${"x".repeat(1_000_000)}`);
+  runLog.append("run-start", {
+    command: "research",
+    apiKey: "sk-ant-abcdefghijklmnop",
+    transcript: "private model transcript"
+  });
+  runLog.append("run-result", {
+    normalizedScore: 0.75,
+    response: "Bearer should-not-appear",
+    error: { stack: "github_pat_abcdefghijklmnop" }
+  });
+  runLog.append("run-event", { authorization: "Bearer also-secret", detail: "ghp_abcdefghijklmnop" });
+  runLog.close();
+
+  expect(runLog.path.split("/").at(-1)?.length).toBeLessThan(200);
+  const contents = await readFile(runLog.path, "utf8");
+  expect(contents).toContain('"command":"research"');
+  expect(contents).toContain('"normalizedScore":0.75');
+  expect(contents).toContain("[REDACTED]");
+  expect(contents).not.toMatch(/sk-ant-|transcript|should-not-appear|github_pat_|ghp_/);
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -132,7 +132,12 @@ test("run logs allowlist lifecycle metadata, redact secrets, and bound session f
     response: "Bearer should-not-appear",
     error: { stack: "github_pat_abcdefghijklmnop" }
   });
-  runLog.append("run-event", { authorization: "Bearer also-secret", detail: "ghp_abcdefghijklmnop" });
+  runLog.append("run-event", {
+    authorization: "Bearer also-secret",
+    detail: "ghp_abcdefghijklmnop",
+    privateKey: "must-not-appear",
+    pem: "-----BEGIN PRIVATE KEY-----\nprivate-material\n-----END PRIVATE KEY-----"
+  });
   runLog.close();
 
   expect(runLog.path.split("/").at(-1)?.length).toBeLessThan(200);
@@ -140,5 +145,7 @@ test("run logs allowlist lifecycle metadata, redact secrets, and bound session f
   expect(contents).toContain('"command":"research"');
   expect(contents).toContain('"normalizedScore":0.75');
   expect(contents).toContain("[REDACTED]");
-  expect(contents).not.toMatch(/sk-ant-|transcript|should-not-appear|github_pat_|ghp_/);
+  expect(contents).not.toMatch(
+    /sk-ant-|transcript|should-not-appear|github_pat_|ghp_|must-not-appear|private-material/
+  );
 });

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -540,6 +540,30 @@ test("validateChangedScripts records failed syntax checks without executing gene
   ]);
 });
 
+test.each(["ts", "mts", "cts"])("validateChangedScripts parses valid .%s TypeScript syntax", async (extension) => {
+  const root = await tempProject();
+  await mkdir(join(root, "scripts"));
+  const relativePath = `scripts/valid.${extension}`;
+  const contents = "interface Result { readonly value: number }\nconst result = { value: 1 } satisfies Result;\n";
+  await writeFile(join(root, relativePath), contents);
+  const patch = parseSkillResearchPatch(
+    JSON.stringify({
+      summary: "Add typed deterministic logic.",
+      resource_decisions: [{ path: relativePath, placement: "script", reason: "Reuse deterministic logic." }],
+      changes: [{ path: relativePath, contents }]
+    })
+  );
+
+  await expect(validateChangedScripts(root, patch)).resolves.toEqual([
+    {
+      path: relativePath,
+      status: "passed",
+      validator: "TypeScript parser",
+      note: "Focused syntax validation passed."
+    }
+  ]);
+});
+
 test("validateChangedScripts passes shell metacharacters as literal path arguments", async () => {
   const root = await tempProject();
   const scriptPath = "scripts/check; echo not-a-command.js";
@@ -595,4 +619,33 @@ test("AnthropicMessagesClient posts messages request and extracts text response"
     system: "system prompt",
     messages: [{ role: "user", content: "user prompt" }]
   });
+});
+
+test("AnthropicMessagesClient retries rate limits and aborts a timed-out attempt", async () => {
+  let attempts = 0;
+  const retryingFetch: typeof fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) return new Response("busy", { status: 429, headers: { "retry-after": "0" } });
+    return new Response(JSON.stringify({ content: [{ type: "text", text: "Recovered" }] }), { status: 200 });
+  };
+  const request = {
+    model: { provider: "anthropic" as const, name: "claude-sonnet-4-6" },
+    system: "system prompt",
+    prompt: "user prompt"
+  };
+
+  await expect(
+    new AnthropicMessagesClient({ apiKey: "test-key", fetch: retryingFetch, maxAttempts: 2 }).complete(request)
+  ).resolves.toMatchObject({ text: "Recovered" });
+  expect(attempts).toBe(2);
+
+  const hangingFetch: typeof fetch = async (_url, init) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    });
+  await expect(
+    new AnthropicMessagesClient({ apiKey: "test-key", fetch: hangingFetch, timeoutMs: 5, maxAttempts: 1 }).complete(
+      request
+    )
+  ).rejects.toThrow("Anthropic request timed out");
 });

--- a/tests/model-agent.test.ts
+++ b/tests/model-agent.test.ts
@@ -648,4 +648,19 @@ test("AnthropicMessagesClient retries rate limits and aborts a timed-out attempt
       request
     )
   ).rejects.toThrow("Anthropic request timed out");
+
+  let backoffAttempts = 0;
+  const backoffFetch: typeof fetch = async () => {
+    backoffAttempts += 1;
+    return new Response("busy", { status: 503, headers: { "retry-after": "5" } });
+  };
+  const controller = new AbortController();
+  const completion = new AnthropicMessagesClient({ apiKey: "test-key", fetch: backoffFetch }).complete({
+    ...request,
+    signal: controller.signal
+  });
+  await vi.waitFor(() => expect(backoffAttempts).toBe(1));
+  controller.abort(new Error("caller cancelled"));
+  await expect(completion).rejects.toThrow("caller cancelled");
+  expect(backoffAttempts).toBe(1);
 });

--- a/tests/sandbox-runner-orchestrator.test.ts
+++ b/tests/sandbox-runner-orchestrator.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createEvalSandbox } from "../packages/skills-autoresearch/src/sandbox.js";
+import { resolveContainedPath } from "../packages/skills-autoresearch/src/contained-path.js";
 import { runEval, runWithConcurrency, EvalAgent } from "../packages/skills-autoresearch/src/runner.js";
 import {
   copySkillSnapshot,
@@ -49,6 +50,20 @@ test("sandbox rejects mutations in read-only mounts with EROFS", async () => {
 
   await sandbox.writeFile(join(sandbox.outputDir, "result.txt"), "ok");
   await expect(readFile(join(sandbox.outputDir, "result.txt"), "utf8")).resolves.toBe("ok");
+
+  const outside = join(root, "outside");
+  await mkdir(outside);
+  await symlink(outside, join(sandbox.outputDir, "redirect"));
+  await expect(sandbox.writeFile(join(sandbox.outputDir, "redirect", "escaped.txt"), "escape")).rejects.toMatchObject({
+    code: "EROFS"
+  });
+});
+
+test("contained paths accept dot-dot-prefixed names but reject parent traversal", async () => {
+  const root = await tempProject();
+  const messages = { absolute: (path: string) => path, outside: (path: string) => path };
+  expect(resolveContainedPath(root, "..metadata/file.json", messages)).toBe(join(root, "..metadata", "file.json"));
+  expect(() => resolveContainedPath(root, "../file.json", messages)).toThrow("../file.json");
 });
 
 test("runEval maps eval type to role and target skill through config", async () => {

--- a/tooling/ast-grep/rules/no-path-reopen-after-lstat.yml
+++ b/tooling/ast-grep/rules/no-path-reopen-after-lstat.yml
@@ -6,9 +6,11 @@ files:
   - packages/skills-autoresearch/src/**/*.ts
 rule:
   all:
-    - pattern: await readFile($PATH, $$$ARGS)
-    - inside:
-        kind: function_declaration
+    - kind: lexical_declaration
+    - has:
+        pattern: await readFile($PATH, $$$ARGS)
+        stopBy: end
+    - follows:
         has:
           pattern: await lstat($PATH)
           stopBy: end

--- a/tooling/ast-grep/rules/no-path-reopen-after-lstat.yml
+++ b/tooling/ast-grep/rules/no-path-reopen-after-lstat.yml
@@ -1,0 +1,15 @@
+id: no-path-reopen-after-lstat
+message: Open and bound the validated file through one descriptor instead of reopening its path with readFile.
+severity: error
+language: TypeScript
+files:
+  - packages/skills-autoresearch/src/**/*.ts
+rule:
+  all:
+    - pattern: await readFile($PATH, $$$ARGS)
+    - inside:
+        kind: function_declaration
+        has:
+          pattern: await lstat($PATH)
+          stopBy: end
+        stopBy: end

--- a/tooling/ast-grep/rules/no-path-reopen-after-lstat.yml
+++ b/tooling/ast-grep/rules/no-path-reopen-after-lstat.yml
@@ -11,7 +11,9 @@ rule:
         pattern: await readFile($PATH, $$$ARGS)
         stopBy: end
     - follows:
-        has:
-          pattern: await lstat($PATH)
-          stopBy: end
+        all:
+          - kind: lexical_declaration
+          - has:
+              pattern: await lstat($PATH)
+              stopBy: end
         stopBy: end

--- a/tooling/ast-grep/rules/no-unabortable-delay-in-loop.yml
+++ b/tooling/ast-grep/rules/no-unabortable-delay-in-loop.yml
@@ -1,0 +1,16 @@
+id: no-unabortable-delay-in-loop
+message: Retry delays inside loops must observe the caller's AbortSignal.
+severity: error
+language: TypeScript
+files:
+  - packages/skills-autoresearch/src/**/*.ts
+rule:
+  all:
+    - pattern: await new Promise(($RESOLVE) => setTimeout($RESOLVE, $DELAY))
+    - inside:
+        any:
+          - kind: for_statement
+          - kind: for_in_statement
+          - kind: while_statement
+          - kind: do_statement
+        stopBy: end

--- a/tooling/ast-grep/tests/__snapshots__/no-path-reopen-after-lstat-snapshot.yml
+++ b/tooling/ast-grep/tests/__snapshots__/no-path-reopen-after-lstat-snapshot.yml
@@ -1,0 +1,28 @@
+id: no-path-reopen-after-lstat
+snapshots:
+  ? |
+    async function unsafe(path: string) {
+      const metadata = await lstat(path);
+      if (!metadata.isFile()) throw new Error("not a file");
+      const contents = await readFile(path, "utf8");
+      return contents;
+    }
+  : labels:
+      - source: await readFile(path, "utf8")
+        style: primary
+        start: 152
+        end: 180
+      - source: await lstat(path)
+        style: secondary
+        start: 57
+        end: 74
+      - source: |-
+          async function unsafe(path: string) {
+            const metadata = await lstat(path);
+            if (!metadata.isFile()) throw new Error("not a file");
+            const contents = await readFile(path, "utf8");
+            return contents;
+          }
+        style: secondary
+        start: 0
+        end: 202

--- a/tooling/ast-grep/tests/__snapshots__/no-path-reopen-after-lstat-snapshot.yml
+++ b/tooling/ast-grep/tests/__snapshots__/no-path-reopen-after-lstat-snapshot.yml
@@ -20,7 +20,7 @@ snapshots:
         style: secondary
         start: 57
         end: 74
-      - source: await lstat(path)
+      - source: const metadata = await lstat(path);
         style: secondary
-        start: 57
-        end: 74
+        start: 40
+        end: 75

--- a/tooling/ast-grep/tests/__snapshots__/no-path-reopen-after-lstat-snapshot.yml
+++ b/tooling/ast-grep/tests/__snapshots__/no-path-reopen-after-lstat-snapshot.yml
@@ -8,21 +8,19 @@ snapshots:
       return contents;
     }
   : labels:
-      - source: await readFile(path, "utf8")
+      - source: const contents = await readFile(path, "utf8");
         style: primary
+        start: 135
+        end: 181
+      - source: await readFile(path, "utf8")
+        style: secondary
         start: 152
         end: 180
       - source: await lstat(path)
         style: secondary
         start: 57
         end: 74
-      - source: |-
-          async function unsafe(path: string) {
-            const metadata = await lstat(path);
-            if (!metadata.isFile()) throw new Error("not a file");
-            const contents = await readFile(path, "utf8");
-            return contents;
-          }
+      - source: await lstat(path)
         style: secondary
-        start: 0
-        end: 202
+        start: 57
+        end: 74

--- a/tooling/ast-grep/tests/__snapshots__/no-unabortable-delay-in-loop-snapshot.yml
+++ b/tooling/ast-grep/tests/__snapshots__/no-unabortable-delay-in-loop-snapshot.yml
@@ -1,0 +1,20 @@
+id: no-unabortable-delay-in-loop
+snapshots:
+  ? |
+    async function retry() {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+    }
+  : labels:
+      - source: await new Promise((resolve) => setTimeout(resolve, 250))
+        style: primary
+        start: 79
+        end: 135
+      - source: |-
+          for (let attempt = 0; attempt < 3; attempt++) {
+              await new Promise((resolve) => setTimeout(resolve, 250));
+            }
+        style: secondary
+        start: 27
+        end: 140

--- a/tooling/ast-grep/tests/no-path-reopen-after-lstat-test.yml
+++ b/tooling/ast-grep/tests/no-path-reopen-after-lstat-test.yml
@@ -1,0 +1,21 @@
+id: no-path-reopen-after-lstat
+valid:
+  - |
+    async function safe(path: string) {
+      const metadata = await lstat(path);
+      const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+      return handle.readFile();
+    }
+  - |
+    async function unrelated(first: string, second: string) {
+      const metadata = await lstat(first);
+      return readFile(second, "utf8");
+    }
+invalid:
+  - |
+    async function unsafe(path: string) {
+      const metadata = await lstat(path);
+      if (!metadata.isFile()) throw new Error("not a file");
+      const contents = await readFile(path, "utf8");
+      return contents;
+    }

--- a/tooling/ast-grep/tests/no-path-reopen-after-lstat-test.yml
+++ b/tooling/ast-grep/tests/no-path-reopen-after-lstat-test.yml
@@ -11,6 +11,12 @@ valid:
       const metadata = await lstat(first);
       return readFile(second, "utf8");
     }
+  - |
+    async function readBeforeValidation(path: string) {
+      const contents = await readFile(path, "utf8");
+      const metadata = await lstat(path);
+      return { contents, metadata };
+    }
 invalid:
   - |
     async function unsafe(path: string) {

--- a/tooling/ast-grep/tests/no-path-reopen-after-lstat-test.yml
+++ b/tooling/ast-grep/tests/no-path-reopen-after-lstat-test.yml
@@ -17,6 +17,14 @@ valid:
       const metadata = await lstat(path);
       return { contents, metadata };
     }
+  - |
+    async function outerRead(path: string) {
+      async function nestedValidation() {
+        return await lstat(path);
+      }
+      const contents = await readFile(path, "utf8");
+      return { contents, nestedValidation };
+    }
 invalid:
   - |
     async function unsafe(path: string) {

--- a/tooling/ast-grep/tests/no-unabortable-delay-in-loop-test.yml
+++ b/tooling/ast-grep/tests/no-unabortable-delay-in-loop-test.yml
@@ -1,0 +1,19 @@
+id: no-unabortable-delay-in-loop
+valid:
+  - |
+    async function retry(signal: AbortSignal) {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await abortableDelay(250, signal);
+      }
+    }
+  - |
+    async function oneShot() {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+invalid:
+  - |
+    async function retry() {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+    }


### PR DESCRIPTION
## What changed

- land the remaining valid correctness and security findings from the prior review set
- bound resume, mounted-file, prompt, and artifact reads before allocation and retain post-read race checks
- require explicit determinization transports, validate catalog-driven inputs, and separate expected request validation from mutable transport data
- add Anthropic request timeouts/retries, TypeScript parser validation, shared containment and score validation, safer run-log metadata, and clearer CLI/error behavior
- remove stale duplicated types, validators, parsing, and unsafe quiet-result casts

## Why

The Luna audit against current `main` found that several review findings had not landed after the earlier PR sequence. This follow-up applies only the still-valid items and leaves stale entrypoint feedback unchanged because executable wrappers now own invocation.

## Validation

- `prettier --check .`
- `eslint .`
- `knip`
- `tsc --noEmit`
- `vitest run` (27 files, 196 tests)
- package TypeScript build
- package contract validation (111-file authoritative inventory)
- `publint` against the built package
- Flue 2 compatibility typecheck and test
- credential-free release-notes alpha smoke run

The root `pnpm` wrapper could not verify its registry signature in the restricted environment. No signature protection was bypassed; the corresponding installed local binaries and underlying CI commands above were run directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--help` usage information.
  * Added automatic retries, cancellation, and configurable timeouts for model requests.
  * Added safer handling for determinization inputs, outputs, and resumed runs.

* **Bug Fixes**
  * Improved validation for budgets, target scores, paths, tracks, and evaluation scores.
  * Improved Unicode normalization and legacy baseline parsing.
  * Run logs now sanitize filenames and redact sensitive information.
  * File and artifact size limits help prevent unsafe or oversized inputs.
  * Determinization reports missing configuration and requires explicit transport for new runs.
  * Sandbox protections now block symlink-based escapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->